### PR TITLE
Use strict patch matching and fix patch context lines

### DIFF
--- a/overlays/firmware-extended/13-rfid-support/patches/01-add-ntag215-support.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/01-add-ntag215-support.patch
@@ -1,21 +1,19 @@
 diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
 --- rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py	2025-11-06 05:01:19.000000000 +0100
 +++ rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py	2025-12-01 23:11:18.401585041 +0100
-@@ -120,7 +120,15 @@
- 
+@@ -121,6 +121,14 @@
  # RFID card type
  FM175XX_MIFARE_CARD_TYPE_UNKNOWN        = 0xFF  # unknown type
--FM175XX_MIFARE_CARD_TYPE_M1             = 0x08  # M1
-+FM175XX_MIFARE_CARD_TYPE_M1             = 0x08  # M1 (ISO 14443A)
+ FM175XX_MIFARE_CARD_TYPE_M1             = 0x08  # M1
 +FM175XX_MIFARE_CARD_TYPE_NTAG           = 0x00  # NTAG (ISO 14443A, same SAK as Ultralight)
- 
++
 +# About NTAG215 Card
 +FM175XX_NTAG215_TOTAL_PAGES             = 135
 +FM175XX_NTAG215_USER_START_PAGE         = 4
 +FM175XX_NTAG215_USER_END_PAGE           = 129
 +FM175XX_NTAG215_BYTES_PER_PAGE          = 4
 +FM175XX_NTAG215_TOTAL_SIZE              = 540
-+
+ 
  # About M1 Card
  # EEPROM
 @@ -584,8 +592,22 @@

--- a/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-fluidd.patch
+++ b/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-fluidd.patch
@@ -1,6 +1,6 @@
 --- a/etc/nginx/sites-available/fluidd
 +++ b/etc/nginx/sites-available/fluidd
-@@ -109,2 +109,26 @@
+@@ -109,3 +109,27 @@
          proxy_pass http://mjpgstreamer4/;
      }
 +
@@ -28,3 +28,4 @@
 +        proxy_set_header Host $host;
 +    }
  }
+

--- a/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-mainsail.patch
+++ b/overlays/firmware-extended/99-remote-screen/patches/01-add-screen-to-nginx-mainsail.patch
@@ -1,6 +1,6 @@
 --- a/etc/nginx/sites-available/mainsail
 +++ b/etc/nginx/sites-available/mainsail
-@@ -109,2 +109,26 @@
+@@ -109,3 +109,27 @@
          proxy_pass http://mjpgstreamer4/;
      }
 +
@@ -28,3 +28,4 @@
 +        proxy_set_header Host $host;
 +    }
  }
+ 

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -68,7 +68,7 @@ for overlay; do
   if [[ -d "$overlay/patches/" ]]; then
     for patchfile in "$overlay/patches/"*.patch; do
       echo "[+] Applying patch: $(basename "$patchfile")"
-      patch -d "$TEMP_DIR/rootfs" -p1 < "$patchfile"
+      patch -F 0 -d "$TEMP_DIR/rootfs" -p1 < "$patchfile"
     done
   fi
 


### PR DESCRIPTION
- Add -F 0 flag to patch command to require exact context matching
- Fix patch line numbers and context in RFID NTAG215 support patch
- Fix patch line numbers and add trailing newlines in nginx patches