### PR TITLE
Add Mainsail web interface support as alternative to Fluidd

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ All basic firmware features plus:
 - [Extended Configuration](docs/extended_config.md) - Customize firmware behavior via config file
 - [Camera Support](docs/camera_support.md) - Hardware-accelerated camera stack (Rockchip MPP/VPU)
 - [USB Camera Support](docs/camera_support.md) - Support for external USB cameras
-- [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files via Fluidd
+- [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
 - [RFID Filament Tag Support](docs/rfid_support.md) - NTAG213/215/216 support for OpenPrintTag and OpenSpool formats
 - Moonraker Apprise notifications - Send print notifications to Discord, Telegram, Slack, and 90+ services
 - WebRTC low-latency streaming
-- Fluidd v1.35.0 with timelapse plugin
+- Fluidd or Mainsail (selectable) with timelapse plugin
 
 Known issues:
 
@@ -46,7 +46,8 @@ Known issues:
 - [SSH Access](docs/ssh_access.md) - How to access the printer via SSH
 - [Extended Configuration](docs/extended_config.md) - Customize firmware behavior via config file
 - [Camera Support](docs/camera_support.md) - Camera features and WebRTC streaming
-- [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files via Fluidd
+- [Extended Configuration](docs/extended_config.md) - Configure web interface and firmware options
+- [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files
 - [RFID Filament Tag Support](docs/rfid_support.md) - RFID filament tag usage and programming
 - [Data Persistence](docs/data_persistence.md) - Persistent storage configuration
 

--- a/docs/extended_config.md
+++ b/docs/extended_config.md
@@ -46,6 +46,13 @@ After saving, reboot the printer.
 
   * `syslog` - Enable logging to syslog (/var/log/messages)
 
+### [web]
+
+* `frontend` - Web interface selection (only one can be active)
+
+  * `fluidd` (default) - Fluidd web interface
+  * `mainsail` - Mainsail web interface
+
 ## Example Configuration
 
 ```ini
@@ -53,6 +60,10 @@ After saving, reboot the printer.
 stack: paxx12
 # stack: snapmaker
 logs: syslog
+
+[web]
+frontend: fluidd
+# frontend: mainsail
 ```
 
 ## Important Notes
@@ -61,6 +72,7 @@ logs: syslog
 - The file uses INI-style format with sections `[camera]` and `[web]`
 - Lines starting with `#` are comments and ignored
 - Only one camera stack can be active at a time
+- Only one web interface mode can be active at a time
 
 ## Revert back to defaults
 

--- a/docs/klipper_includes.md
+++ b/docs/klipper_includes.md
@@ -13,9 +13,9 @@ This overlay modifies the default Klipper and Moonraker configurations to includ
 
 ## Usage
 
-### Using Fluidd Web Interface
+### Using Fluidd or Mainsail Web Interface
 
-1. Open Fluidd in your web browser (`http://<printer-ip>`)
+1. Open Fluidd or Mainsail in your web browser (`http://<printer-ip>`)
 2. Go to **Configuration** tab
 3. Navigate to the **klipper** folder to create Klipper configuration files (`.cfg`)
 4. Navigate to the **moonraker** folder to create Moonraker configuration files (`.cfg`)
@@ -24,7 +24,7 @@ This overlay modifies the default Klipper and Moonraker configurations to includ
 
 ### Klipper Configuration
 
-In the Fluidd Configuration tab, go to the **klipper** folder and create `.cfg` files with your custom Klipper configuration.
+In the Configuration tab, go to the **klipper** folder and create `.cfg` files with your custom Klipper configuration.
 
 Example `custom-macros.cfg`:
 
@@ -37,7 +37,7 @@ gcode:
 
 ### Moonraker Configuration
 
-In the Fluidd Configuration tab, go to the **moonraker** folder and create `.cfg` files with your custom Moonraker configuration.
+In the Configuration tab, go to the **moonraker** folder and create `.cfg` files with your custom Moonraker configuration.
 
 Example `usb-camera.cfg` for USB camera support:
 

--- a/overlays/firmware-extended/00-default-config/root/home/lava/default-config/extended/extended.cfg
+++ b/overlays/firmware-extended/00-default-config/root/home/lava/default-config/extended/extended.cfg
@@ -4,3 +4,7 @@
 stack: paxx12
 # stack: snapmaker
 # logs: syslog
+
+[web]
+frontend: fluidd
+# frontend: mainsail

--- a/overlays/firmware-extended/50-stub-moonraker-timelapse/root/home/lava/moonraker/moonraker/components/timelapse.py
+++ b/overlays/firmware-extended/50-stub-moonraker-timelapse/root/home/lava/moonraker/moonraker/components/timelapse.py
@@ -18,5 +18,30 @@ class Timelapse:
                                         full_access=True
                                         )
 
+        # required by Mainsail API
+        self.server.register_endpoint(
+            "/machine/timelapse/settings",
+            ["GET", "POST"],
+            self._handle_settings
+        )
+        self.server.register_endpoint(
+            "/machine/timelapse/lastframeinfo",
+            ["GET"],
+            self._handle_lastframeinfo
+        )
+
+    async def _handle_settings(self, web_request: WebRequest) -> Dict[str, Any]:
+        """Return stub timelapse settings."""
+        return {
+            "enabled": False
+        }
+
+    async def _handle_lastframeinfo(self, web_request: WebRequest) -> Dict[str, Any]:
+        """Return stub last frame info."""
+        return {
+            "lastframefile": "",
+            "count": 0
+        }
+
 def load_component(config: ConfigHelper) -> Timelapse:
     return Timelapse(config)

--- a/overlays/firmware-extended/91-mainsail-install/root/etc/init.d/S49nginx_conf
+++ b/overlays/firmware-extended/91-mainsail-install/root/etc/init.d/S49nginx_conf
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+EXTENDED_CFG="/home/lava/printer_data/config/extended/extended.cfg"
+SITES_ENABLED="/etc/nginx/sites-enabled"
+SITES_AVAILABLE="/etc/nginx/sites-available"
+
+configure_nginx_site()
+{
+	rm -f "$SITES_ENABLED/fluidd"
+	rm -f "$SITES_ENABLED/mainsail"
+
+	WEB_FRONTEND=$(/usr/local/bin/extended-config.py "$EXTENDED_CFG" web frontend fluidd)
+
+	if [ "$WEB_FRONTEND" = "mainsail" ]; then
+		echo "Enabling Mainsail web interface"
+		ln -sf "$SITES_AVAILABLE/mainsail" "$SITES_ENABLED/"
+	else
+		echo "Enabling Fluidd web interface"
+		ln -sf "$SITES_AVAILABLE/fluidd" "$SITES_ENABLED/"
+	fi
+}
+
+case "$1" in
+	start)
+		configure_nginx_site
+		;;
+
+	stop)
+		;;
+
+	restart|reload)
+		configure_nginx_site
+		;;
+
+	*)
+		echo "Usage: $0 {start|stop|restart|reload}"
+		exit 1
+		;;
+esac
+
+exit $?

