### PR TITLE
Add GitHub Pages build script [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tools/rk2918_tools/afptool
 tools/rk2918_tools/img_maker
 tools/rk2918_tools/img_unpack
 tools/rk2918_tools/mkkrnlimg
+_site/

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+cd docs
+if ! which github-pages > /dev/null; then
+  echo "Installing github-pages gem..."
+  gem install github-pages --version 232 --no-document
+fi
+github-pages build --verbose --destination ../_site


### PR DESCRIPTION
- Add `build_docs.sh` script to build documentation using `github-pages` gem
- Update `.gitignore` to exclude generated `_site` directory