### PR TITLE
Add Mainsail web UI support (experimental)

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get update -y &&
         sudo apt-get install -y build-essential cmake \
           gcc-aarch64-linux-gnu pkg-config squashfs-tools git-core \
-          bc libssl-dev
+          bc libssl-dev unzip flex bison
 
     - name: Set GIT_VERSION
       shell: bash

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,7 +37,7 @@ jobs:
         sudo apt-get update -y &&
         sudo apt-get install -y build-essential cmake \
           gcc-aarch64-linux-gnu pkg-config squashfs-tools git-core \
-          bc libssl-dev
+          bc libssl-dev unzip flex bison
 
     - name: Set GIT_VERSION
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tools/%: FORCE
 firmware: firmware/$(FIRMWARE_FILE)
 
 firmware/$(FIRMWARE_FILE):
-	@mkdir -ap firmware
+	@mkdir -p firmware
 	wget -O $@.tmp "https://public.resource.snapmaker.com/firmware/U1/$(FIRMWARE_FILE)"
 	echo "$(FIRMWARE_SHA256)  $@.tmp" | sha256sum -c --quiet
 	mv $@.tmp $@

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Known issues:
 - [SSH Access](docs/ssh_access.md) - How to access the printer via SSH
 - [USB Ethernet](docs/usb_ethernet.md) - USB ethernet adapter configuration
 - [Camera Support](docs/camera_support.md) - Camera features and WebRTC streaming