--- a/overlays/firmware-extended/91-mainsail-install/root/etc/nginx/sites-available/mainsail
+++ b/overlays/firmware-extended/91-mainsail-install/root/etc/nginx/sites-available/mainsail
@@ -1,0 +1,97 @@
+# /etc/nginx/sites-available/mainsail
+
+server {
+    listen 80 default_server;
+    # uncomment the next line to activate IPv6
+    # listen [::]:80 default_server;
+
+    # access_log /var/log/nginx/mainsail-access.log;
+    error_log /var/log/nginx/mainsail-error.log;
+
+    # disable this section on smaller hardware like a pi zero
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_comp_level 4;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/json application/xml;
+
+    # web_path from mainsail static files
+    root /home/lava/mainsail;
+
+    index index.html;
+    server_name _;
+
+    # disable max upload size checks
+    client_max_body_size 0;
+
+    # disable proxy request buffering
+    proxy_request_buffering off;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    location /websocket {
+        proxy_pass http://apiserver/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 86400;
+    }
+
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://apiserver$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    location /webcam/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer1/;
+    }
+
+    location /webcam2/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer2/;
+    }
+
+    location /webcam3/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer3/;
+    }
+
+    location /webcam4/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer4/;
+    }
+}

--- a/overlays/firmware-extended/91-mainsail-install/root/home/lava/default-config/extended/klipper/mainsail_pause_resume.cfg
+++ b/overlays/firmware-extended/91-mainsail-install/root/home/lava/default-config/extended/klipper/mainsail_pause_resume.cfg
@@ -1,0 +1,9 @@
+[gcode_macro PAUSE]
+description: Pause the actual running print
+rename_existing: _PAUSE_BASE
+gcode: _PAUSE_BASE
+
+[gcode_macro RESUME]
+description: Resume the actual running print
+rename_existing: _RESUME_BASE
+gcode: _RESUME_BASE

--- a/overlays/firmware-extended/91-mainsail-install/scripts/01-install-mainsail.sh
+++ b/overlays/firmware-extended/91-mainsail-install/scripts/01-install-mainsail.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+set -eo pipefail
+
+ROOTFS_DIR="$1"
+TARGET_DIR="$ROOT_DIR/tmp"
+
+echo ">> Checking for fluidd nginx configurations..."
+if [[ ! -f "$ROOTFS_DIR/etc/nginx/sites-available/fluidd" ]]; then
+  echo "ERROR: fluidd not found at $ROOTFS_DIR/etc/nginx/sites-available/fluidd"
+  exit 1
+fi
+if [[ ! -L "$ROOTFS_DIR/etc/nginx/sites-enabled/fluidd" ]]; then
+  echo "ERROR: fluidd not found at $ROOTFS_DIR/etc/nginx/sites-enabled/fluidd"
+  exit 1
+fi
+
+VERSION=v2.16.0
+URL=https://github.com/mainsail-crew/mainsail/releases/download/$VERSION/mainsail.zip
+SHA256=0a4218ed9b053000024eed9223f9efef2caafeb78a3daebb02283e4320303431
+FILENAME=mainsail-$VERSION.zip
+
+if [[ ! -f "$TARGET_DIR/$FILENAME" ]]; then
+  echo ">> Downloading $FILENAME..."
+  wget -O "$TARGET_DIR/$FILENAME" "$URL"
+fi
+
+echo ">> Verifying $FILENAME checksum..."
+echo "$SHA256  $TARGET_DIR/$FILENAME" | sha256sum --check --status
+
+echo ">> Extracting $FILENAME..."
+rm -rf "$TARGET_DIR/mainsail-$VERSION"
+unzip -o "$TARGET_DIR/$FILENAME" -d "$TARGET_DIR/mainsail-$VERSION"
+
+echo ">> Installing $FILENAME to target rootfs..."
+rm -rf "$1/home/lava/mainsail"
+cp -r "$TARGET_DIR/mainsail-$VERSION" "$1/home/lava/mainsail"


### PR DESCRIPTION
- Add 91-mainsail-install overlay with Mainsail v2.16.0
- Add S49nginx_conf init script to dynamically configure web interface based on `extended.cfg`
- Update documentation to reflect selectable web interface option
