### PR TITLE
Add Remote Screen Access Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All basic firmware features plus:
 - Moonraker Apprise notifications - Send print notifications to Discord, Telegram, Slack, and 90+ services
 - WebRTC low-latency streaming
 - Fluidd or Mainsail (selectable) with timelapse plugin
+- [Remote Screen](docs/remote_screen.md) - View printer screen remotely via web browser
 
 Known issues:
 
@@ -51,6 +52,7 @@ Known issues:
 - [Klipper and Moonraker Custom Includes](docs/klipper_includes.md) - Add custom configuration files
 - [RFID Filament Tag Support](docs/rfid_support.md) - RFID filament tag usage and programming
 - [Data Persistence](docs/data_persistence.md) - Persistent storage configuration
+- [Remote Screen](docs/remote_screen.md) - Access printer screen remotely via web browser
 
 ## Dependent projects
 

--- a/docs/remote_screen.md
+++ b/docs/remote_screen.md
@@ -1,0 +1,98 @@
+# Remote Screen Access
+
+**Available in: Extended firmware only**
+
+The extended firmware includes web-based remote screen access with touch control, allowing you to interact with your printer's touchscreen from any device with a web browser.
+
+## Features
+
+- Full screen mirroring of the printer's display
+- Touch input support (tap, swipe, multi-touch)
+- Access from any device (desktop, tablet, phone)
+- Authentication inherited from Fluidd/Mainsail web interface
+
+## Accessing the Remote Screen
+
+Once enabled, access the remote screen at:
+
+```text
+http://<printer-ip>/screen/
+```
+
+Replace `<printer-ip>` with your printer's IP address.
+
+## Enabling Remote Screen Access
+
+Remote screen access is **disabled by default**. To enable it:
+
+### Via Fluidd/Mainsail
+
+1. On the printer, go to **Settings > Maintenance > Advanced Mode** and enable it
+2. Open Fluidd or Mainsail in your web browser (`http://<printer-ip>`)
+3. Go to the **Configuration** tab
+4. Navigate to the root directory and open `extended.cfg`
+5. Add or modify the `[remote_screen]` section:
+
+   ```ini
+   [remote_screen]
+   enabled: true
+   ```
+
+6. Save the file
+7. Reboot the printer
+
+### Via SSH
+
+```bash
+ssh lava@<printer-ip>
+vi /home/lava/printer_data/config/extended/extended.cfg
+```
+
+Add or modify:
+
+```ini
+[remote_screen]
+enabled: true
+```
+
+Save and reboot the printer.
+
+## Security
+
+- Reuses Fluidd/Mainsail authentication which is none by default
+- Remote screen is disabled by default in [extended.cfg](../10-default-config/root/home/lava/default-config/extended/extended.cfg) because by default there is no authentication
+- User has to explicitly enable it in `extended.cfg`
+- Requires authentication only if Fluidd/Mainsail also require authentication (Moonraker config)
+
+## Browser/Device Compatibility
+
+The remote screen uses normal HTML and works with all modern browsers.
+It can also be installed as a Progressive Web App (PWA) on supported devices for a more app-like experience.
+
+## Troubleshooting
+
+### Remote screen not accessible
+
+1. Verify remote screen is enabled in `extended.cfg`
+2. Reboot the printer after enabling
+3. Check that you can access Fluidd/Mainsail web interfaces normally
+
+### Screen appears frozen
+
+1. Refresh the browser page
+2. Check if the printer's physical screen is responding
+3. Restart the remote screen service:
+
+   ```bash
+   ssh lava@<printer-ip>
+   sudo /etc/init.d/S99fb-http restart
+   ```
+
+## Technical Details
+
+The remote screen feature uses:
+
+- **fb-http-server.py**: A lightweight Python HTTP server that serves the framebuffer as PNG snapshots and accepts touch input
+- **nginx**: Serves the web interface and proxies WebSocket connections
+
+For more technical information, see the [overlay README](../overlays/firmware-extended/99-remote-screen/README.md).

--- a/overlays/firmware-extended/10-default-config/root/home/lava/default-config/extended/extended.cfg
+++ b/overlays/firmware-extended/10-default-config/root/home/lava/default-config/extended/extended.cfg
@@ -8,3 +8,10 @@ stack: paxx12
 [web]
 frontend: fluidd
 # frontend: mainsail
+
+[remote_screen]
+# Enable remote screen access at http://<printer-ip>/screen/
+# Uses same authentication as Fluidd/Mainsail, enable it using moonraker's force_logins option.
+# By default, authentication is not required so this is insecure.
+enabled: false
+

