### PR TITLE
Add warranty warning to releases and rename artifacts [ci skip]

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -53,19 +53,13 @@ jobs:
       run: make firmware
 
     - name: Build with Basic firmware
-      run: make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}.bin
+      run: make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Build with Extended firmware
-      run: make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}.bin
+      run: make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Clear Kernel Git Repo
       run: git -C tmp/kernel/ clean -fdx
-
-    - name: Generate RELEASE details
-      run: |
-        echo "# Release ${{ env.GIT_VERSION }}" > RELEASE.tmp
-        echo "" >> RELEASE.tmp
-        cat RELEASE.md >> RELEASE.tmp
 
     - name: 'Release debian files'
       uses: ncipollo/release-action@v1
@@ -75,7 +69,7 @@ jobs:
         updateOnlyUnreleased: true
         generateReleaseNotes: true
         prerelease: true
-        bodyFile: RELEASE.tmp
+        bodyFile: RELEASE
         artifacts: "U1_*.bin"
 
     - name: Save Firmwares Cache

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -49,10 +49,10 @@ jobs:
       run: make firmware
 
     - name: Build with Basic firmware
-      run: make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}.bin
+      run: make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Build with Extended firmware
-      run: make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}.bin
+      run: make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Clear Kernel Git Repo
       run: git -C tmp/kernel/ clean -fdx

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+## Notice
+
+> **Warning**: Installing custom firmware may void warranty and could potentially damage your device.
+> Use at your own risk.
+
 ## Install
 
 For detailed installation instructions, see the [Installation Guide](docs/install.md).


### PR DESCRIPTION
- Add warning notice to RELEASE.md about warranty and risks
- Rename firmware artifacts to include _upgrade suffix
- Simplify release workflow by using RELEASE.md directly