### PR TITLE
Enable object post processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All basic firmware features plus:
 - [USB Camera Support](docs/camera_support.md) - Support for external USB cameras
 - [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
 - [RFID Filament Tag Support](docs/rfid_support.md) - NTAG213/215/216 support for OpenPrintTag and OpenSpool formats
+- Moonraker Adaptive Mesh Support - Object processing for adaptive mesh features
 - Moonraker Apprise notifications - Send print notifications to Discord, Telegram, Slack, and 90+ services
 - WebRTC low-latency streaming
 - Fluidd or Mainsail (selectable) with timelapse plugin

--- a/overlays/firmware-extended/52-enable-moonraker-adaptive-mesh/root/home/lava/default-config/extended/moonraker/04_adaptive_mesh.cfg
+++ b/overlays/firmware-extended/52-enable-moonraker-adaptive-mesh/root/home/lava/default-config/extended/moonraker/04_adaptive_mesh.cfg
@@ -1,0 +1,6 @@
+# DO NOT REMOVE THIS FILE
+
+# Enable object processing in Moonraker's file manager
+# to support adaptive mesh features.
+[file_manager]
+enable_object_processing: True


### PR DESCRIPTION
Enable Moonraker adaptive mesh support
    
Add configuration to enable object processing in Moonraker's file manager,
which is required for adaptive mesh features to function properly.