### PR TITLE
Add sudo to build commands in CI workflows

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -53,13 +53,13 @@ jobs:
       run: make firmware
 
     - name: Build with Basic firmware
-      run: make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}_upgrade.bin
+      run: sudo make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Build with Extended firmware
-      run: make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
+      run: sudo make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Clear Kernel Git Repo
-      run: git -C tmp/kernel/ clean -fdx
+      run: sudo git -C tmp/kernel/ clean -fdx
 
     - name: 'Release debian files'
       uses: ncipollo/release-action@v1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -49,13 +49,13 @@ jobs:
       run: make firmware
 
     - name: Build with Basic firmware
-      run: make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}_upgrade.bin
+      run: sudo make build PROFILE=basic OUTPUT_FILE=U1_basic_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Build with Extended firmware
-      run: make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
+      run: sudo make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Clear Kernel Git Repo
-      run: git -C tmp/kernel/ clean -fdx
+      run: sudo git -C tmp/kernel/ clean -fdx
 
     - uses: actions/upload-artifact@v4
       with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,14 +27,16 @@ make firmware
 Build basic firmware:
 
 ```bash
-make build PROFILE=basic OUTPUT_FILE=firmware/U1_basic.bin
+sudo make build PROFILE=basic OUTPUT_FILE=firmware/U1_basic.bin
 ```
 
 Build extended firmware:
 
 ```bash
-make build PROFILE=extended OUTPUT_FILE=firmware/U1_extended.bin
+sudo make build PROFILE=extended OUTPUT_FILE=firmware/U1_extended.bin
 ```
+
+**Note:** The build process requires root privileges due to squashfs root filesystem operations.
 
 ## Profiles
 

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -5,6 +5,11 @@ if [[ $# -lt 3 ]]; then
   exit 1
 fi
 
+if [[ $(id -u) -ne 0 ]]; then
+  echo "Error: This script must be run as root (sudo) - squashfs operations require root privileges"
+  exit 1
+fi
+
 set -eo pipefail
 
 IN_FIRMWARE="$(realpath "$1")"


### PR DESCRIPTION
Build process requires root privileges for squashfs root filesystem operations.