### PR TITLE
Give parameters to base pause and resume macros

### DIFF
--- a/overlays/firmware-extended/91-mainsail-install/root/home/lava/default-config/extended/klipper/mainsail_pause_resume.cfg
+++ b/overlays/firmware-extended/91-mainsail-install/root/home/lava/default-config/extended/klipper/mainsail_pause_resume.cfg
@@ -1,9 +1,9 @@
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: _PAUSE_BASE
-gcode: _PAUSE_BASE
+gcode: _PAUSE_BASE {rawparams}
 
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: _RESUME_BASE
-gcode: _RESUME_BASE
+gcode: _RESUME_BASE {rawparams}


### PR DESCRIPTION
Add parameters to the base `PAUSE` and `RESUME` macros.

Fixes #153 