### PR TITLE
Add IPv6 workaround for SnOrca camera

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ OVERLAYS += store-version kernel-modules
 OVERLAYS += enable-ssh enable-usb-eth-hotplug disable-wlan-power-save
 OVERLAYS += stub-fluidd-timelapse camera-v4l2-mpp fluidd-upgrade
 OVERLAYS += enable-klipper-includes enable-moonraker-apprise
+OVERLAYS += ipv6-workarounds-for-snorca
 endif
 
 $(OUTPUT_FILE): firmware/$(FIRMWARE_FILE) tools

--- a/overlays/ipv6-workarounds-for-snorca/patches/01-fix-camera-in-dualstack-lan-mode.patch
+++ b/overlays/ipv6-workarounds-for-snorca/patches/01-fix-camera-in-dualstack-lan-mode.patch
@@ -1,0 +1,37 @@
+diff -uNr rootfs.original/home/lava/moonraker/moonraker/components/machine.py rootfs/home/lava/moonraker/moonraker/components/machine.py
+--- rootfs.original/home/lava/moonraker/moonraker/components/machine.py
++++ rootfs/home/lava/moonraker/moonraker/components/machine.py
+@@ -378,6 +378,33 @@
+             "moonraker": self.unit_name,
+             "klipper": kconn.unit_name
+         }
++
++        # Filter IPv6 addresses for MQTT clients (Snapmaker Orca) in dual-stack
++        # environments to work around bug where Orca prefers IPv6 for camera
++        # but fails to handle it correctly
++        transport = web_request.get_subscribable()
++        if transport is not None and transport.transport_type.name == "MQTT":
++            if "network" in sys_info:
++                has_ipv4 = False
++                has_ipv6 = False
++
++                # Check if we have both IPv4 and IPv6 (dual-stack)
++                for iface, iface_info in sys_info["network"].items():
++                    for addr_info in iface_info.get("ip_addresses", []):
++                        if addr_info["family"] == "ipv4" and not addr_info.get("is_link_local", False):
++                            has_ipv4 = True
++                        elif addr_info["family"] == "ipv6" and not addr_info.get("is_link_local", False):
++                            has_ipv6 = True
++
++                # If dual-stack, remove non-link-local IPv6 addresses
++                if has_ipv4 and has_ipv6:
++                    for iface, iface_info in sys_info["network"].items():
++                        filtered_addrs = [
++                            addr for addr in iface_info.get("ip_addresses", [])
++                            if addr["family"] != "ipv6" or addr.get("is_link_local", False)
++                        ]
++                        iface_info["ip_addresses"] = filtered_addrs
++
+         return {"system_info": sys_info}
+ 
+     async def _set_sudo_password(


### PR DESCRIPTION
- force moonraker to prioritize ipv4 even if ipv6 is available
  - this only applies to MQTT clients (only SnOrca?), not all moonraker clients (fluidd, homeassistant other normal http clients should be unaffected)
  - only applies in dual-stack (ipv4+ipv6) environments
    - Camera works just fine in ipv4-only environments so no fix needed
    - In ipv6-only environments it can't be worked around at all because of SnOrca

SnOrca's ipv6 is currently broken and unsupported.
I tried to isolate and minimize this horrible workaround to not break ipv6 for clients that work just fine.
Intentionally called overlay "ipv6-workarounds-for-snorca" because I expect we'll have more than this one and that we'll want to easily find and remove them all when SnOrca's ipv6 gets fixed.