### PR TITLE
Fix relative paths after overlay restructuring

### DIFF
--- a/overlays/firmware-extended/02-camera-v4l2-mpp/scripts/01-v4l2-mpp.sh
+++ b/overlays/firmware-extended/02-camera-v4l2-mpp/scripts/01-v4l2-mpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT_DIR="$(realpath "$(dirname "$0")/../../..")"
+ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
 
 GIT_URL=https://github.com/paxx12/v4l2-mpp.git
 GIT_SHA=6c5a3ea7c3b0d245e0d0edfc00f3e4f185a19597

--- a/overlays/firmware-extended/03-rfid-support/pre-scripts/01_klippy_fix_lf.sh
+++ b/overlays/firmware-extended/03-rfid-support/pre-scripts/01_klippy_fix_lf.sh
@@ -5,7 +5,7 @@ if [[ $# -ne 1 ]]; then
   exit 1
 fi
 
-ROOT_DIR="$(realpath "$(dirname "$0")/../../..")"
+ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
 
 dos2unix "$1/home/lava/klipper/klippy/extras/filament_detect.py" \
   "$1/home/lava/klipper/klippy/extras/fm175xx_reader.py"

--- a/overlays/firmware-extended/03-rfid-support/test/app/__init__.py
+++ b/overlays/firmware-extended/03-rfid-support/test/app/__init__.py
@@ -6,4 +6,4 @@ BASE = os.path.dirname(os.path.abspath(__file__))
 # Extend the module search path to include extras directories
 __path__ = pkgutil.extend_path(__path__, __name__)
 __path__.append(os.path.join(BASE, "../../root/home/lava/klipper/klippy/extras"))
-__path__.append(os.path.join(BASE, "../../../../tmp/extracted/rootfs/home/lava/klipper/klippy/extras"))
+__path__.append(os.path.join(BASE, "../../../../../tmp/extracted/rootfs/home/lava/klipper/klippy/extras"))


### PR DESCRIPTION
Update ROOT_DIR calculations and module search paths to account for the new hierarchical overlay directory structure with category prefixes.