### PR TITLE
Create `.default` files for modified config files

### DIFF
--- a/docs/extended_config.md
+++ b/docs/extended_config.md
@@ -33,6 +33,17 @@ vi /home/lava/printer_data/config/extended/extended.cfg
 
 After saving, reboot the printer.
 
+## Identifying Customized Settings
+
+When you modify a configuration file, the system automatically creates a `.default` file alongside it containing the original default values. For example, if you customize `extended.cfg`, you'll find `extended.cfg.default` in the same directory.
+
+This makes it easy to:
+- See which files you have customized
+- Compare your changes against the defaults
+- Restore default values if needed
+
+The `.default` files are updated on each boot to reflect the current firmware defaults.
+
 ## Configuration Options
 
 ### [camera]

--- a/overlays/firmware-extended/10-default-config/root/etc/init.d/S49default-config
+++ b/overlays/firmware-extended/10-default-config/root/etc/init.d/S49default-config
@@ -17,7 +17,18 @@ start() {
     fi
 
     mkdir -p /home/lava/printer_data/config
+
+    # Copy default config files without overwriting existing ones
     cp -rn /home/lava/default-config/. /home/lava/printer_data/config/
+
+    # Remove old .default files and create new ones for files that differ
+    find /home/lava/printer_data/config/extended -name "*.default" -exec rm -v {} +
+    pushd /home/lava/default-config/extended > /dev/null
+    diff -rq . /home/lava/printer_data/config/extended \
+        | sed -n 's/^Files \.\/\(.*\) and .* differ$/\1/p' \
+        | xargs -I{} cp -v {} /home/lava/printer_data/config/extended/{}.default
+    popd > /dev/null
+
     chown -R lava:lava /home/lava/printer_data/config
 }
 


### PR DESCRIPTION
Add logic to compare user config files against defaults and create `.default` copies for files that differ. This helps users identify which settings they have customized.