### PR TITLE
Allow kernel clean step to fail in CI workflows

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -46,6 +46,7 @@ jobs:
       run: ./dev.sh make build PROFILE=extended OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_upgrade.bin
 
     - name: Clear Kernel Git Repo
+      continue-on-error: true
       run: ./dev.sh git -C tmp/kernel/ clean -fdx
 
     - name: Generate Changelog

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -68,6 +68,7 @@ jobs:
       run: ./dev.sh make build PROFILE=extended-devel OUTPUT_FILE=U1_extended_${{ env.GIT_VERSION }}_devel.bin
 
     - name: Clear Kernel Git Repo
+      continue-on-error: true
       run: ./dev.sh git -C tmp/kernel/ clean -fdx
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The kernel git repo may not exist if the build was cached or skipped, causing the clean step to fail unnecessarily.