### PR TITLE
Fix upgrade-firmware script and unify build output directory [skip]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq (,$(OVERLAYS))
 	@echo "No overlays specified. Set PROFILE variable to 'basic' or 'extended'."
 	@exit 1
 endif
-	./scripts/create_firmware.sh $< tmp/extended $@ $(addprefix overlays/,$(OVERLAYS))
+	./scripts/create_firmware.sh $< tmp/firmware $@ $(addprefix overlays/,$(OVERLAYS))
 
 .PHONY: build
 build: $(OUTPUT_FILE)

--- a/scripts/dev/upgrade-firmware.sh
+++ b/scripts/dev/upgrade-firmware.sh
@@ -5,9 +5,13 @@ if [[ $# -ne 2 ]]; then
   exit 1
 fi
 
+SSH_HOST="$1"
+PROFILE="$2"
+shift 2
+
 set -xe
 
-rm -f "firmware/firmware_$2.bin"
-make "${2}_firmware"
-scp "tmp/$2/update.img" "$1:/tmp/"
-ssh "$1" /home/lava/bin/systemUpgrade.sh upgrade soc /tmp/update.img
+rm -rf "firmware/firmware_$PROFILE.bin" "tmp/firmware"
+make build OUTPUT_FILE=firmware/firmware_$PROFILE.bin PROFILE="$PROFILE"
+scp "tmp/firmware/update.img" "$SSH_HOST:/tmp/"
+ssh "$SSH_HOST" /home/lava/bin/systemUpgrade.sh upgrade soc /tmp/update.img


### PR DESCRIPTION
Update upgrade-firmware.sh to use the unified build process and fix the Makefile to use tmp/firmware instead of tmp/extended as the output directory.