### PR TITLE
Add SSH key embedding and dev.sh SSH mounting for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tools/rk2918_tools/img_maker
 tools/rk2918_tools/img_unpack
 tools/rk2918_tools/mkkrnlimg
 _site/
+
+# Local SSH keys (personal, not committed)
+overlays/common/04-ssh-authorized-keys/local-keys/*.pub

--- a/dev.sh
+++ b/dev.sh
@@ -4,6 +4,7 @@ set -e
 
 IMAGE_NAME="snapmaker-u1-dev"
 BUILD_CONTEXT=".github/dev"
+SSH_FOLDER="$HOME/.ssh"
 
 if ! docker build -t "$IMAGE_NAME" "$BUILD_CONTEXT"; then
     echo "[!] Docker build failed."
@@ -15,4 +16,4 @@ TTY_FLAG=""
 
 ENV_FLAGS="-e GIT_VERSION"
 
-exec docker run --rm $TTY_FLAG $ENV_FLAGS -w "$PWD" -v "$PWD:$PWD" "$IMAGE_NAME" "$@"
+exec docker run --rm $TTY_FLAG $ENV_FLAGS -w "$PWD" -v "$PWD:$PWD" -v "$SSH_FOLDER:/root/.ssh" "$IMAGE_NAME" "$@"

--- a/overlays/common/04-ssh-authorized-keys/README.md
+++ b/overlays/common/04-ssh-authorized-keys/README.md
@@ -1,0 +1,51 @@
+# SSH Authorized Keys Overlay
+
+This overlay installs SSH public keys to enable passwordless SSH authentication to the printer.
+
+## Usage
+
+1. Copy your SSH public key to the `local-keys/` directory:
+
+```bash
+cp ~/.ssh/id_rsa.pub overlays/common/04-ssh-authorized-keys/local-keys/
+# or
+cp ~/.ssh/id_ed25519.pub overlays/common/04-ssh-authorized-keys/local-keys/
+```
+
+2. Build the firmware normally:
+
+```bash
+./dev.sh make build PROFILE=extended
+```
+
+3. Flash the firmware to your printer
+
+4. SSH without password:
+
+```bash
+ssh lava@<printer-ip>
+# or
+ssh root@<printer-ip>
+```
+
+## How It Works
+
+- The `scripts/install-ssh-key.sh` script runs during the build process
+- It finds all `.pub` files in `local-keys/` and adds them to both:
+  - `/home/lava/.ssh/authorized_keys` (lava user)
+  - `/root/.ssh/authorized_keys` (root user)
+- The `local-keys/` directory is git-ignored, so your personal keys won't be committed
+- If no keys are found, the overlay gracefully skips (no errors)
+
+## Multiple Keys
+
+You can add multiple public keys - all `.pub` files in `local-keys/` will be installed.
+
+## Security Notes
+
+- Only public keys (`.pub` files) should be placed here
+- Never commit your private keys
+- The `.gitignore` ensures `.pub` files in this directory won't be committed
+- Keys are installed with proper permissions (600) and ownership for both users:
+  - `/home/lava/.ssh/` owned by lava (UID 1000)
+  - `/root/.ssh/` owned by root (UID 0)

--- a/overlays/common/04-ssh-authorized-keys/local-keys/.gitkeep
+++ b/overlays/common/04-ssh-authorized-keys/local-keys/.gitkeep
@@ -1,0 +1,3 @@
+# This directory is git-ignored
+# Place your SSH public key(s) here (e.g., id_rsa.pub, id_ed25519.pub)
+# They will be installed to /home/lava/.ssh/authorized_keys during firmware build

--- a/overlays/common/04-ssh-authorized-keys/scripts/install-ssh-key.sh
+++ b/overlays/common/04-ssh-authorized-keys/scripts/install-ssh-key.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+# This script installs SSH authorized keys from a local-only directory
+# The keys directory is git-ignored, so personal keys won't be committed
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OVERLAY_DIR="$(dirname "$SCRIPT_DIR")"
+LOCAL_KEYS_DIR="$OVERLAY_DIR/local-keys"
+ROOTFS_DIR="${1:-}"
+
+if [ -z "$ROOTFS_DIR" ]; then
+    echo "Error: ROOTFS_DIR not provided"
+    exit 1
+fi
+
+# Check if local-keys directory exists with a public key
+if [ ! -d "$LOCAL_KEYS_DIR" ]; then
+    echo "Info: No local-keys directory found, skipping SSH key installation"
+    exit 0
+fi
+
+# Find any .pub files
+PUB_KEYS=$(find "$LOCAL_KEYS_DIR" -maxdepth 1 -name "*.pub" 2>/dev/null || true)
+
+if [ -z "$PUB_KEYS" ]; then
+    echo "Info: No .pub files found in local-keys, skipping SSH key installation"
+    exit 0
+fi
+
+# Function to install keys for a user
+install_keys_for_user() {
+    local ssh_dir="$1"
+    local uid="$2"
+    local gid="$3"
+    local username="$4"
+
+    mkdir -p "$ssh_dir"
+    chmod 700 "$ssh_dir"
+
+    local auth_keys="$ssh_dir/authorized_keys"
+    > "$auth_keys"
+
+    while IFS= read -r pubkey; do
+        if [ -f "$pubkey" ]; then
+            cat "$pubkey" >> "$auth_keys"
+        fi
+    done <<< "$PUB_KEYS"
+
+    chmod 600 "$auth_keys"
+    chown -R "$uid:$gid" "$ssh_dir"
+
+    echo "  ✓ $username"
+}
+
+# Install keys for both lava and root users
+echo "Installing SSH authorized keys for:"
+while IFS= read -r pubkey; do
+    if [ -f "$pubkey" ]; then
+        echo "  - $(basename "$pubkey")"
+    fi
+done <<< "$PUB_KEYS"
+
+echo ""
+echo "Installing for users:"
+
+# Install for lava user (UID 1000, GID 1000)
+install_keys_for_user "$ROOTFS_DIR/home/lava/.ssh" 1000 1000 "lava"
+
+# Install for root user (UID 0, GID 0)
+install_keys_for_user "$ROOTFS_DIR/root/.ssh" 0 0 "root"
+
+echo ""
+echo "SSH authorized keys installed successfully"

--- a/overlays/common/04-ssh-authorized-keys/verify.sh
+++ b/overlays/common/04-ssh-authorized-keys/verify.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Quick verification script to check if SSH keys will be installed
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_KEYS_DIR="$SCRIPT_DIR/local-keys"
+
+echo "SSH Authorized Keys Overlay - Verification"
+echo "==========================================="
+echo
+
+if [ ! -d "$LOCAL_KEYS_DIR" ]; then
+    echo "❌ local-keys directory not found"
+    exit 1
+fi
+
+PUB_KEYS=$(find "$LOCAL_KEYS_DIR" -maxdepth 1 -name "*.pub" 2>/dev/null || true)
+
+if [ -z "$PUB_KEYS" ]; then
+    echo "⚠️  No .pub files found in local-keys/"
+    echo "   SSH keys will NOT be installed in firmware"
+    echo
+    echo "To add your SSH key:"
+    echo "  cp ~/.ssh/id_ed25519.pub $LOCAL_KEYS_DIR/"
+    exit 0
+fi
+
+echo "✓ Found SSH public keys:"
+while IFS= read -r pubkey; do
+    if [ -f "$pubkey" ]; then
+        echo "  - $(basename "$pubkey")"
+        echo "    $(head -c 50 "$pubkey")..."
+    fi
+done <<< "$PUB_KEYS"
+
+echo
+echo "✓ These keys will be installed for:"
+echo "  - lava user: /home/lava/.ssh/authorized_keys"
+echo "  - root user: /root/.ssh/authorized_keys"
+echo
+echo "✓ Git status:"
+git status --short "$LOCAL_KEYS_DIR" | head -3 || echo "  (not in git repository)"

--- a/scripts/dev/upgrade-firmware.sh
+++ b/scripts/dev/upgrade-firmware.sh
@@ -11,6 +11,13 @@ shift 2
 
 set -xe
 
+# this will remove any old host fingerprints for the host being updated
+# and will quickly connect to it to allow the user to confirm the new fingerprint
+# this avoids any ssh prompts during the build and upgrade process (if the user has an ssh key setup)
+# this is inherently unsafe, so should only be used in controlled environments
+ssh-keygen -f /root/.ssh/known_hosts -R $SSH_HOST
+ssh $SSH_HOST exit
+
 rm -rf "firmware/firmware_$PROFILE.bin" "tmp/firmware"
 make build OUTPUT_FILE=firmware/firmware_$PROFILE.bin PROFILE="$PROFILE"
 scp "tmp/firmware/update.img" "$SSH_HOST:/tmp/"


### PR DESCRIPTION
I don't think this is particularly in the correct place, but I wasn't sure what the best approach was here.  While working on the [rfid ui](https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/156) I wanted a way to be able to be a little more hands off when updating firmware using the update-firmware script.  This is the best I was able to come up with.  I assume there is a much better way to do this though (I imagine if we do want to keep the ability bake in ssh keys, it should go in the devel overlays, rather than common).  Definitely would like to get feedback on how we can make the iteration process faster when you need to push new versions to a real machine, and will be happy to update this as needed to match what that process might be.

# Changes
- Add overlays/common/04-ssh-authorized-keys/ overlay for embedding SSH public keys
- Add SSH folder mounting to dev.sh for container development
- Update .gitignore to exclude personal SSH keys
- Update upgrade-firmware.sh to remove the ssh host from known hosts, as it will fail due to the firmware upgrade changing the host sha