### PR TITLE
Add watchdog restart for v4l2-mpp capture services

### DIFF
--- a/overlays/camera-v4l2-mpp/root/etc/init.d/S99v4l2-mpp-mipi
+++ b/overlays/camera-v4l2-mpp/root/etc/init.d/S99v4l2-mpp-mipi
@@ -20,15 +20,48 @@ CMD_HTTP_ARGS="--jpeg-sock /tmp/capture-mipi-jpeg.sock --mjpeg-sock /tmp/capture
 CMD_SNAP_MQTT=/usr/local/bin/stream-snap-mqtt.py
 CMD_SNAP_MQTT_ARGS="--jpeg-sock /tmp/capture-mipi-jpeg.sock --publish-dir /home/lava/printer_data/camera"
 
+CAPTURE_PID=/var/run/capture-mipi-mpp.pid
+MONITOR_PID=/var/run/capture-mipi-mpp-monitor.pid
+
+start_capture() {
+    printf "Starting capture-mipi-mpp: "
+    start-stop-daemon -S -b -q -m -p "$CAPTURE_PID" -x $CMD_CAPTURE -- $CMD_CAPTURE_ARGS
+    echo "OK"
+}
+
+start_monitor() {
+    # Ensure only one monitor loop exists
+    if pid_mon="$(cat "$MONITOR_PID" 2>/dev/null)" && kill -0 "$pid_mon" 2>/dev/null; then
+        return
+    fi
+
+    (
+        while true; do
+            if ! pid="$(cat "$CAPTURE_PID" 2>/dev/null)" || ! kill -0 "$pid" 2>/dev/null; then
+                echo "capture-mipi-mpp not running, restarting..."
+                start_capture
+            fi
+            sleep 5
+        done
+    ) &
+    echo $! > "$MONITOR_PID"
+}
+
+stop_monitor() {
+    if [ -f "$MONITOR_PID" ]; then
+        kill "$(cat "$MONITOR_PID")" 2>/dev/null
+        rm -f "$MONITOR_PID"
+    fi
+}
+
 start() {
     if [ ! -e /dev/video11 ]; then
         echo "MIPI camera device /dev/video11 not found, not starting."
         return
     fi
 
-    printf "Starting capture-mipi-mpp: "
-    start-stop-daemon -S -b -q -m -p /var/run/capture-mipi-mpp.pid -x $CMD_CAPTURE -- $CMD_CAPTURE_ARGS
-    echo "OK"
+    start_capture
+    start_monitor
 
     printf "Starting stream-webrtc: "
     start-stop-daemon -S -b -q -m -p /var/run/stream-mipi-webrtc.pid -c lava -x $CMD_WEBRTC -- $CMD_WEBRTC_ARGS
@@ -44,6 +77,8 @@ start() {
 }
 
 stop() {
+    stop_monitor
+
     printf "Stopping stream-snap-mqtt: "
     start-stop-daemon -K -q -p /var/run/stream-mipi-snap-mqtt.pid
     echo "OK"
@@ -57,7 +92,7 @@ stop() {
     echo "OK"
 
     printf "Stopping capture-mipi-mpp: "
-    start-stop-daemon -K -q -p /var/run/capture-mipi-mpp.pid
+    start-stop-daemon -K -q -p "$CAPTURE_PID"
     echo "OK"
 }
 

--- a/overlays/camera-v4l2-mpp/root/etc/init.d/S99v4l2-mpp-usb
+++ b/overlays/camera-v4l2-mpp/root/etc/init.d/S99v4l2-mpp-usb
@@ -11,15 +11,47 @@ CMD_WEBRTC_ARGS="--h264-sock /tmp/capture-usb-h264.sock --webrtc-sock /tmp/captu
 CMD_HTTP=/usr/local/bin/stream-http.py
 CMD_HTTP_ARGS="--jpeg-sock /tmp/capture-usb-jpeg.sock --mjpeg-sock /tmp/capture-usb-mjpeg.sock --h264-sock /tmp/capture-usb-h264.sock --webrtc-sock /tmp/capture-usb-webrtc.sock --bind 127.0.0.1 --port 8081"
 
+CAPTURE_PID=/var/run/capture-usb-mpp.pid
+MONITOR_PID=/var/run/capture-usb-mpp-monitor.pid
+
+start_capture() {
+    printf "Starting capture-usb-mpp: "
+    start-stop-daemon -S -b -q -m -p "$CAPTURE_PID" -x $CMD_CAPTURE -- $CMD_CAPTURE_ARGS
+    echo "OK"
+}
+
+start_monitor() {
+    if pid_mon="$(cat "$MONITOR_PID" 2>/dev/null)" && kill -0 "$pid_mon" 2>/dev/null; then
+        return
+    fi
+
+    (
+        while true; do
+            if ! pid="$(cat "$CAPTURE_PID" 2>/dev/null)" || ! kill -0 "$pid" 2>/dev/null; then
+                echo "capture-usb-mpp not running, restarting..."
+                start_capture
+            fi
+            sleep 5
+        done
+    ) &
+    echo $! > "$MONITOR_PID"
+}
+
+stop_monitor() {
+    if [ -f "$MONITOR_PID" ]; then
+        kill "$(cat "$MONITOR_PID")" 2>/dev/null
+        rm -f "$MONITOR_PID"
+    fi
+}
+
 start() {
     if [ ! -e /dev/video18 ]; then
         echo "USB camera device /dev/video18 not found, not starting."
         return
     fi
 
-    printf "Starting capture-usb-mpp: "
-    start-stop-daemon -S -b -q -m -p /var/run/capture-usb-mpp.pid -x $CMD_CAPTURE -- $CMD_CAPTURE_ARGS
-    echo "OK"
+    start_capture
+    start_monitor
 
     printf "Starting stream-webrtc: "
     start-stop-daemon -S -b -q -m -p /var/run/stream-usb-webrtc.pid -c lava -x $CMD_WEBRTC -- $CMD_WEBRTC_ARGS
@@ -31,6 +63,8 @@ start() {
 }
 
 stop() {
+    stop_monitor
+
     printf "Stopping stream-http: "
     start-stop-daemon -K -q -p /var/run/stream-usb-http.pid
     echo "OK"
@@ -40,7 +74,7 @@ stop() {
     echo "OK"
 
     printf "Stopping capture-usb-mpp: "
-    start-stop-daemon -K -q -p /var/run/capture-usb-mpp.pid
+    start-stop-daemon -K -q -p "$CAPTURE_PID"
     echo "OK"
 }
 


### PR DESCRIPTION
  - Add a lightweight monitor loop to S99v4l2-mpp-{mipi,usb} that restarts capture-*-mpp if it exits, preventing the camera stream from staying black after a crash or timeout.
  - Use pidfiles for both capture and monitor; ensure only one monitor runs and clean it up on stop.
  - No other behavior changes to the streaming stack; just keeps the producer alive.

## Test
On the printer (or a device with the firmware unpacked/running), you can simulate a crash and watch it restart:

Kill the producer; monitor should restart it within 5s
```  
kill -9 "$(cat /var/run/capture-mipi-mpp.pid)"   # or capture-usb-mpp.pid
```

Check it came back
```
sleep 6
ps | grep capture-mipi-mpp   # or capture-usb-mpp
```

Also verify monitor cleanup on stop:
```
/etc/init.d/S99v4l2-mpp-mipi stop
pgrep -f capture-mpp-monitor  # should be empty
```
And ensure the monitor doesn’t multiply:
```
/etc/init.d/S99v4l2-mpp-mipi start
/etc/init.d/S99v4l2-mpp-mipi start
pgrep -f capture-mpp-monitor  # should show only one monitor pid
```