### PR TITLE
Fix HTTP status code for unchanged snapshots in fb-http-server

### DIFF
--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/bin/fb-http-server.py
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/bin/fb-http-server.py
@@ -283,7 +283,7 @@ class ScreenHandler(BaseHTTPRequestHandler):
             client_etag = self.headers.get('If-None-Match', '').strip('"')
             etag, png_data = self.framebuffer.get_snapshot(client_etag)
             if png_data is None:
-                self.send_response(204)
+                self.send_response(304)
                 self.send_header('ETag', f'"{etag}"')
                 self.end_headers()
                 return

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/index.html
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/fb-http-server/index.html
@@ -69,7 +69,7 @@ async function updateImage() {
         if (etag) headers['If-None-Match'] = etag;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 1000);
-        const resp = await fetch('snapshot', { headers: headers, signal: controller.signal });
+        const resp = await fetch(`snapshot?ts=${Date.now()}`, { headers: headers, signal: controller.signal });
         clearTimeout(timeout);
         if (resp.status === 200) {
             const newEtag = resp.headers.get('ETag');
@@ -81,7 +81,7 @@ async function updateImage() {
             if (oldUrl.startsWith('blob:')) URL.revokeObjectURL(oldUrl);
             frameCount++;
             errorCount = 0;
-        } else if (resp.status === 204) {
+        } else if (resp.status === 304) {
             etag = resp.headers.get('ETag') || etag;
             errorCount = 0;
         } else {


### PR DESCRIPTION
Use 304 Not Modified instead of 204 No Content for cached snapshot responses with matching ETags. Add cache-busting timestamp parameter to snapshot requests to prevent browser caching issues.