### PR TITLE
Use `workflow_run` for PR comments

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   push:
     branches:
@@ -12,7 +14,6 @@ jobs:
   custom-firmware-build:
     runs-on: ubuntu-24.04-arm
     permissions:
-      pull-requests: write
       contents: read
     steps:
     - name: Record start time
@@ -125,52 +126,24 @@ jobs:
         name: extended-devel-build
         path: U1_extended_*_devel.bin
 
-    - name: Comment PR with artifact links
-      uses: actions/github-script@v7
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    - name: Save PR info
+      if: github.event_name == 'pull_request'
+      run: |
+        mkdir -p pr-info
+        echo "${{ github.event.pull_request.number }}" > pr-info/number
+        echo "${{ github.event.pull_request.head.sha }}" > pr-info/head_sha
+        echo "${{ github.sha }}" > pr-info/merge_sha
+        echo "${{ github.base_ref }}" > pr-info/base_ref
+        echo "${{ env.GIT_VERSION }}" > pr-info/version
+        echo "${{ env.JOB_START }}" > pr-info/job_start
+        echo "$(date +%s)" > pr-info/job_end
+
+    - name: Upload PR info
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
       with:
-        script: |
-          const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: ${{ github.run_id }}
-          });
-
-          const durationSec = Math.floor(Date.now() / 1000) - ${{ env.JOB_START }};
-          const durationMin = Math.floor(durationSec / 60);
-          const durationRemSec = durationSec % 60;
-          const duration = `${durationMin}m ${durationRemSec}s`;
-
-          const mergeCommitSha = '${{ github.sha }}'.substring(0, 7);
-          const prHeadSha = '${{ github.event.pull_request.head.sha }}'.substring(0, 7);
-          const prHeadFullSha = '${{ github.event.pull_request.head.sha }}';
-
-          const artifactLines = artifacts.artifacts.map(a => {
-            const url = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${a.id}`;
-            const size = (a.size_in_bytes / 1024 / 1024).toFixed(2);
-            return `| [\`${a.name}\`](${url}) | ${size} MB |`;
-          }).join('\n');
-
-          const body = [
-            '## ✅ Build Artifacts',
-            '',
-            `**Version:** \`${{ env.GIT_VERSION }}\``,
-            `**Build commit:** \`${mergeCommitSha}\` (merge of [${prHeadSha}](https://github.com/${{ github.repository }}/commit/${prHeadFullSha}) into \`${{ github.base_ref }}\`)`,
-            `**Build duration:** ${duration}`,
-            '',
-            '| Artifact | Size |',
-            '|----------|------|',
-            artifactLines,
-            '',
-            `[View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`
-          ].join('\n');
-
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            body: body
-          });
+        name: pr-info
+        path: pr-info/
 
     - name: Save Firmwares Cache
       if: steps.cache-firmwares.outputs.cache-hit != 'true'

--- a/.github/workflows/pull_request_comment.yaml
+++ b/.github/workflows/pull_request_comment.yaml
@@ -1,0 +1,78 @@
+name: PR Comment
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+    - name: Download PR info
+      uses: actions/download-artifact@v4
+      with:
+        name: pr-info
+        path: pr-info
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Comment PR with artifact links
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const prNumber = parseInt(fs.readFileSync('pr-info/number', 'utf8').trim());
+          const headSha = fs.readFileSync('pr-info/head_sha', 'utf8').trim();
+          const mergeSha = fs.readFileSync('pr-info/merge_sha', 'utf8').trim();
+          const baseRef = fs.readFileSync('pr-info/base_ref', 'utf8').trim();
+          const version = fs.readFileSync('pr-info/version', 'utf8').trim();
+          const jobStart = parseInt(fs.readFileSync('pr-info/job_start', 'utf8').trim());
+          const jobEnd = parseInt(fs.readFileSync('pr-info/job_end', 'utf8').trim());
+
+          const runId = ${{ github.event.workflow_run.id }};
+          const durationSec = jobEnd - jobStart;
+          const durationMin = Math.floor(durationSec / 60);
+          const durationRemSec = durationSec % 60;
+          const duration = `${durationMin}m ${durationRemSec}s`;
+
+          const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: runId
+          });
+
+          const buildArtifacts = artifacts.artifacts.filter(a => a.name !== 'pr-info');
+          const artifactLines = buildArtifacts.map(a => {
+            const url = `https://github.com/${{ github.repository }}/actions/runs/${runId}/artifacts/${a.id}`;
+            const size = (a.size_in_bytes / 1024 / 1024).toFixed(2);
+            return `| [\`${a.name}\`](${url}) | ${size} MB |`;
+          }).join('\n');
+
+          const prHeadSha = headSha.substring(0, 7);
+          const mergeCommitSha = mergeSha.substring(0, 7);
+
+          const body = [
+            '## ✅ Build Artifacts',
+            '',
+            `**Version:** \`${version}\``,
+            `**Build:** \`${mergeCommitSha}\` (merge of [${prHeadSha}](https://github.com/${{ github.repository }}/commit/${headSha}) into \`${baseRef}\`)`,
+            `**Duration:** ${duration}`,
+            '',
+            '| Artifact | Size |',
+            '|----------|------|',
+            artifactLines,
+            '',
+            `[View workflow run](https://github.com/${{ github.repository }}/actions/runs/${runId})`
+          ].join('\n');
+
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            body: body
+          });


### PR DESCRIPTION
Allows commenting on fork PRs by using workflow_run event which
runs in base repo context with write permissions.
