### PR TITLE
Add curl

### DIFF
--- a/overlays/firmware-extended/20-system-utils/scripts/curl_install.sh
+++ b/overlays/firmware-extended/20-system-utils/scripts/curl_install.sh
@@ -40,3 +40,4 @@ if [[ ! -x "$1/usr/local/bin/curl" ]]; then
 fi
 
 echo ">> curl installed to $1/usr/local/bin"
+


### PR DESCRIPTION
- add system-utils overlay to "extended" profile for things like curl
- install curl to /usr/local/bin
- add curl to dev Dockerfile so container can use curl to download curl

Reasoning:
There is no curl in stock firmware.
We would like to have curl available so that we can e.g. interact with Moonraker API. Specifically, in future PR I'll make adding/removing USB camera to Moonraker on hotplug so that users don't have to manually add it to Moonraker/Fluidd.

Curl is installed from latest binary release of https://github.com/stunnel/static-curl (Travis Lee). This download location is featured at https://curl.se/download.html so it's reliable enough for us to use.