### PR TITLE
Fix auto replenish due to overlayed PAUSE/RESUME macro

### DIFF
--- a/overlays/firmware-extended/91-mainsail-install/root/home/lava/default-config/extended/klipper/mainsail_pause_resume.cfg
+++ b/overlays/firmware-extended/91-mainsail-install/root/home/lava/default-config/extended/klipper/mainsail_pause_resume.cfg
@@ -1,9 +1,9 @@
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: _PAUSE_BASE
-gcode: _PAUSE_BASE
+gcode: _PAUSE_BASE {rawparams}
 
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: _RESUME_BASE
-gcode: _RESUME_BASE
+gcode: _RESUME_BASE {rawparams}


### PR DESCRIPTION
The `1.0.0` requires to pass a few params `INNER_PAUSE`. However, due to Mainsail overlay the additional params to `PAUSE` were lost.

Fixes https://github.com/paxx12/SnapmakerU1-Extended-Firmware/issues/153