--- a/overlays/firmware-extended/90-fluidd-upgrade/patches/01-add-nginx_auth_check_endpoint.patch
+++ b/overlays/firmware-extended/90-fluidd-upgrade/patches/01-add-nginx_auth_check_endpoint.patch
@@ -1,0 +1,23 @@
+--- a/etc/nginx/sites-available/fluidd
++++ b/etc/nginx/sites-available/fluidd
+@@ -59,6 +59,20 @@
+         proxy_read_timeout 600;
+     }
+ 
++    # Internal auth check endpoint for use by 3rd party services that want to check if user is authenticated with moonraker
++    location = /auth_check {
++        internal;
++        # Forward token query parameter if present (for websocket oneshot tokens)
++        proxy_pass http://apiserver/access/user$is_args$args;
++        proxy_pass_request_body off;
++        proxy_set_header Content-Length "";
++        proxy_set_header X-Original-URI $request_uri;
++        proxy_set_header Authorization $http_authorization;
++        # Forward client IP for oneshot token validation
++        proxy_set_header X-Real-IP $remote_addr;
++        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
++    }
++
+     location /webcam/ {
+         postpone_output 0;
+         proxy_buffering off;

--- a/overlays/firmware-extended/91-mainsail-install/root/etc/nginx/sites-available/mainsail
+++ b/overlays/firmware-extended/91-mainsail-install/root/etc/nginx/sites-available/mainsail
@@ -59,6 +59,20 @@ server {
         proxy_set_header X-Scheme $scheme;
     }
 
+    # Internal auth check endpoint for use by 3rd party services that want to check if user is authenticated with moonraker
+    location = /auth_check {
+        internal;
+        # Forward token query parameter if present (for websocket oneshot tokens)
+        proxy_pass http://apiserver/access/user$is_args$args;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Authorization $http_authorization;
+        # Forward client IP for oneshot token validation
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location /webcam/ {
         postpone_output 0;
         proxy_buffering off;

--- a/overlays/firmware-extended/99-remote-screen/README.md
+++ b/overlays/firmware-extended/99-remote-screen/README.md
@@ -1,0 +1,30 @@
+# Remote Screen 2 - Simple HTTP Framebuffer Server
+
+A lightweight Python HTTP server that exposes the framebuffer as PNG snapshots and accepts touch input.
+
+## Features
+
+- Reads from `/dev/fb0` and converts to PNG
+- Simple web viewer that refreshes at ~2Hz
+- Touch input support via `/dev/input/event0`
+
+## Endpoints
+
+- `GET /` - HTML viewer with auto-refresh and touch support
+- `GET /snapshot` - Current framebuffer as PNG image
+- `POST /touch?x=&y=` - Send touch event at coordinates
+
+## Configuration
+
+Edit `/etc/init.d/S99fb-http` to change:
+
+- `PORT` - HTTP port (default: 8092)
+- `BIND` - Bind address (default: 0.0.0.0)
+- `FB_DEVICE` - Framebuffer device (default: /dev/fb0)
+- `TOUCH_DEVICE` - Touch input device (default: /dev/input/event0)
+- `HTML_TEMPLATE` - Path to HTML template file (default: /usr/local/share/fb-http-server/index.html)
+
+## Dependencies
+
+- Python 3
+- Pillow (installed via pip)

--- a/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-fluidd.patch
+++ b/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-fluidd.patch
@@ -1,0 +1,30 @@
+--- a/etc/nginx/sites-available/fluidd
++++ b/etc/nginx/sites-available/fluidd
+@@ -109,2 +109,26 @@
+         proxy_pass http://mjpgstreamer4/;
+     }
++
++    # Remote screen access via fb-http-server
++    location = /screen {
++        return 301 /screen/;
++    }
++
++    location /screen/ {
++        alias /usr/local/share/fb-http-server/;
++        index index.html;
++    }
++
++    location /screen/snapshot {
++        auth_request /auth_check;
++        proxy_pass http://127.0.0.1:8092/snapshot;
++        proxy_http_version 1.1;
++        proxy_set_header Host $host;
++    }
++
++    location /screen/touch {
++        auth_request /auth_check;
++        proxy_pass http://127.0.0.1:8092/touch;
++        proxy_http_version 1.1;
++        proxy_set_header Host $host;
++    }
+ }

--- a/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-mainsail.patch
+++ b/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-mainsail.patch
@@ -1,0 +1,30 @@
+--- a/etc/nginx/sites-available/mainsail
++++ b/etc/nginx/sites-available/mainsail
+@@ -109,2 +109,26 @@
+         proxy_pass http://mjpgstreamer4/;
+     }
++
++    # Remote screen access via fb-http-server
++    location = /screen {
++        return 301 /screen/;
++    }
++
++    location /screen/ {
++        alias /usr/local/share/fb-http-server/;
++        index index.html;
++    }
++
++    location /screen/snapshot {
++        auth_request /auth_check;
++        proxy_pass http://127.0.0.1:8092/snapshot;
++        proxy_http_version 1.1;
++        proxy_set_header Host $host;
++    }
++
++    location /screen/touch {
++        auth_request /auth_check;
++        proxy_pass http://127.0.0.1:8092/touch;
++        proxy_http_version 1.1;
++        proxy_set_header Host $host;
++    }
+ }

