### PR TITLE
Revert "Store version in a firmware"

### DIFF
--- a/overlays/store-version/scripts/01_store_version.sh
+++ b/overlays/store-version/scripts/01_store_version.sh
@@ -11,6 +11,5 @@ if [[ -n "$GIT_VERSION" ]]; then
   ABBRV=$(git describe --abbrev --always)
 
   # 0.9.0-paxx12-1-gabcdef0
-  echo "${GIT_VERSION#v}" > "$ROOTFS_DIR/etc/VERSION"
-  echo "${GIT_VERSION#v}_$(date +%Y%m%d%H%M%S)_${ABBRV}" > "$ROOTFS_DIR/etc/CUSTOMVERSION"
+  echo "${GIT_VERSION#v}-${ABBRV}" > "$ROOTFS_DIR/etc/CUSTOM_VERSION"
 fi


### PR DESCRIPTION
Reverts paxx12/SnapmakerU1-Extended-Firmware#42

Since this breaks the Snorca discovery of supported version.