### PR TITLE
Add non-standard OpenSpool `subtype` field

### DIFF
--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -66,6 +66,21 @@ Example payload:
 }
 ```
 
+Using the non-standard OpenSpool `subtype` field it is possible to specify a material subtype:
+
+```json
+{
+  "protocol": "openspool",
+  "version": "1.0",
+  "type": "PETG",
+  "subtype": "Rapid",
+  "color_hex": "AFAFAF",
+  "brand": "Elegoo",
+  "min_temp": "230",
+  "max_temp": "260"
+}
+```
+
 **Supported OpenSpool Fields:**
 - `protocol` (required) - Must be "openspool"
 - `version` (required) - Specification version (e.g., "1.0")
@@ -76,6 +91,13 @@ Example payload:
 - `max_temp` (optional) - Maximum nozzle temperature in °C
 - `bed_min_temp` (optional) - Minimum bed temperature in °C
 - `bed_max_temp` (optional) - Maximum bed temperature in °C
+
+**Supported non-standard OpenSpool Fields:**
+- `subtype` (optional, default: "Basic") - Material subtype (e.g. "Rapid", "HF")
+
+## Snapmaker Orca Filament Naming Scheme
+
+In order for Snapmaker Orca to recognize the filement, it must be named according to this naming scheme: `<brand> <type> <subtype>`, e.g. `Generic PLA Basic` and `Elegoo PETG Rapid`.
 
 ## Reading Existing Tags
 

--- a/overlays/firmware-extended/03-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/03-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -151,7 +151,7 @@ def openspool_parse_payload(payload):
         info['MANUFACTURER'] = data.get('brand', 'Generic')
 
         info['MAIN_TYPE'] = data.get('type', 'PLA').upper()
-        info['SUB_TYPE'] = 'Basic'
+        info['SUB_TYPE'] = data.get('subtype', 'Basic')
         info['TRAY'] = 0
 
         color_hex = data.get('color_hex', 'FFFFFF')


### PR DESCRIPTION
This PR adds the ability to specify the material subtype using a non-standard OpenSpool field, `subtype` as well as adding information on naming filaments in Snapmaker Orca.

I have tested the changes using Snapmaker Orca 2.1.5.