--- a/overlays/firmware-extended/99-remote-screen/root/etc/init.d/S99fb-http
+++ b/overlays/firmware-extended/99-remote-screen/root/etc/init.d/S99fb-http
@@ -1,0 +1,62 @@
+#!/bin/sh
+EXTENDED_CFG="/home/lava/printer_data/config/extended/extended.cfg"
+REMOTE_SCREEN_ENABLED=$(/usr/local/bin/extended-config.py "$EXTENDED_CFG" remote_screen enabled false)
+
+NAME="fb-http-server"
+DAEMON="/usr/local/bin/fb-http-server.py"
+PIDFILE="/var/run/$NAME.pid"
+LOGFILE="/var/log/$NAME.log"
+
+FB_DEVICE="/dev/fb0"
+TOUCH_DEVICE="/dev/input/event0"
+HTML_TEMPLATE="/usr/local/share/fb-http-server/index.html"
+PORT=8092
+BIND=127.0.0.1
+
+start() {
+	[ "$REMOTE_SCREEN_ENABLED" = "true" ] || { echo "$NAME is disabled in extended.cfg, not starting." && return 0; }
+    printf "Starting $NAME: "
+    if [ -f "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") 2>/dev/null; then
+        echo "already running"
+        return 1
+    fi
+    start-stop-daemon -S -b -m -p "$PIDFILE" -x /usr/bin/python3 -- \
+        "$DAEMON" --bind "$BIND" --port "$PORT" --fb "$FB_DEVICE" \
+		--touch "$TOUCH_DEVICE" --html "$HTML_TEMPLATE" >> "$LOGFILE" 2>&1
+    echo "OK"
+}
+
+stop() {
+    printf "Stopping $NAME: "
+    if [ -f "$PIDFILE" ]; then
+        start-stop-daemon -K -p "$PIDFILE" -s TERM
+        rm -f "$PIDFILE"
+        echo "OK"
+    else
+        echo "not running"
+    fi
+}
+
+restart() {
+    stop
+    sleep 1
+    start
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|reload)
+        restart
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+        ;;
+esac
+
+exit $?

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/bin/fb-http-server.py
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/bin/fb-http-server.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+
+import argparse
+import ctypes
+import fcntl
+import hashlib
+import mmap
+import os
+import struct
+import time
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from io import BytesIO
+from urllib.parse import urlparse, parse_qs
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+FBIOGET_VSCREENINFO = 0x4600
+FBIOGET_FSCREENINFO = 0x4602
+
+class FbVarScreeninfo(ctypes.Structure):
+    _fields_ = [
+        ("xres", ctypes.c_uint32),
+        ("yres", ctypes.c_uint32),
+        ("xres_virtual", ctypes.c_uint32),
+        ("yres_virtual", ctypes.c_uint32),
+        ("xoffset", ctypes.c_uint32),
+        ("yoffset", ctypes.c_uint32),
+        ("bits_per_pixel", ctypes.c_uint32),
+        ("grayscale", ctypes.c_uint32),
+        ("red", ctypes.c_uint32 * 3),
+        ("green", ctypes.c_uint32 * 3),
+        ("blue", ctypes.c_uint32 * 3),
+        ("transp", ctypes.c_uint32 * 3),
+        ("nonstd", ctypes.c_uint32),
+        ("activate", ctypes.c_uint32),
+        ("height", ctypes.c_uint32),
+        ("width", ctypes.c_uint32),
+        ("accel_flags", ctypes.c_uint32),
+        ("pixclock", ctypes.c_uint32),
+        ("left_margin", ctypes.c_uint32),
+        ("right_margin", ctypes.c_uint32),
+        ("upper_margin", ctypes.c_uint32),
+        ("lower_margin", ctypes.c_uint32),
+        ("hsync_len", ctypes.c_uint32),
+        ("vsync_len", ctypes.c_uint32),
+        ("sync", ctypes.c_uint32),
+        ("vmode", ctypes.c_uint32),
+        ("rotate", ctypes.c_uint32),
+        ("colorspace", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32 * 4),
+    ]
+
+class FbFixScreeninfo(ctypes.Structure):
+    _fields_ = [
+        ("id", ctypes.c_char * 16),
+        ("smem_start", ctypes.c_ulong),
+        ("smem_len", ctypes.c_uint32),
+        ("type", ctypes.c_uint32),
+        ("type_aux", ctypes.c_uint32),
+        ("visual", ctypes.c_uint32),
+        ("xpanstep", ctypes.c_uint16),
+        ("ypanstep", ctypes.c_uint16),
+        ("ywrapstep", ctypes.c_uint16),
+        ("line_length", ctypes.c_uint32),
+        ("mmio_start", ctypes.c_ulong),
+        ("mmio_len", ctypes.c_uint32),
+        ("accel", ctypes.c_uint32),
+        ("capabilities", ctypes.c_uint16),
+        ("reserved", ctypes.c_uint16 * 2),
+    ]
+
+EV_SYN = 0x00
+EV_KEY = 0x01
+EV_ABS = 0x03
+SYN_REPORT = 0x00
+BTN_TOUCH = 0x14a
+ABS_X = 0x00
+ABS_Y = 0x01
+ABS_MT_SLOT = 0x2f
+ABS_MT_TRACKING_ID = 0x39
+ABS_MT_POSITION_X = 0x35
+ABS_MT_POSITION_Y = 0x36
+
+def log(msg):
+    ts = time.strftime('%H:%M:%S')
+    print(f"[{ts}] {msg}", flush=True)
+
+class Framebuffer:
+    def __init__(self, device='/dev/fb0'):
+        self.device = device
+        self.fd = None
+        self.mm = None
+        self.width = 0
+        self.height = 0
+        self.bpp = 0
+        self.line_length = 0
+        self._cache_hash = None
+        self._cache_raw = None
+        self._cache_png = None
+        self._cache_time = 0
+        self._open()
+
+    def _open(self):
+        self.fd = os.open(self.device, os.O_RDONLY)
+        vinfo = FbVarScreeninfo()
+        fcntl.ioctl(self.fd, FBIOGET_VSCREENINFO, vinfo)
+        finfo = FbFixScreeninfo()
+        fcntl.ioctl(self.fd, FBIOGET_FSCREENINFO, finfo)
+
+        self.width = vinfo.xres
+        self.height = vinfo.yres
+        self.bpp = vinfo.bits_per_pixel
+        self.line_length = finfo.line_length
+
+        size = finfo.line_length * vinfo.yres
+        self.mm = mmap.mmap(self.fd, size, mmap.MAP_SHARED, mmap.PROT_READ)
+        log(f"Framebuffer: {self.width}x{self.height} @ {self.bpp}bpp, line_length={self.line_length}")
+
+    def get_snapshot(self, client_etag=None):
+        self.mm.seek(0)
+        raw = self.mm.read(self.line_length * self.height)
+        raw_hash = hashlib.md5(raw).hexdigest()[:16]
+        if client_etag and client_etag == raw_hash:
+            return raw_hash, None
+        if raw_hash == self._cache_hash and self._cache_png:
+            return raw_hash, self._cache_png
+        if Image is None:
+            return raw_hash, b''
+        if self.bpp == 32:
+            img = Image.frombytes('RGBA', (self.width, self.height), raw, 'raw', 'BGRA', self.line_length)
+            img = img.convert('RGB')
+        elif self.bpp == 16:
+            img = Image.frombytes('RGB', (self.width, self.height), raw, 'raw', 'BGR;16', self.line_length)
+        else:
+            img = Image.frombytes('RGB', (self.width, self.height), raw, 'raw', 'BGR', self.line_length)
+        buf = BytesIO()
+        img.save(buf, 'PNG', compress_level=6)
+        png_data = buf.getvalue()
+        self._cache_hash = raw_hash
+        self._cache_png = png_data
+        return raw_hash, png_data
+
+    def close(self):
+        if self.mm:
+            self.mm.close()
+        if self.fd:
+            os.close(self.fd)
+
+class TouchInput:
+    def __init__(self, device='/dev/input/event0', fb_width=1024, fb_height=600):
+        self.device = device
+        self.fd = None
+        self.fb_width = fb_width
+        self.fb_height = fb_height
+        self.touch_max_x = 1024
+        self.touch_max_y = 600
+        self._open()
+
+    def _open(self):
+        try:
+            self.fd = os.open(self.device, os.O_WRONLY)
+            self._get_abs_info()
+            log(f"Touch device: {self.device}, range: {self.touch_max_x}x{self.touch_max_y}")
+        except OSError as e:
+            log(f"Failed to open touch device: {e}")
+            self.fd = None
+
+    def _get_abs_info(self):
+        EVIOCGABS = lambda axis: 0x80184540 + axis
+        try:
+            buf = bytearray(24)
+            fcntl.ioctl(self.fd, EVIOCGABS(ABS_MT_POSITION_X), buf)
+            self.touch_max_x = struct.unpack('iiiii', buf[:20])[2]
+            fcntl.ioctl(self.fd, EVIOCGABS(ABS_MT_POSITION_Y), buf)
+            self.touch_max_y = struct.unpack('iiiii', buf[:20])[2]
+        except OSError:
+            try:
+                fcntl.ioctl(self.fd, EVIOCGABS(ABS_X), buf)
+                self.touch_max_x = struct.unpack('iiiii', buf[:20])[2]
+                fcntl.ioctl(self.fd, EVIOCGABS(ABS_Y), buf)
+                self.touch_max_y = struct.unpack('iiiii', buf[:20])[2]
+            except OSError:
+                pass
+
+    def _write_event(self, ev_type, code, value):
+        if self.fd is None:
+            return
+        tv_sec = int(time.time())
+        tv_usec = int((time.time() % 1) * 1000000)
+        event = struct.pack('llHHi', tv_sec, tv_usec, ev_type, code, value)
+        os.write(self.fd, event)
+
+    def _scale(self, x, y):
+        touch_x = int(x * self.touch_max_x / self.fb_width)
+        touch_y = int(y * self.touch_max_y / self.fb_height)
+        return touch_x, touch_y
+
+    def tap(self, x, y):
+        if self.fd is None:
+            log(f"Touch device not available, would tap at ({x}, {y})")
+            return
+        touch_x, touch_y = self._scale(x, y)
+        log(f"Tap at ({x}, {y}) -> touch ({touch_x}, {touch_y})")
+        self._write_event(EV_ABS, ABS_MT_SLOT, 0)
+        self._write_event(EV_ABS, ABS_MT_TRACKING_ID, 1)
+        self._write_event(EV_ABS, ABS_MT_POSITION_X, touch_x)
+        self._write_event(EV_ABS, ABS_MT_POSITION_Y, touch_y)
+        self._write_event(EV_KEY, BTN_TOUCH, 1)
+        self._write_event(EV_SYN, SYN_REPORT, 0)
+        time.sleep(0.05)
+        self._write_event(EV_ABS, ABS_MT_TRACKING_ID, -1)
+        self._write_event(EV_KEY, BTN_TOUCH, 0)
+        self._write_event(EV_SYN, SYN_REPORT, 0)
+
+    def touch_down(self, x, y):
+        if self.fd is None:
+            return
+        touch_x, touch_y = self._scale(x, y)
+        log(f"Touch down at ({x}, {y})")
+        self._write_event(EV_ABS, ABS_MT_SLOT, 0)
+        self._write_event(EV_ABS, ABS_MT_TRACKING_ID, 1)
+        self._write_event(EV_ABS, ABS_MT_POSITION_X, touch_x)
+        self._write_event(EV_ABS, ABS_MT_POSITION_Y, touch_y)
+        self._write_event(EV_KEY, BTN_TOUCH, 1)
+        self._write_event(EV_SYN, SYN_REPORT, 0)
+
+    def touch_move(self, x, y):
+        if self.fd is None:
+            return
+        touch_x, touch_y = self._scale(x, y)
+        self._write_event(EV_ABS, ABS_MT_POSITION_X, touch_x)
+        self._write_event(EV_ABS, ABS_MT_POSITION_Y, touch_y)
+        self._write_event(EV_SYN, SYN_REPORT, 0)
+
+    def touch_up(self):
+        if self.fd is None:
+            return
+        log(f"Touch up")
+        self._write_event(EV_ABS, ABS_MT_TRACKING_ID, -1)
+        self._write_event(EV_KEY, BTN_TOUCH, 0)
+        self._write_event(EV_SYN, SYN_REPORT, 0)
+
+    def close(self):
+        if self.fd:
+            os.close(self.fd)
+
+class ScreenHandler(BaseHTTPRequestHandler):
+    framebuffer = None
+    touch_input = None
+    html_content = None
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == '/snapshot':
+            self.handle_snapshot()
+        elif path == '/' or path == '/index.html':
+            self.handle_index()
+        else:
+            self.send_error(404, 'Not Found')
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/touch':
+            self.handle_touch(parsed.query)
+        else:
+            self.send_error(404, 'Not Found')
+
+    def handle_index(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', len(self.html_content))
+        self.end_headers()
+        self.wfile.write(self.html_content)
+
+    def handle_snapshot(self):
+        try:
+            client_etag = self.headers.get('If-None-Match', '').strip('"')
+            etag, png_data = self.framebuffer.get_snapshot(client_etag)
+            if png_data is None:
+                self.send_response(204)
+                self.send_header('ETag', f'"{etag}"')
+                self.end_headers()
+                return
+            log(f"Snapshot: {len(png_data)} bytes, etag={etag}")
+            self.send_response(200)
+            self.send_header('Content-Type', 'image/png')
+            self.send_header('Content-Length', len(png_data))
+            self.send_header('ETag', f'"{etag}"')
+            self.send_header('Cache-Control', 'no-cache')
+            self.end_headers()
+            self.wfile.write(png_data)
+        except Exception as e:
+            log(f"Snapshot error: {e}")
+            self.send_error(500, str(e))
+
+    def handle_touch(self, query):
+        try:
+            params = parse_qs(query)
+            action = params.get('a', ['tap'])[0]
+            x = int(params.get('x', [0])[0])
+            y = int(params.get('y', [0])[0])
+            if action == 'down':
+                self.touch_input.touch_down(x, y)
+            elif action == 'move':
+                self.touch_input.touch_move(x, y)
+            elif action == 'up':
+                self.touch_input.touch_up()
+            else:
+                self.touch_input.tap(x, y)
+            response = f'{{"status":"ok","a":"{action}","x":{x},"y":{y}}}'.encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', len(response))
+            self.end_headers()
+            self.wfile.write(response)
+        except Exception as e:
+            log(f"Touch error: {e}")
+            response = f'{{"status":"error","message":"{e}"}}'.encode()
+            self.send_response(500)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', len(response))
+            self.end_headers()
+            self.wfile.write(response)
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    default_html = os.path.join(script_dir, 'index.html')
+    parser = argparse.ArgumentParser(description='Framebuffer HTTP Server')
+    parser.add_argument('-p', '--port', type=int, default=8092, help='HTTP port')
+    parser.add_argument('--bind', default='0.0.0.0', help='Bind address')
+    parser.add_argument('--fb', default='/dev/fb0', help='Framebuffer device')
+    parser.add_argument('--touch', default='/dev/input/event0', help='Touch input device')
+    parser.add_argument('--html', default=default_html, help='Path to index.html')
+    args = parser.parse_args()
+    
+    if not os.path.isfile(args.html):
+        log(f"ERROR: HTML file not found: {args.html}")
+        return 1
+
+    if Image is None:
+        log("WARNING: PIL/Pillow not found, PNG capture will not work")
+        log("Install with: pip install Pillow")
+    
+    with open(args.html, 'rb') as f:
+        html_content = f.read()
+
+    fb = Framebuffer(args.fb)
+    touch = TouchInput(args.touch, fb.width, fb.height)
+
+    ScreenHandler.framebuffer = fb
+    ScreenHandler.touch_input = touch
+    ScreenHandler.html_content = html_content
+
+    server = ThreadingHTTPServer((args.bind, args.port), ScreenHandler)
+    log(f"Server running on http://{args.bind}:{args.port}")
+    log(f"  GET  /           - HTML viewer")
+    log(f"  GET  /snapshot   - PNG snapshot")
+    log(f"  POST /touch?x=&y= - Send touch event")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log("Shutting down...")
+    finally:
+        fb.close()
+        touch.close()
+
+if __name__ == '__main__':
+    main()

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/auth.js
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/auth.js
@@ -1,0 +1,80 @@
+// Moonraker authentication: Get JWT from Fluidd/Mainsail localStorage
+function getJWT() {
+    // Fluidd stores tokens as "user-token-{hash}" where hash is based on the instance
+    
+    // First try: instance-specific token (most secure)
+    const instanceKey = `user-token-${window.location.host.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    let token = localStorage.getItem(instanceKey);
+    if (token) return token;
+    
+    // Second try: search for any Fluidd user-token pattern
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith('user-token-')) {
+            token = localStorage.getItem(key);
+            if (token) return token;
+        }
+    }
+    
+    return null;
+}
+
+// Check authentication with Moonraker
+async function checkAuth() {
+    const jwt = getJWT();
+    
+    const headers = {};
+    if (jwt) {
+        headers['Authorization'] = `Bearer ${jwt}`;
+    }
+
+    try {
+        const response = await fetch('/access/oneshot_token', {
+            headers: headers
+        });
+
+        if (!response.ok) {
+            // If 401, redirect to login
+            if (response.status === 401) {
+                console.log('Authentication required, redirecting to login...');
+                window.location.href = '/';
+                return false;
+            }
+            console.warn(`Auth check returned: ${response.status} ${response.statusText}`);
+            return false;
+        }
+
+        // Verify response contains valid token (works with auth enabled or disabled)
+        const data = await response.json();
+        const token = data.result || data;
+        
+        if (!token) {
+            console.error('Invalid auth response: no token received');
+            return false;
+        }
+
+        return true;
+    } catch (err) {
+        console.error("Authentication error:", err);
+        return false;
+    }
+}
+
+// Initialize authentication check on page load
+async function initAuth() {
+    const authenticated = await checkAuth();
+    if (!authenticated) {
+        console.log('Authentication check failed');
+    }
+    return authenticated;
+}
+
+// Get auth headers for API requests
+function getAuthHeaders() {
+    const jwt = getJWT();
+    const headers = {};
+    if (jwt) {
+        headers['Authorization'] = `Bearer ${jwt}`;
+    }
+    return headers;
+}

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/icon.svg
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <!-- Main body -->
+  <rect x="64" y="100" width="128" height="120" rx="8" fill="#f0f0f0" stroke="#333" stroke-width="4"/>
+  <!-- Front opening -->
+  <rect x="80" y="140" width="96" height="60" rx="4" fill="#1a1a1a" opacity="0.3"/>
+  <!-- Multi-head extruders on top - narrow and tall -->
+  <rect x="76" y="40" width="16" height="64" rx="2" fill="#666"/>
+  <rect x="104" y="40" width="16" height="64" rx="2" fill="#666"/>
+  <rect x="132" y="40" width="16" height="64" rx="2" fill="#666"/>
+  <rect x="160" y="40" width="16" height="64" rx="2" fill="#666"/>
+  <!-- Left spools (squircles, stacked) -->
+  <rect x="40" y="120" width="24" height="40" rx="6" fill="#f4a300"/>
+  <rect x="46" y="126" width="12" height="28" rx="3" fill="#333"/>
+  <rect x="40" y="164" width="24" height="40" rx="6" fill="#4a9eff"/>
+  <rect x="46" y="170" width="12" height="28" rx="3" fill="#333"/>
+  <!-- Right spools (squircles, stacked) -->
+  <rect x="192" y="120" width="24" height="40" rx="6" fill="#e83e3e"/>
+  <rect x="198" y="126" width="12" height="28" rx="3" fill="#333"/>
+  <rect x="192" y="164" width="24" height="40" rx="6" fill="#4caf50"/>
+  <rect x="198" y="170" width="12" height="28" rx="3" fill="#333"/>
+  <!-- Display screen -->
+  <rect x="164" y="116" width="20" height="12" rx="2" fill="#4a9eff"/>
+</svg>

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/index.html
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<title>Snapmaker U1 Screen</title>
+<link rel="manifest" href="manifest.json">
+<meta name="theme-color" content="#1a1a1a">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="U1 Screen">
+<link rel="icon" type="image/svg+xml" href="icon.svg">
+<link rel="apple-touch-icon" href="icon.svg">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { width: 100%; height: 100%; background: #1a1a1a; overflow: hidden; }
+#container { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; position: relative; }
+#screen { max-width: 100%; max-height: 100%; cursor: crosshair; touch-action: none; }
+#status { position: fixed; top: 8px; right: 8px; color: #888; font: 12px monospace; }
+.touch-ring {
+    position: fixed; pointer-events: none;
+    width: 40px; height: 40px; margin: -20px 0 0 -20px;
+    border: 3px solid rgba(255,100,100,0.8);
+    border-radius: 50%; opacity: 1;
+    animation: touch-fade 0.4s ease-out forwards;
+}
+@keyframes touch-fade {
+    0% { transform: scale(0.5); opacity: 1; }
+    100% { transform: scale(1.5); opacity: 0; }
+}
+</style>
+</head>
+<body>
+<div id="container">
+<img id="screen" src="snapshot">
+</div>
+<div id="status">--</div>
+<script src="auth.js"></script>
+<script>
+// Register service worker for PWA support
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js').catch(() => {});
+}
+
+// Check authentication on load
+(async function() {
+    const authenticated = await initAuth();
+    if (!authenticated) {
+        // Authentication failed and redirected
+        return;
+    }
+})();
+
+const img = document.getElementById('screen');
+const status = document.getElementById('status');
+let loading = false;
+let etag = '';
+let frameCount = 0;
+let lastFpsTime = performance.now();
+
+async function updateImage() {
+    if (loading) return;
+    loading = true;
+    try {
+        const headers = getAuthHeaders();
+        if (etag) headers['If-None-Match'] = etag;
+        const resp = await fetch('snapshot', { headers: headers });
+        if (resp.status === 200) {
+            const newEtag = resp.headers.get('ETag');
+            if (newEtag) etag = newEtag;
+            const blob = await resp.blob();
+            const url = URL.createObjectURL(blob);
+            const oldUrl = img.src;
+            img.src = url;
+            if (oldUrl.startsWith('blob:')) URL.revokeObjectURL(oldUrl);
+            frameCount++;
+        } else if (resp.status === 204) {
+            etag = resp.headers.get('ETag') || etag;
+        }
+    } catch (e) {}
+    loading = false;
+    const now = performance.now();
+    if (now - lastFpsTime >= 1000) {
+        status.textContent = frameCount + ' fps';
+        frameCount = 0;
+        lastFpsTime = now;
+    }
+}
+
+setInterval(updateImage, 100);
+
+let dragging = false;
+let dragMoved = false;
+
+function showTouchRing(clientX, clientY) {
+    const ring = document.createElement('div');
+    ring.className = 'touch-ring';
+    ring.style.left = clientX + 'px';
+    ring.style.top = clientY + 'px';
+    document.body.appendChild(ring);
+    setTimeout(() => ring.remove(), 400);
+}
+
+function getImageCoords(clientX, clientY) {
+    const rect = img.getBoundingClientRect();
+    const scaleX = img.naturalWidth / rect.width;
+    const scaleY = img.naturalHeight / rect.height;
+    const x = Math.round((clientX - rect.left) * scaleX);
+    const y = Math.round((clientY - rect.top) * scaleY);
+    return { x: x, y: y };
+}
+
+function sendTouch(action, x, y) {
+    const headers = getAuthHeaders();
+    fetch('touch?a=' + action + '&x=' + x + '&y=' + y, { method: 'POST', headers: headers }).catch(() => {});
+}
+
+function onDown(clientX, clientY) {
+    dragging = true;
+    dragMoved = false;
+    showTouchRing(clientX, clientY);
+    const coords = getImageCoords(clientX, clientY);
+    sendTouch('down', coords.x, coords.y);
+}
+
+function onMove(clientX, clientY) {
+    if (!dragging) return;
+    dragMoved = true;
+    const coords = getImageCoords(clientX, clientY);
+    sendTouch('move', coords.x, coords.y);
+}
+
+function onUp(clientX, clientY) {
+    if (!dragging) return;
+    dragging = false;
+    const coords = getImageCoords(clientX, clientY);
+    sendTouch('up', coords.x, coords.y);
+}
+
+img.addEventListener('mousedown', function(e) {
+    e.preventDefault();
+    onDown(e.clientX, e.clientY);
+});
+
+document.addEventListener('mousemove', function(e) {
+    onMove(e.clientX, e.clientY);
+});
+
+document.addEventListener('mouseup', function(e) {
+    onUp(e.clientX, e.clientY);
+});
+
+img.addEventListener('touchstart', function(e) {
+    e.preventDefault();
+    if (e.touches.length > 0) {
+        onDown(e.touches[0].clientX, e.touches[0].clientY);
+    }
+});
+
+img.addEventListener('touchmove', function(e) {
+    e.preventDefault();
+    if (e.touches.length > 0) {
+        onMove(e.touches[0].clientX, e.touches[0].clientY);
+    }
+});
+
+img.addEventListener('touchend', function(e) {
+    e.preventDefault();
+    if (e.changedTouches.length > 0) {
+        onUp(e.changedTouches[0].clientX, e.changedTouches[0].clientY);
+    }
+});
+</script>
+</body>
+</html>

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/manifest.json
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Snapmaker U1 Screen",
+  "short_name": "U1 Screen",
+  "description": "Remote screen access for Snapmaker U1 3D printer",
+  "start_url": "/screen/index.html",
+  "display": "standalone",
+  "orientation": "landscape",
+  "background_color": "#1a1a1a",
+  "theme_color": "#1a1a1a",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/sw.js
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/sw.js
@@ -1,0 +1,15 @@
+// Service Worker for Snapmaker U1 Remote Screen PWA
+const CACHE_NAME = 'u1-screen-v1';
+
+self.addEventListener('install', (event) => {
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(clients.claim());
+});
+
+// Basic fetch handler - no caching to avoid stale content
+self.addEventListener('fetch', (event) => {
+    event.respondWith(fetch(event.request));
+});

--- a/overlays/firmware-extended/99-remote-screen/scripts/01-install-pillow.sh
+++ b/overlays/firmware-extended/99-remote-screen/scripts/01-install-pillow.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+set -eo pipefail
+
+echo ">> Installing Pillow for JPEG support"
+"$ROOT_DIR/scripts/helpers/chroot_firmware.sh" "$1" /usr/bin/pip3 install Pillow


### PR DESCRIPTION
Enable users to view and interact with printer's screen through a web browser

**Does not start automatically**

- Implements a simple FB HTTP server exposing PNG and touch events
- Adds authentication and PWA support
- Integrates authentication via moonraker token
- Adds installable web app support
- Extract inline html from web server

Demo
[Screencast_20251228_133808.webm](https://github.com/user-attachments/assets/98c1acd4-6ee2-4d41-bd51-3ce47a74ce58)

User docs: [docs/remote_screen.md](docs/remote_screen.md)

Dev docs (read when reviewing this PR): [overlays/firmware-extended/99-remote-screen/README.md](overlays/firmware-extended/99-remote-screen/README.md)