### PR TITLE
Relax OpenSpool NDEF material type parsing

### DIFF
--- a/overlays/firmware-extended/03-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/03-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -150,12 +150,7 @@ def openspool_parse_payload(payload):
         info['VENDOR'] = data.get('brand', 'Generic')
         info['MANUFACTURER'] = data.get('brand', 'Generic')
 
-        material_type = data.get('type', '').upper()
-        if material_type in filament_protocol.FILAMENT_PROTO_MAIN_TYPE_MAPPING:
-            info['MAIN_TYPE'] = material_type
-        else:
-            info['MAIN_TYPE'] = 'Reserved'
-
+        info['MAIN_TYPE'] = data.get('type', 'PLA').upper()
         info['SUB_TYPE'] = 'Basic'
         info['TRAY'] = 0
 


### PR DESCRIPTION
Remove unnecessary validation against FILAMENT_PROTO_MAIN_TYPE_MAPPING and use the material type directly from the spool data. This allows custom material types to pass through instead of being mapped to 'Reserved'.