### PR TITLE
Docs: clarify remote_screen and webcam gui settings in clean installs

### DIFF
--- a/docs/remote_screen.md
+++ b/docs/remote_screen.md
@@ -31,7 +31,7 @@ enabled: true
 
 **Step 2:** Edit `extended/moonraker/04_remote_screen.cfg`, locate the setting below and set it to true:
 ```ini
-[webcam_gui]
+[webcam gui]
 enabled: true
 ```
 


### PR DESCRIPTION
Clarifies the documentation to reflect clean install behavior:

- [remote_screen] already exists in extended/extended.cfg
- [webcam gui] is already present and only needs to be set to true

No functional changes, documentation only.