### PR TITLE
Fix upload timeout when `mainsail` is enabled

### DIFF
--- a/overlays/firmware-extended/91-mainsail-install/root/etc/nginx/sites-available/mainsail
+++ b/overlays/firmware-extended/91-mainsail-install/root/etc/nginx/sites-available/mainsail
@@ -57,6 +57,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Scheme $scheme;
+        proxy_read_timeout 600;
     }
 
     # Internal auth check endpoint for use by 3rd party services that want to check if user is authenticated with moonraker


### PR DESCRIPTION
The `mainsail` did not have `proxy_read_timeout 600;` which resulted in timeouts when sending large uploads, as `nginx` defaults were used.