### PR TITLE
Add `web authentication support` for Firmware Config

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -42,6 +42,7 @@ Toggle settings directly from the web interface:
 | Setting | Options | Description |
 |---------|---------|-------------|
 | Frontend | Fluidd, Mainsail | Switch between web interfaces |
+| Require Login (Fluidd only) | Enabled, Disabled | Require login for Moonraker API access |
 | Internal Camera | Paxx12, Snapmaker, Disabled | Select camera service |
 | Camera RTSP Stream | Enabled, Disabled | Enable RTSP streaming |
 | USB Camera | Enabled, Disabled | Enable USB camera support |
@@ -225,6 +226,19 @@ The `.default` files are updated on each boot to reflect the current firmware de
 
 To restore default extended configuration, remove or rename the `extended` folder in Fluidd/Mainsail Configuration tab, then reboot.
 
+### Password Recovery
+
+If you forget your Moonraker admin password when Require Login/Password (Fluidd only) is enabled:
+
+1. Create an empty file named `extended-recover.txt` on a USB drive
+2. Insert the USB drive into the printer
+3. Restart the printer
+4. The extended configuration (including authentication settings) will be backed up and reset
+5. Remove the USB drive
+6. Re-enable Require Login/Password (Fluidd only) in Firmware Config to generate a new admin password
+
+**Important:** The `extended-recover.txt` method resets ALL extended configuration, not just authentication. Your other settings (camera, VPN, etc.) will also be reset to defaults.
+
 ### Recovery from Configuration Issues
 
 If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
@@ -232,7 +246,7 @@ If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
 1. Create an empty file named `extended-recover.txt` on a USB drive
 2. Insert the USB drive into the printer
 3. Restart the printer
-4. The extended configuration will be backed up to `extended.bak` and reset to defaults
+4. The extended configuration will be backed up to `extended.backup.N` and reset to defaults
 5. Remove the USB drive (the recovery file will be automatically deleted)
 
 ## Related Documentation

--- a/overlays/firmware-extended/10-firmware-config/root/etc/nginx/fluidd.d/firmware-config.conf
+++ b/overlays/firmware-extended/10-firmware-config/root/etc/nginx/fluidd.d/firmware-config.conf
@@ -2,12 +2,24 @@ location = /firmware-config {
     return 302 /firmware-config/;
 }
 
