### PR TITLE
feat: NFC tag spool_id for Spoolman integration

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,57 @@
+## Summary
+
+Your RFID filament detection implementation is excellent - thank you for the solid NDEF/OpenSpool support!
+
+This PR extends it with optional Spoolman integration by:
+- Extracting the `spool_id` field from OpenSpool JSON payloads
+- Calling an optional `ON_NFC_SPOOL_READ` macro when `spool_id` is present
+
+This allows users with [Spoolman](https://github.com/Donkie/Spoolman) to get automatic spool tracking when loading filament.
+
+## Changes
+
+- **filament_protocol_ndef.py**: Extract optional `spool_id` field from OpenSpool JSON into `info['SPOOL_ID']`
+- **02-add-ndef-protocol.patch**: Call `ON_NFC_SPOOL_READ CHANNEL=<n> SPOOL_ID=<id>` macro when spool_id is present
+- **docs/rfid_support.md**: Add Spoolman Integration section with field reference and example macro
+- **examples/nfc_spoolman.cfg**: Ready-to-use macro file users can copy to their config
+
+## Tag Format
+
+Users add `spool_id` to their existing OpenSpool tags:
+
+```json
+{
+  "protocol": "openspool",
+  "version": "1.0",
+  "brand": "Elegoo",
+  "type": "PLA",
+  "color_hex": "#FF5733",
+  "spool_id": 42
+}
+```
+
+## Backward Compatibility
+
+- Tags without `spool_id` work exactly as before
+- The macro call only fires when `spool_id` is present
+- No configuration required unless user wants Spoolman integration
+
+## Example Macro
+
+Users create `extended/klipper/nfc_spoolman.cfg`:
+
+```cfg
+[gcode_macro ON_NFC_SPOOL_READ]
+gcode:
+    {% set channel = params.CHANNEL|int %}
+    {% set spool_id = params.SPOOL_ID|int %}
+    {% set tool = "T" ~ channel %}
+    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE={spool_id}
+    RESPOND PREFIX="NFC" MSG="Spool {spool_id} assigned to {tool}"
+```
+
+## Testing
+
+- Tested with NTAG215 tags containing OpenSpool JSON with spool_id field
+- Verified backward compatibility with tags without spool_id
+- Verified macro is called with correct channel and spool_id parameters

--- a/overlays/firmware-extended/13-rfid-support/examples/nfc_spoolman.cfg
+++ b/overlays/firmware-extended/13-rfid-support/examples/nfc_spoolman.cfg
@@ -1,0 +1,25 @@
+# NFC Tag -> Spoolman Integration
+# Copy this file to extended/klipper/ to enable automatic spool tracking
+#
+# When an NFC tag with a spool_id field is read, this macro is called
+# with the channel (0-3 = T0-T3) and the spool_id from the tag.
+#
+# Tag format example:
+# {"protocol":"openspool","version":"1.0","type":"PLA","brand":"Elegoo","color_hex":"#FF5733","spool_id":42}
+#
+# Customize this macro to integrate with your Spoolman setup.
+
+[gcode_macro ON_NFC_SPOOL_READ]
+description: Called automatically when NFC tag with spool_id is read
+gcode:
+    {% set channel = params.CHANNEL|int %}
+    {% set spool_id = params.SPOOL_ID|int %}
+    {% set tool = "T" ~ channel %}
+
+    # Update tool's spool assignment (requires tool macros with spool_id variable)
+    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE={spool_id}
+
+    # Optional: Trigger deferred spool save to Moonraker/Spoolman
+    # UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=1
+
+    RESPOND PREFIX="NFC" MSG="Spool {spool_id} assigned to {tool}"

--- a/overlays/firmware-extended/13-rfid-support/patches/02-add-ndef-protocol.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/02-add-ndef-protocol.patch
@@ -7,8 +7,8 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py roo
 +from . import filament_protocol_ndef
  from . import fm175xx_reader
  from . import filament_feed
- 
-@@ -124,6 +125,14 @@
+
+@@ -124,6 +125,22 @@
                      filament_info = info
                  else:
                      logging.error("channel[%d] m1 parse err: %d", channel, error)
@@ -18,6 +18,15 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py roo
 +                if (error == filament_protocol.FILAMENT_PROTO_OK):
 +                    logging.info("channel[%d] NDEF parse ok....", channel)
 +                    filament_info = info
++                    # Call macro if spool_id present in NFC tag (for Spoolman integration)
++                    spool_id = info.get('SPOOL_ID')
++                    if spool_id is not None:
++                        try:
++                            gcode = self.printer.lookup_object('gcode')
++                            gcode.run_script_from_command(
++                                f"ON_NFC_SPOOL_READ CHANNEL={channel} SPOOL_ID={spool_id}")
++                        except Exception as e:
++                            logging.warning(f"Failed to run ON_NFC_SPOOL_READ: {e}")
 +                else:
 +                    logging.error("channel[%d] NDEF parse err....", channel)
          else:

--- a/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -220,6 +220,9 @@ def openspool_parse_payload(payload):
         info['OFFICIAL'] = True
         info['CARD_UID'] = []
 
+        # Extract spool_id for Spoolman integration (optional field)
+        info['SPOOL_ID'] = data.get('spool_id', None)
+
         return filament_protocol.FILAMENT_PROTO_OK, info
 
     except json.JSONDecodeError as e:


### PR DESCRIPTION
## Summary

Thanks for building the extended firmware - it's made the U1 so much more usable.

I added an optional `spool_id` field to the OpenSpool parsing so users with [Spoolman](https://github.com/Donkie/Spoolman) can get automatic spool tracking when they load filament. Tags without spool_id still work exactly as before.

## Changes

- **filament_protocol_ndef.py**: Extract optional `spool_id` field from OpenSpool JSON into `info['SPOOL_ID']`
- **02-add-ndef-protocol.patch**: Call `ON_NFC_SPOOL_READ CHANNEL=<n> SPOOL_ID=<id>` macro when spool_id is present
- **docs/rfid_support.md**: Add Spoolman Integration section with field reference and example macro
- **examples/nfc_spoolman.cfg**: Ready-to-use macro file users can copy to their config

## Tag Format

Users add `spool_id` to their existing OpenSpool tags:

```json
{
  "protocol": "openspool",
  "version": "1.0",
  "brand": "Elegoo",
  "type": "PLA",
  "color_hex": "#FF5733",
  "spool_id": 42
}
```

## Backward Compatibility

- Tags without `spool_id` work exactly as before
- The macro call only fires when `spool_id` is present
- No configuration required unless user wants Spoolman integration

## Example Macro

Users create `extended/klipper/nfc_spoolman.cfg`:

```cfg
[gcode_macro ON_NFC_SPOOL_READ]
gcode:
    {% set channel = params.CHANNEL|int %}
    {% set spool_id = params.SPOOL_ID|int %}
    {% set tool = "T" ~ channel %}
    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE={spool_id}
    RESPOND PREFIX="NFC" MSG="Spool {spool_id} assigned to {tool}"
```

## Testing

- Tested with NTAG215 tags containing OpenSpool JSON with spool_id field
- Verified backward compatibility with tags without spool_id
- Verified macro is called with correct channel and spool_id parameters