-- [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files via Fluidd
+- [Mainsail Web UI](docs/mainsail.md) - Mainsail web interface (experimental)
+- [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files
 - [Data Persistence](docs/data_persistence.md) - Persistent storage configuration
 
 ## Dependent projects

--- a/docs/camera_support.md
+++ b/docs/camera_support.md
@@ -32,6 +32,45 @@ settings for the best performance:
 
 <img src="images/usb_cam.png" alt="Fluidd USB camera" width="300"/>
 
+## Configuring Camera Streaming
+
+The internal camera defaults to WebRTC streaming for low latency. You can switch between streaming modes via SSH.
+
+### Switch to MJPEG Adaptive (better compatibility)
+
+```bash
+cat > /home/lava/printer_data/config/moonraker/webcam.cfg << 'EOF'
+[webcam case]
+service: mjpegstreamer-adaptive
+stream_url: /webcam/stream.mjpg
+snapshot_url: /webcam/snapshot.jpg
+aspect_ratio: 16:9
+EOF
+/etc/init.d/S61moonraker restart
+```
+
+### Switch to WebRTC (low latency)
+
+```bash
+cat > /home/lava/printer_data/config/moonraker/webcam.cfg << 'EOF'
+[webcam case]
+service: webrtc-camerastreamer
+stream_url: /webcam/webrtc
+snapshot_url: /webcam/snapshot.jpg
+aspect_ratio: 16:9
+EOF
+/etc/init.d/S61moonraker restart
+```
+
+### Available Services
+
+| Service | Description |
+|---------|-------------|
+| `webrtc-camerastreamer` | Low-latency WebRTC (recommended) |
+| `mjpegstreamer-adaptive` | MJPEG with adaptive framerate |
+| `mjpegstreamer` | Basic MJPEG streaming |
+| `ipstream` | Direct stream embedding |
+
 ## Enable Snapmaker's Camera Stack
 
 Only one Camera Stack can be operational at the given moment.

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,18 +2,32 @@
 
 ## Prerequisites
 
-- Linux build environment
-- `make`
+- Linux build environment (Ubuntu/Debian recommended, WSL2 supported)
+- `build-essential` (includes `make`, `gcc`)
 - `wget`
+- `unzip`
 - `squashfs-tools`
-- `gcc-aarch64-linux-gnu`
+- `gcc-aarch64-linux-gnu` (C cross-compiler for ARM64)
+- `g++-aarch64-linux-gnu` (C++ cross-compiler for ARM64)
 - `cmake`
 - `pkg-config`
 - `git-core`
 - `bc`
 - `libssl-dev`
+- `flex`
+- `bison`
+
+### Install all dependencies (Ubuntu/Debian)
+
+```bash
+sudo apt update
+sudo apt install -y build-essential cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+    squashfs-tools git-core bc libssl-dev pkg-config wget unzip flex bison
+```
 
 Prefer to run builds in a dockerized environment.
+
+**Note:** OpenSSL for aarch64 is automatically built from source during the build process for WebRTC support.
 
 ## Quick Start
 
@@ -43,7 +57,9 @@ sudo make build PROFILE=extended OUTPUT_FILE=firmware/U1_extended.bin
 The build system supports two profiles:
 
 - `basic` - simple modifications not changing key components of the firmware
-- `extended` - extensive modifications changing key components of the firmware
+- `extended` - extensive modifications with Fluidd web UI (includes timelapse)
+
+For experimental Mainsail support, see [Mainsail Web UI](mainsail.md).
 
 ## Overlays
 
@@ -59,8 +75,10 @@ The build system supports two profiles:
 - `disable-wlan-power-save` - Disable WLAN power saving
 - `enable-native-camera-fluidd` - Native camera integration in Fluidd (~1Hz)
 - `camera-v4l2-mpp` - Hardware-accelerated camera stack (MPP/VPU)
-- `stub-fluidd-timelapse` - Stub timelapse component for Moonraker
+- `stub-fluidd-timelapse` - Moonraker-timelapse component for Fluidd/Mainsail
 - `fluidd-upgrade` - Upgrade Fluidd to v1.35.0 with timelapse plugin
+- `mainsail` - Install Mainsail web UI v2.15.0 (replaces Fluidd)
+- `enable-klipper-includes` - Custom Klipper and Moonraker configuration includes
 
 ## Project Structure
 
@@ -75,8 +93,10 @@ The build system supports two profiles:
 │   ├── disable-wlan-power-save/ Disable WLAN power saving
 │   ├── enable-native-camera-fluidd/ Native camera for Fluidd
 │   ├── camera-v4l2-mpp/         Hardware-accelerated camera (MPP/VPU)
-│   ├── stub-fluidd-timelapse/   Timelapse stub
-│   └── fluidd-upgrade/          Fluidd upgrade
+│   ├── stub-fluidd-timelapse/   Moonraker-timelapse component
+│   ├── fluidd-upgrade/          Fluidd upgrade
+│   ├── mainsail/                Mainsail web UI
+│   └── enable-klipper-includes/ Custom config includes
 ├── firmware/                    Downloaded and generated firmware files
 ├── scripts/                     Build and modification scripts
 ├── tmp/                         Temporary build artifacts

--- a/docs/mainsail.md
+++ b/docs/mainsail.md
@@ -1,0 +1,132 @@
+# Mainsail Web UI
+
+**Status: Experimental (not an official profile yet)**
+
+The `mainsail` overlay replaces the default Fluidd web interface with [Mainsail](https://docs.mainsail.xyz/), an alternative Klipper web interface.
+
+> **Note**: Mainsail support is currently experimental. The overlays are available but there is no official `extended-mainsail` profile yet. See [Building](#building-with-mainsail) for how to build a custom firmware with Mainsail.
+
+## What is Mainsail?
+
+Mainsail is a modern, responsive web interface for Klipper-based 3D printers. It provides:
+
+- Clean, intuitive user interface
+- Real-time printer status monitoring
+- G-code file management and uploads
+- Webcam integration with WebRTC support
+- Macro management and execution
+- Bed mesh visualization
+- Temperature graphs and controls
+- Console for direct Klipper commands
+
+## Features
+
+- Mainsail v2.15.0 web interface
+- Full Moonraker API integration
+- Hardware-accelerated camera streaming (WebRTC/MJPEG)
+- Custom Klipper/Moonraker configuration includes
+- SSH access for advanced users
+- USB ethernet adapter support
+
+### Camera Support
+
+The Mainsail overlay includes the same camera stack as the extended firmware:
+
+- Internal MIPI camera support
+- USB camera support (when enabled)
+- WebRTC low-latency streaming (default)
+- MJPEG streaming (alternative)
+
+## Accessing Mainsail
+
+After flashing the firmware:
+
+1. Connect to the same network as your printer
+2. Open a web browser
+3. Navigate to `http://<printer-ip>/`
+4. Mainsail will load automatically
+
+To find your printer's IP address:
+- Check your router's DHCP client list
+- Use the Snapmaker mobile app
+- Connect via SSH and run `ip addr`
+
+## Comparison: Mainsail vs Fluidd
+
+| Feature | Mainsail | Fluidd |
+|---------|----------|--------|
+| Interface Style | Modern, grid-based | Clean, minimal |
+| Webcam Support | Excellent | Excellent |
+| Bed Mesh Viewer | Yes | Yes |
+| Macro Management | Advanced | Good |
+| Multi-printer | Yes | Limited |
+| Customization | Highly customizable | Moderate |
+| Mobile Support | Responsive | Responsive |
+
+## Building with Mainsail
+
+Since Mainsail is experimental, you need to specify overlays manually:
+
+```bash
+# Build firmware with Mainsail (instead of Fluidd)
+sudo make build OUTPUT_FILE=firmware/U1_mainsail.bin \
+  OVERLAYS="store-version kernel-modules enable-ssh enable-usb-eth-hotplug disable-wlan-power-save stub-fluidd-timelapse stub-mainsail-timelapse camera-v4l2-mpp mainsail enable-klipper-includes"
+```
+
+## Configuration
+
+Mainsail uses the same Moonraker API as Fluidd, so all existing configurations work:
+
+- Klipper config: `/home/lava/origin_printer_data/config/printer.cfg`
+- Moonraker config: `/home/lava/origin_printer_data/config/moonraker.conf`
+- Custom includes: See [Klipper Includes](klipper_includes.md)
+
+### Camera Configuration
+
+Camera configuration is stored in `moonraker/webcam.cfg`. The default uses WebRTC for low latency.
+
+To change the camera streaming mode, see [Camera Support - Configuring Camera Streaming](camera_support.md#configuring-camera-streaming).
+
+## Troubleshooting
+
+### Mainsail won't load
+
+1. Verify nginx is running: `systemctl status nginx`
+2. Check nginx config: `nginx -t`
+3. Verify Mainsail files exist: `ls -la /home/lava/mainsail/`
+
+### Can't connect to printer
+
+1. Verify Moonraker is running: `systemctl status moonraker`
+2. Check Moonraker logs: `journalctl -u moonraker`
+3. Verify API is accessible: `curl http://localhost:7125/printer/info`
+
+### Camera not showing
+
+1. Check camera service: `/etc/init.d/S99v4l2-mpp-mipi status`
+2. Verify camera device: `ls -l /dev/video*`
+3. Check camera config in Moonraker
+4. Test camera backend directly: `wget -q -O /dev/null http://127.0.0.1:8080/snapshot.jpg && echo "OK"`
+5. If backend works but Mainsail shows error, verify CORS headers in nginx config
+
+### Camera shows "Error while connecting"
+
+This usually indicates a browser CORS issue. The firmware includes CORS headers by default. If you still see this error:
+
+1. Clear your browser cache and reload
+2. Try a different browser
+3. Verify nginx is serving the webcam: `wget -q -O /dev/null http://127.0.0.1/webcam/snapshot.jpg`
+4. Check nginx error logs: `tail -f /var/log/nginx/error.log`
+
+## Version Information
+
+- **Mainsail Version**: v2.15.0
+- **Release Date**: November 2024
+- **Source**: https://github.com/mainsail-crew/mainsail
+
+## Related Documentation
+
+- [Mainsail Official Docs](https://docs.mainsail.xyz/)
+- [Camera Support](camera_support.md)
+- [Klipper Includes](klipper_includes.md)
+- [SSH Access](ssh_access.md)

--- a/overlays/camera-v4l2-mpp/scripts/01-v4l2-mpp.sh
+++ b/overlays/camera-v4l2-mpp/scripts/01-v4l2-mpp.sh
@@ -10,14 +10,181 @@ fi
 set -eo pipefail
 
 TARGET_DIR="$ROOT_DIR/tmp/v4l2-mpp"
+OPENSSL_DIR="$ROOT_DIR/tmp/openssl-aarch64"
 
 if [[ ! -d "$TARGET_DIR" ]]; then
   git clone https://github.com/paxx12/v4l2-mpp.git "$TARGET_DIR" --recursive
   git -C "$TARGET_DIR" checkout bd429bf63542a56499c46c333855994002f0beda
 fi
 
-echo ">> Compiling dependencies..."
-make -C "$TARGET_DIR" deps
+# Clean up any existing build artifacts that may be wrong architecture
+# This prevents issues when tmp directory is reused between native and cross builds
+clean_wrong_arch_builds() {
+  local check_file="$1"
+  if [[ -f "$check_file" ]]; then
+    local arch=$(file "$check_file" | grep -o 'ARM aarch64\|x86-64' || true)
+    if [[ "$arch" != "ARM aarch64" ]]; then
+      echo ">> Detected non-aarch64 build artifacts, cleaning..."
+      rm -rf "$TARGET_DIR/deps/mpp/build"
+      rm -rf "$TARGET_DIR/deps/libdatachannel/build"
+      rm -rf "$TARGET_DIR/deps/live/usr-local"
+      rm -rf "$OPENSSL_DIR"
+      make -C "$TARGET_DIR" clean 2>/dev/null || true
+    fi
+  fi
+}
+
+# Check a known build artifact for architecture
+clean_wrong_arch_builds "$TARGET_DIR/deps/mpp/build/mpp/libmpp.so"
+
+# Build OpenSSL for aarch64 if not already built
+if [[ ! -f "$OPENSSL_DIR/lib/libssl.a" ]]; then
+  echo ">> Building OpenSSL for aarch64..."
+  OPENSSL_VERSION="3.0.15"
+  OPENSSL_TARBALL="$ROOT_DIR/tmp/openssl-${OPENSSL_VERSION}.tar.gz"
+
+  if [[ ! -f "$OPENSSL_TARBALL" ]]; then
+    wget -O "$OPENSSL_TARBALL" "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"
+  fi
+
+  rm -rf "$ROOT_DIR/tmp/openssl-${OPENSSL_VERSION}"
+  tar -xzf "$OPENSSL_TARBALL" -C "$ROOT_DIR/tmp"
+
+  cd "$ROOT_DIR/tmp/openssl-${OPENSSL_VERSION}"
+  ./Configure linux-aarch64 \
+    --cross-compile-prefix=aarch64-linux-gnu- \
+    --prefix="$OPENSSL_DIR" \
+    no-shared \
+    no-tests
+  make -j$(nproc)
+  make install_sw
+  cd "$ROOT_DIR"
+fi
+
+# Cross-compile for aarch64 (ARM64) - set after OpenSSL build to avoid prefix doubling
+export CC=aarch64-linux-gnu-gcc
+export CXX=aarch64-linux-gnu-g++
+export CROSS_COMPILE=aarch64-linux-gnu-
+
+# Create cmake toolchain file for cross-compilation
+TOOLCHAIN_FILE="$TARGET_DIR/aarch64-toolchain.cmake"
+cat > "$TOOLCHAIN_FILE" << EOF
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+# OpenSSL paths for aarch64 (built from source)
+set(OPENSSL_ROOT_DIR "$OPENSSL_DIR")
+set(OPENSSL_INCLUDE_DIR "$OPENSSL_DIR/include")
+set(OPENSSL_CRYPTO_LIBRARY "$OPENSSL_DIR/lib/libcrypto.a")
+set(OPENSSL_SSL_LIBRARY "$OPENSSL_DIR/lib/libssl.a")
+set(OPENSSL_USE_STATIC_LIBS TRUE)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+EOF
+
+cd "$TARGET_DIR"
+
+echo ">> Compiling MPP dependency (hardware acceleration)..."
+./deps/compile_mpp.sh
+
+# Cross-compile liveMedia for aarch64 (RTSP support)
+LIVE_DIR="$TARGET_DIR/deps/live"
+LIVE_INSTALL="$TARGET_DIR/deps/live/usr-local"
+if [[ ! -f "$LIVE_INSTALL/lib/libliveMedia.a" ]] || ! file "$LIVE_INSTALL/lib/libliveMedia.a" | grep -q "aarch64"; then
+  echo ">> Compiling liveMedia (RTSP) for aarch64..."
+
+  # Download liveMedia if not present
+  if [[ ! -d "$LIVE_DIR/live-src" ]]; then
+    LIVE_TARBALL="$ROOT_DIR/tmp/live555-latest.tar.gz"
+    # Always fetch latest to ensure we get a working version
+    wget -O "$LIVE_TARBALL" "http://www.live555.com/liveMedia/public/live555-latest.tar.gz"
+    rm -rf "$LIVE_DIR/live"
+    tar -xzf "$LIVE_TARBALL" -C "$LIVE_DIR"
+    mv "$LIVE_DIR/live" "$LIVE_DIR/live-src"
+  fi
+
+  cd "$LIVE_DIR/live-src"
+
+  # Create aarch64 cross-compile config (note: no quotes on EOFCONFIG to allow variable expansion)
+  cat > config.linux-aarch64 << EOFCONFIG
+COMPILE_OPTS =		\$(INCLUDES) -I. -I$OPENSSL_DIR/include -O2 -DSOCKLEN_T=socklen_t -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
+C =			c
+C_COMPILER =		aarch64-linux-gnu-gcc
+C_FLAGS =		\$(COMPILE_OPTS)
+CPP =			cpp
+CPLUSPLUS_COMPILER =	aarch64-linux-gnu-g++
+CPLUSPLUS_FLAGS =	\$(COMPILE_OPTS) -Wall -DBSD=1 -std=c++20
+OBJ =			o
+LINK =			aarch64-linux-gnu-g++ -o
+LINK_OPTS =		-L. -L$OPENSSL_DIR/lib
+CONSOLE_LINK_OPTS =	\$(LINK_OPTS)
+LIBRARY_LINK =		aarch64-linux-gnu-ar cr 
+LIBRARY_LINK_OPTS =
+LIB_SUFFIX =		a
+LIBS_FOR_CONSOLE_APPLICATION = -lssl -lcrypto
+LIBS_FOR_GUI_APPLICATION =
+EXE =
+EOFCONFIG
+
+  ./genMakefiles linux-aarch64
+  make -j$(nproc)
+
+  # Install to usr-local
+  rm -rf "$LIVE_INSTALL"
+  mkdir -p "$LIVE_INSTALL/lib" "$LIVE_INSTALL/include"
+  cp */lib*.a "$LIVE_INSTALL/lib/"
+  for dir in liveMedia groupsock BasicUsageEnvironment UsageEnvironment; do
+    mkdir -p "$LIVE_INSTALL/include/$dir"
+    cp $dir/include/*.hh "$LIVE_INSTALL/include/$dir/" 2>/dev/null || true
+    cp $dir/include/*.h "$LIVE_INSTALL/include/$dir/" 2>/dev/null || true
+  done
+
+  cd "$TARGET_DIR"
+fi
+
+echo ">> Compiling libdatachannel (WebRTC)..."
+cd "$TARGET_DIR/deps/libdatachannel"
+cmake -S . -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" \
+  -DNO_WEBSOCKET=ON \
+  -DNO_EXAMPLES=ON \
+  -DNO_TESTS=ON \
+  -DUSE_NICE=OFF \
+  -DBUILD_SHARED_LIBS=OFF
+make -C build -j$(nproc)
+
+# Create symlinks for static libraries (v4l2-mpp expects specific names)
+if [ -f build/libdatachannel.a ] && [ ! -f build/libdatachannel-static.a ]; then
+  ln -sf libdatachannel.a build/libdatachannel-static.a
+fi
+if [ -f build/deps/libjuice/libjuice.a ] && [ ! -f build/deps/libjuice/libjuice-static.a ]; then
+  ln -sf libjuice.a build/deps/libjuice/libjuice-static.a
+fi
+
+# Copy OpenSSL libraries to libdatachannel build dir (linker expects them there)
+cp "$OPENSSL_DIR/lib/libcrypto.a" build/
+cp "$OPENSSL_DIR/lib/libssl.a" build/
+
+cd "$TARGET_DIR"
+
+# Fix link order in stream-webrtc Makefile (libssl must come before libcrypto)
+sed -i 's/-lcrypto -lssl/-lssl -lcrypto -ldl/g' apps/stream-webrtc/Makefile
+
+# Add cross-compiled OpenSSL include path for stream-rtsp (liveMedia uses OpenSSL for TLS)
+export CPLUS_INCLUDE_PATH="$OPENSSL_DIR/include:$CPLUS_INCLUDE_PATH"
+export C_INCLUDE_PATH="$OPENSSL_DIR/include:$C_INCLUDE_PATH"
+export LIBRARY_PATH="$OPENSSL_DIR/lib:$LIBRARY_PATH"
+
+# Copy OpenSSL libs to liveMedia install dir (stream-rtsp links from there)
+cp "$OPENSSL_DIR/lib/libssl.a" "$LIVE_INSTALL/lib/"
+cp "$OPENSSL_DIR/lib/libcrypto.a" "$LIVE_INSTALL/lib/"
 
 echo ">> Compiling v4l2-mpp applications..."
 make -C "$TARGET_DIR" install DESTDIR="$1"

--- a/overlays/enable-klipper-includes/patches/01-add-klipper-includes.patch
+++ b/overlays/enable-klipper-includes/patches/01-add-klipper-includes.patch
@@ -1,7 +1,7 @@
 diff -uNr rootfs.original/home/lava/origin_printer_data/config/printer.cfg rootfs/home/lava/origin_printer_data/config/printer.cfg
 --- rootfs.original/home/lava/origin_printer_data/config/printer.cfg	2025-11-06 05:01:19.000000000 +0100
 +++ rootfs/home/lava/origin_printer_data/config/printer.cfg	2025-12-04 10:31:52.832922872 +0100
-@@ -1258,4 +1258,7 @@
+@@ -1258,4 +1258,9 @@
  #*# max_x = 240.0
  #*# min_y = 20.0
  #*# max_y = 240.0
@@ -9,5 +9,7 @@ diff -uNr rootfs.original/home/lava/origin_printer_data/config/printer.cfg rootf
 \ No newline at end of file
 +#*#
 +
++# Firmware-provided configuration (overwritten on firmware update)
 +[include /home/lava/klipper-config/*.cfg]
++# User configuration files (persists across firmware updates)
 +[include klipper/*.cfg]

--- a/overlays/mainsail/root/etc/nginx/sites-available/mainsail
+++ b/overlays/mainsail/root/etc/nginx/sites-available/mainsail
@@ -1,0 +1,86 @@
+# Mainsail nginx configuration
+# Based on stock fluidd config with mainsail-specific adjustments
+
+# Map for WebSocket connection upgrade
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80 default_server;
+
+    access_log /var/log/nginx/mainsail-access.log;
+    error_log /var/log/nginx/mainsail-error.log;
+
+    # Disable gzip for better compatibility
+    gzip off;
+
+    # Maximum upload size (for gcode files)
+    client_max_body_size 0;
+
+    # Serve Mainsail static files
+    root /home/lava/mainsail;
+
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # Camera location with CORS headers for Mainsail webcam access
+    location /camera/ {
+        alias /tmp/camera/;
+    }
+
+    # Webcam proxy with CORS headers
+    location /webcam/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        proxy_pass http://127.0.0.1:8080/;
+        # CORS headers for Mainsail webcam access
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS";
+        add_header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept";
+    }
+
+    # Second webcam (USB camera)
+    location /webcam2/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        proxy_pass http://127.0.0.1:8081/;
+        # CORS headers for Mainsail webcam access
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS";
+        add_header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept";
+    }
+
+    # Moonraker WebSocket
+    location /websocket {
+        proxy_pass http://apiserver/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 86400;
+    }
+
+    # Moonraker API
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://apiserver$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+    }
+}

--- a/overlays/mainsail/root/etc/nginx/sites-enabled/mainsail
+++ b/overlays/mainsail/root/etc/nginx/sites-enabled/mainsail
@@ -1,0 +1,1 @@
+../sites-available/mainsail

--- a/overlays/mainsail/root/home/lava/klipper-config/01_mainsail_macros.cfg
+++ b/overlays/mainsail/root/home/lava/klipper-config/01_mainsail_macros.cfg
@@ -1,0 +1,68 @@
+# Mainsail required macros
+# These macros are required by Mainsail for pause/resume functionality
+
+[gcode_macro PAUSE]
+description: Pause the current print
+rename_existing: BASE_PAUSE
+gcode:
+    # Parameters
+    {% set z = params.Z|default(10)|int %}
+
+    {% if printer['pause_resume'].is_paused|int == 0 %}
+        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z}
+        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}
+
+        SAVE_GCODE_STATE NAME=PAUSE
+        BASE_PAUSE
+
+        {% if (printer.gcode_move.position.z + z) < printer.toolhead.axis_maximum.z %}
+            G91
+            G1 Z{z} F900
+        {% else %}
+            { action_respond_info("Pause zhop exceeds maximum Z height.") }
+            SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE=0
+        {% endif %}
+
+        G90
+        G1 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_minimum.y + 5} F6000
+    {% endif %}
+
+[gcode_macro RESUME]
+description: Resume the current print
+rename_existing: BASE_RESUME
+variable_zhop: 0
+variable_etemp: 0
+gcode:
+    # Parameters
+    {% set e = params.E|default(2.5)|int %}
+
+    {% if printer['pause_resume'].is_paused|int == 1 %}
+        # Heat extruder if needed
+        {% if etemp > 0 %}
+            M109 S{etemp|int}
+        {% endif %}
+
+        RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=100
+
+        {% if zhop > 0 %}
+            G91
+            G1 Z{zhop * -1} F900
+            G90
+        {% endif %}
+
+        G91
+        G1 E{e} F2100
+        G90
+
+        BASE_RESUME
+    {% endif %}
+
+[gcode_macro CANCEL_PRINT]
+description: Cancel the current print
+rename_existing: BASE_CANCEL_PRINT
+gcode:
+    TURN_OFF_HEATERS
+    CLEAR_PAUSE
+    SDCARD_RESET_FILE
+    BASE_CANCEL_PRINT
+    G28 X Y

--- a/overlays/mainsail/scripts/01-install-mainsail.sh
+++ b/overlays/mainsail/scripts/01-install-mainsail.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Mainsail Installation Script
+# Downloads and installs Mainsail web UI to the target rootfs
+#
+
+ROOT_DIR="$(realpath "$(dirname "$0")/../../..")"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+set -eo pipefail
+
+TARGET_DIR="$ROOT_DIR/tmp"
+
+VERSION=v2.15.0
+URL=https://github.com/mainsail-crew/mainsail/releases/download/$VERSION/mainsail.zip
+SHA256=ac8cde4d1d5c818454c9567e548f1ec5ce75e5e331fa878aaded7235e7e0da32
+FILENAME=mainsail-$VERSION.zip
+
+if [[ ! -f "$TARGET_DIR/$FILENAME" ]]; then
+  echo ">> Downloading $FILENAME..."
+  wget -O "$TARGET_DIR/$FILENAME" "$URL"
+fi
+
+echo ">> Verifying $FILENAME checksum..."
+echo "$SHA256  $TARGET_DIR/$FILENAME" | sha256sum --check --status
+
+echo ">> Extracting $FILENAME..."
+rm -rf "$TARGET_DIR/mainsail-$VERSION"
+unzip -o "$TARGET_DIR/$FILENAME" -d "$TARGET_DIR/mainsail-$VERSION"
+
+echo ">> Installing $FILENAME to target rootfs..."
+rm -rf "$1/home/lava/mainsail"
+cp -r "$TARGET_DIR/mainsail-$VERSION" "$1/home/lava/mainsail"
+
+echo ">> Setting ownership..."
+chown -R 1000:1000 "$1/home/lava/mainsail"
+
+echo ">> Mainsail $VERSION installed successfully."

--- a/overlays/mainsail/scripts/01-remove-fluidd-site.sh
+++ b/overlays/mainsail/scripts/01-remove-fluidd-site.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Remove fluidd nginx site to be replaced by mainsail
+# Fails if fluidd symlink doesn't exist (to catch firmware changes)
+#
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+ROOTFS="$1"
+FLUIDD_SITE="$ROOTFS/etc/nginx/sites-enabled/fluidd"
+
+if [[ ! -L "$FLUIDD_SITE" ]]; then
+  echo "!! ERROR: $FLUIDD_SITE is not a symlink"
+  echo ">> Firmware structure may have changed"
+  exit 1
+fi
+
+echo ">> Removing fluidd site symlink"
+rm "$FLUIDD_SITE"

--- a/overlays/stub-mainsail-timelapse/root/home/lava/klipper-config/timelapse_compat.cfg
+++ b/overlays/stub-mainsail-timelapse/root/home/lava/klipper-config/timelapse_compat.cfg
@@ -1,0 +1,18 @@
+# Compatibility macros for Mainsail timelapse UI
+# These stub macros prevent "Unknown command" errors
+# Actual timelapse functionality uses Snapmaker's OrcaSlicer integration
+
+[gcode_macro _SET_TIMELAPSE_SETUP]
+description: Stub macro for Mainsail timelapse compatibility
+gcode:
+  # Timelapse settings are managed by OrcaSlicer
+
+[gcode_macro GET_TIMELAPSE_SETUP]
+description: Print timelapse setup info
+gcode:
+  {action_respond_info("Timelapse is configured via OrcaSlicer slicer settings")}
+
+[gcode_macro HYPERLAPSE]
+description: Hyperlapse stub for Mainsail compatibility
+gcode:
+  {action_respond_info("Hyperlapse: Use OrcaSlicer timelapse settings")}

--- a/overlays/stub-mainsail-timelapse/root/home/lava/moonraker-config/01_timelapse_stub.cfg
+++ b/overlays/stub-mainsail-timelapse/root/home/lava/moonraker-config/01_timelapse_stub.cfg
@@ -1,0 +1,3 @@
+# Enable timelapse component stub for Mainsail
+# This prevents Mainsail from showing timelapse errors
+[timelapse]

--- a/overlays/stub-mainsail-timelapse/root/home/lava/moonraker/moonraker/components/timelapse.py
+++ b/overlays/stub-mainsail-timelapse/root/home/lava/moonraker/moonraker/components/timelapse.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Dict, Any
+
+if TYPE_CHECKING:
+    from confighelper import ConfigHelper
+    from ..common import WebRequest
+
+class Timelapse:
+    """Stub timelapse component for Mainsail compatibility.
+
+    Provides empty API responses to prevent UI errors.
+    Actual timelapse functionality is handled by OrcaSlicer.
+    """
+
+    def __init__(self, confighelper: ConfigHelper) -> None:
+        self.confighelper = confighelper
+        self.server = confighelper.get_server()
+
+        # Register timelapse directory with file manager
+        file_manager = self.server.lookup_component("file_manager")
+        camera_path = file_manager.datapath.joinpath("camera")
+        file_manager.register_directory("timelapse",
+                                        str(camera_path),
+                                        full_access=True)
+
+        # Register API endpoints that Mainsail expects
+        self.server.register_endpoint(
+            "/machine/timelapse/settings",
+            ["GET", "POST"],
+            self._handle_settings
+        )
+        self.server.register_endpoint(
+            "/machine/timelapse/lastframeinfo",
+            ["GET"],
+            self._handle_lastframeinfo
+        )
+        self.server.register_endpoint(
+            "/machine/timelapse/render",
+            ["POST"],
+            self._handle_render
+        )
+
+    async def _handle_settings(self, web_request: WebRequest) -> Dict[str, Any]:
+        """Return stub timelapse settings."""
+        return {
+            "enabled": False,
+            "autorender": False,
+            "mode": "layermacro",
+            "camera": "",
+            "snapshoturl": "",
+            "stream_delay_compensation": 0.05,
+            "gcode_verbose": False,
+            "parkhead": False,
+            "parkpos": "back_left",
+            "park_custom_pos_x": 0.0,
+            "park_custom_pos_y": 0.0,
+            "park_custom_pos_dz": 0.0,
+            "park_travel_speed": 100,
+            "park_retract_speed": 15,
+            "park_extrude_speed": 15,
+            "park_retract_distance": 1.0,
+            "park_extrude_distance": 1.0,
+            "hyperlapse_cycle": 30,
+            "fw_retract": False,
+            "constant_rate_factor": 23,
+            "output_framerate": 30,
+            "pixelformat": "yuv420p",
+            "extraoutputparams": "",
+            "variable_fps": False,
+            "targetlength": 10,
+            "variable_fps_min": 5,
+            "variable_fps_max": 60,
+            "duplicatelastframe": 0,
+            "previewimage": True,
+            "saveframes": False
+        }
+
+    async def _handle_lastframeinfo(self, web_request: WebRequest) -> Dict[str, Any]:
+        """Return stub last frame info."""
+        return {
+            "lastframefile": "",
+            "count": 0
+        }
+
+    async def _handle_render(self, web_request: WebRequest) -> Dict[str, Any]:
+        """Return stub render response."""
+        return {
+            "status": "not_available",
+            "msg": "Timelapse rendering not available. Use OrcaSlicer for timelapse."
+        }
+
+def load_component(config: ConfigHelper) -> Timelapse:
+    return Timelapse(config)


### PR DESCRIPTION
Add overlays for Mainsail as an alternative web interface to Fluidd. Mainsail is marked as experimental - no official profile yet, but overlays are available for custom builds.

New overlays:
- mainsail: Mainsail v2.15.0 web interface with nginx configuration
- stub-mainsail-timelapse: Compatibility stubs for Mainsail timelapse UI

Changes to existing overlays:
- camera-v4l2-mpp: Add WebRTC support with OpenSSL cross-compilation, webcam config init script (S56webcam_config)
- enable-klipper-includes: Minor patch adjustment

Documentation:
- docs/mainsail.md: Mainsail usage and build instructions
- docs/camera_support.md: Camera streaming configuration (WebRTC/MJPEG)
- docs/development.md: Updated prerequisites and overlay list

To build with Mainsail (experimental):
`sudo make build OUTPUT_FILE=firmware/U1_mainsail.bin \ OVERLAYS="store-version kernel-modules enable-ssh enable-usb-eth-hotplug \ disable-wlan-power-save stub-fluidd-timelapse stub-mainsail-timelapse \ camera-v4l2-mpp mainsail enable-klipper-includes"`