+location = /firmware-config/auth_check {
+    internal;
+    proxy_pass http://apiserver/access/user$is_args$args;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_set_header Authorization $http_authorization;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
 location /firmware-config/ {
     alias /usr/local/share/firmware-config/html/;
     index index.html;
 }
 
 location /firmware-config/api/ {
+    auth_request /firmware-config/auth_check;
     proxy_pass http://127.0.0.1:9091/api/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/overlays/firmware-extended/10-firmware-config/root/home/lava/origin_printer_data/config/extended/moonraker/authorization.cfg
+++ b/overlays/firmware-extended/10-firmware-config/root/home/lava/origin_printer_data/config/extended/moonraker/authorization.cfg
@@ -1,0 +1,2 @@
+[authorization]
+force_logins: false

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/10_settings_security.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/10_settings_security.yaml
@@ -1,0 +1,70 @@
+settings:
+  remote_access:
+    label: Remote Access
+    items:
+      moonraker-auth:
+        label: Require Login/Password (Fluidd only)
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /home/lava/printer_data/config/extended/moonraker/authorization.cfg
+          - authorization
+          - force_logins
+          - "false"
+        options:
+          "true":
+            label: Enabled
+            confirm: "Enable authentication? A new admin user with random password will be created. You will need to log in to access Fluidd and Firmware Config. Note: Mainsail does not support this feature."
+            cmd:
+              - bash
+              - -c
+              - |
+                FRONTEND=$(/usr/local/bin/extended-config.py get /home/lava/printer_data/config/extended/extended.cfg web frontend fluidd)
+                if [ "$FRONTEND" = "mainsail" ]; then
+                  echo "ERROR: Authentication requires Fluidd."
+                  echo "Mainsail does not support Moonraker authentication."
+                  echo "Please switch to Fluidd first."
+                  exit 1
+                fi
+                URL="http://127.0.0.1:7125"
+                echo "Deleting existing admin user..."
+                /usr/local/bin/curl -s -X DELETE "$URL/access/user" -H "Content-Type: application/json" -d '{"username": "admin"}' > /dev/null 2>&1
+                echo "Enabling force_logins in Moonraker..."
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/moonraker/authorization.cfg authorization force_logins true &&
+                echo "Restarting Moonraker..."
+                /etc/init.d/S61moonraker restart
+                echo "Waiting for Moonraker to restart..."
+                sleep 10
+                PASSWORD=$(head -c 12 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 16)
+                echo "Creating new admin user..."
+                RESULT=$(/usr/local/bin/curl -s -X POST "$URL/access/user" -H "Content-Type: application/json" -d "{\"username\": \"admin\", \"password\": \"$PASSWORD\"}")
+                if echo "$RESULT" | grep -q '"action": "user_created"'; then
+                  echo ""
+                  echo "============================================"
+                  echo "  IMPORTANT: Save these credentials!"
+                  echo "============================================"
+                  echo "  Username: admin"
+                  echo "  Password: $PASSWORD"
+                  echo "============================================"
+                  echo ""
+                  echo "You can change your password in Fluidd"
+                  echo "under Profile > Change Password."
+                  echo ""
+                  echo "If you forget your password, create a file"
+                  echo "named 'extended-recover.txt' on a USB drive"
+                  echo "and reboot to reset extended configuration."
+                  echo ""
+                else
+                  echo "Warning: Could not create admin user"
+                  echo "$RESULT"
+                fi
+          "false":
+            label: Disabled
+            confirm: "Disable authentication? Anyone on your network will be able to access the printer."
+            cmd:
+              - bash
+              - -vc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/moonraker/authorization.cfg authorization force_logins false &&
+                /etc/init.d/S61moonraker restart
+        default: "false"

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -73,7 +73,7 @@
         .progress-info.visible { display: flex; }
         .notice { display: none; background: var(--warning); color: #000; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 14px; }
         .notice.visible { display: block; }
-        .notice a { color: #000; }
+        .notice a { color: #000; font-weight: 600; }
     </style>
 </head>
 <body>
@@ -82,6 +82,10 @@
 
         <div id="service-notice" class="notice">
             Service unavailable. Ensure <strong>Advanced Mode</strong> is enabled, then restart the printer. <a href="https://github.com/paxx12/SnapmakerU1-Extended-Firmware/blob/main/docs/firmware_config.md" target="_blank">View docs</a>
+        </div>
+
+        <div id="auth-notice" class="notice">
+            Authentication required. Please <a href="/">log in to Fluidd</a> first, then return to this page.
         </div>
 
         <div id="main-content">
@@ -152,6 +156,26 @@
         // Helper function to get element by ID
         const $ = id => document.getElementById(id);
 
+        // Auth functions for Moonraker/Fluidd token
+        function getJWT() {
+            const instanceKey = `user-token-${window.location.host.replace(/[^a-zA-Z0-9]/g, '_')}`;
+            let token = localStorage.getItem(instanceKey);
+            if (token) return token;
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i);
+                if (key && key.startsWith('user-token-')) {
+                    token = localStorage.getItem(key);
+                    if (token) return token;
+                }
+            }
+            return null;
+        }
+
+        function getAuthHeaders() {
+            const jwt = getJWT();
+            return jwt ? { 'Authorization': `Bearer ${jwt}` } : {};
+        }
+
         // Global state
         let selectedFile = null;
         let actionsData = [];
@@ -161,17 +185,26 @@
             $('service-notice').classList.add('visible');
         }
 
-        function hideServiceNotice() {
+        function showAuthNotice() {
+            $('auth-notice').classList.add('visible');
+        }
+
+        function hideNotices() {
             $('service-notice').classList.remove('visible');
+            $('auth-notice').classList.remove('visible');
         }
 
         async function apiFetch(url, options = {}) {
+            options.headers = { ...getAuthHeaders(), ...options.headers };
             const resp = await fetch(url, options);
-            if (resp.status === 502) {
+            hideNotices();
+            if (resp.status === 401) {
+                showAuthNotice();
+                throw new Error('Authentication required');
+            } else if (resp.status === 502) {
                 showServiceNotice();
                 throw new Error('Service unavailable');
             }
-            hideServiceNotice();
             return resp;
         }
 
@@ -441,6 +474,8 @@
             const startTime = performance.now();
 
             xhr.open('POST', 'api/upgrade/upload');
+            const jwt = getJWT();
+            if (jwt) xhr.setRequestHeader('Authorization', `Bearer ${jwt}`);
 
             xhr.upload.onprogress = (e) => {
                 if (e.lengthComputable) {


### PR DESCRIPTION
Add web authentication support for Firmware Config

- Add nginx `auth_request` to validate Moonraker JWT tokens for /api routes
- Add 'Require Login/Password (Fluidd only) ' setting to enable `force_logins` in Moonraker
- Auto-create admin user with random password when authentication enabled
- Add auth notice banner when user is not authenticated
- Update documentation with authentication and password recovery instructions
