### PR TITLE
Draft: Add USB recovery with early boot support

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -241,16 +241,11 @@ If you forget your Moonraker admin password when Require Login/Password (Fluidd 
 
 ### Recovery from Configuration Issues
 
-If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
-
-1. Create an empty file named `extended-recover.txt` on a USB drive
-2. Insert the USB drive into the printer
-3. Restart the printer
-4. The extended configuration will be backed up to `extended.backup.N` and reset to defaults
-5. Remove the USB drive (the recovery file will be automatically deleted)
+If an invalid configuration breaks Moonraker (printer won't connect to WiFi), use the USB recovery option. See [USB Recovery](recovery.md) for detailed instructions.
 
 ## Related Documentation
 
+- [USB Recovery](recovery.md) - USB-based recovery options for troubleshooting
 - [Camera Support](camera_support.md) - Camera features and WebRTC streaming
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files
 - [Data Persistence](data_persistence.md) - Understanding persistent storage

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ Stock firmware with SSH access and minimal debugging features:
 Heavily expanded firmware with extensive features and customization. Includes all basic features plus:
 
 - [Firmware Configuration](firmware_config.md) - Customize firmware behavior via web interface or config file
+- [USB Recovery](recovery.md) - Recovery options via USB drive for troubleshooting
 - [Camera Support](camera_support.md) - Hardware-accelerated camera stack with WebRTC streaming for internal and USB cameras
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -1,0 +1,116 @@
+---
+title: USB Recovery
+---
+
+# USB Recovery
+
+**Available in: Extended firmware**
+
+The extended firmware supports USB-based recovery options that run early in the boot process. These allow you to recover from configuration issues, reset settings, or upgrade firmware without network access.
+
+## How It Works
+
+1. Create a trigger file on a USB drive (FAT32 formatted)
+2. Insert the USB drive into the printer
+3. Power on or reboot the printer
+4. The trigger file is renamed and the action displays on screen with a 10-second countdown
+5. The recovery action executes
+
+The trigger file is renamed immediately when detected (before the countdown begins) to prevent repeated triggering if the action fails or the printer reboots unexpectedly.
+
+## Recovery Options
+
+### Reset Extended Configuration
+
+**Trigger file:** `extended-recover.txt` (empty file)
+
+Resets the extended firmware configuration to defaults:
+- Backs up the current `extended` config directory to `extended.backup.N`
+- Disables debug/data persistence mode
+
+Use this when:
+- Invalid configuration prevents the printer from connecting to WiFi
+- Moonraker fails to start due to configuration errors
+- You cannot login or forgot the password
+- You want to start fresh with default settings
+
+**Steps:**
+1. Create an empty file named `extended-recover.txt` on a USB drive
+2. Insert the USB drive and reboot the printer
+3. Wait for the 10-second countdown and completion message
+4. Remove the USB drive
+
+Your previous configuration is preserved in the backup directory and can be restored manually if needed.
+
+### Apply WiFi Configuration
+
+**Trigger file:** `wpa_supplicant.txt`
+
+Applies WiFi settings from a configuration file:
+- Copies the file to the printer's WiFi configuration
+- Only works if the printer GUI has been started at least once
+
+Use this when:
+- You need to configure WiFi without screen access
+- Setting up a printer with a known network configuration
+
+**Steps:**
+1. Create a `wpa_supplicant.txt` file on a USB drive with your WiFi settings:
+   ```
+   ctrl_interface=/var/run/wpa_supplicant
+   update_config=1
+   country=US
+
+   network={
+       ssid="YourNetworkName"
+       psk="YourPassword"
+   }
+   ```
+2. Insert the USB drive and reboot the printer
+3. Wait for the 10-second countdown and completion message
+4. Remove the USB drive
+
+### Firmware Upgrade
+
+**Trigger file:** `i_want_to_upgrade_my_u1.bin` (firmware file)
+
+Upgrades the printer firmware from a USB drive:
+- Installs the firmware file
+- Logs output to `i_want_to_upgrade_my_u1.log` on the USB drive
+- Renames the file to `i_want_to_upgrade_my_u1-done.bin` after completion
+
+Use this when:
+- The current firmware does not start
+- Network-based upgrade is not available
+- You need to install a specific firmware version
+
+**Steps:**
+1. Download the firmware file and rename it to `i_want_to_upgrade_my_u1.bin`
+2. Copy it to a USB drive
+3. Insert the USB drive and reboot the printer
+4. Wait for the upgrade to complete (this takes several minutes)
+5. The printer will restart automatically
+
+## Safety Features
+
+- **Immediate trigger removal** - Trigger files are deleted as soon as detected, preventing repeated execution on reboot
+- **10-second countdown** - Visual warning before action begins
+- **Screen feedback** - Status displayed on the printer screen throughout
+
+## Troubleshooting
+
+### Recovery not triggering
+- Ensure the USB drive is FAT32 formatted
+- Check the trigger filename is exact (case-sensitive on some systems)
+- Try a different USB drive
+- Ensure the USB drive is inserted before powering on
+
+### Screen shows nothing
+- Recovery runs early in boot, before the normal UI starts
+- If the screen stays black, the recovery may not have triggered
+- Check that the printer detects the USB drive
+
+## Related Documentation
+
+- [Firmware Configuration](firmware_config.md) - Configuration options and web interface
+- [Data Persistence](data_persistence.md) - Understanding debug mode and persistent storage

--- a/overlays/firmware-extended/10-firmware-config/root/etc/init.d/S49extended-config
+++ b/overlays/firmware-extended/10-firmware-config/root/etc/init.d/S49extended-config
@@ -4,19 +4,6 @@ DEFAULT_DIR="/usr/local/share/firmware-config/extended"
 EXTENDED_DIR="/home/lava/printer_data/config/extended"
 
 start() {
-    if [ -f /mnt/udisk/extended-recover.txt ]; then
-        # Move existing extended config to a backup location
-        # find the next available backup number
-        if [ -d "$EXTENDED_DIR" ]; then
-            BACKUP_NUM=1
-            while [ -d "$EXTENDED_DIR.backup.$BACKUP_NUM" ]; do
-                BACKUP_NUM=$((BACKUP_NUM + 1))
-            done
-            mv "$EXTENDED_DIR" "$EXTENDED_DIR.backup.$BACKUP_NUM"
-        fi
-        rm -f /mnt/udisk/extended-recover.txt
-    fi
-
     mkdir -p "$EXTENDED_DIR"
 
     # Delete old files with matching checksums to force cleanup

--- a/overlays/firmware-extended/10-usb-recovery/root/etc/init.d/S00z-usb-recovery
+++ b/overlays/firmware-extended/10-usb-recovery/root/etc/init.d/S00z-usb-recovery
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+USB_DEV="/dev/sda1"
+USB_MOUNT="/tmp/usb-disk"
+OEM_DEV=$(blkid /dev/mmcblk0* | awk -F: '/PARTLABEL="oem"/{print $1}')
+USERDATA_DEV=$(blkid /dev/mmcblk0* | awk -F: '/PARTLABEL="userdata"/{print $1}')
+FB_DEV="/dev/fb0"
+FONT="/home/lava/resource/font/Roboto-Medium.ttf"
+
+# log stdout and stderr to /tmp/usb-recovery.log and stdout
+exec > >(tee /tmp/usb-recovery.log) 2>&1
+
+log() {
+	echo "[usb-recovery] $@"
+}
+
+fb_text() {
+	local bg_color="$1"
+	local fg_color="$2"
+	local header="$3"
+	shift 3
+
+	log "$header: $*"
+
+	[[ -c "$FB_DEV" ]] || return 0
+	[[ -f "$FONT" ]] || return 0
+
+	local vf="drawtext=fontfile=$FONT:text='$header':fontcolor=$fg_color:fontsize=36:x=(w-text_w)/2:y=100"
+	local y=160
+	for arg in "$@"; do
+		if [[ "$arg" == --* ]]; then
+			fg_color="${arg#--}"
+			continue
+		fi
+
+		vf="$vf,drawtext=fontfile=$FONT:text='$arg':fontcolor=$fg_color:fontsize=24:x=(w-text_w)/2:y=$y"
+		y=$((y + 32))
+	done
+
+	ffmpeg -v error -y -f lavfi -i "color=$bg_color:s=480x320" -frames:v 1 \
+		-vf "$vf" -pix_fmt bgra -f rawvideo "$FB_DEV"
+}
+
+fb_text_timer() {
+	local timer="$1"
+	shift
+
+	for i in $(seq $timer -1 1); do
+		fb_text "$@" --red "Starting in $i seconds..."
+		sleep 1
+	done
+	fb_text "$@" --green "Starting now..."
+}
+
+wait_for_usb() {
+	for (( i=0; i<=3; i++ )); do
+		if [[ -b "$USB_DEV" ]]; then
+			log "USB device found after $i seconds"
+			return 0
+		fi
+		sleep 1
+	done
+	return 1
+}
+
+mount_usb() {
+	[[ -b "$USB_DEV" ]] || return 1
+
+	if mountpoint -q "$USB_MOUNT" 2>/dev/null; then
+		return 0
+	fi
+
+	mkdir -p "$USB_MOUNT"
+	mount "$USB_DEV" "$USB_MOUNT" 2>/dev/null
+}
+
+umount_usb() {
+	mountpoint -q "$USB_MOUNT" 2>/dev/null && umount "$USB_MOUNT"
+	rmdir "$USB_MOUNT" 2>/dev/null
+}
+
+check_format_everything() {
+	[[ -f "$USB_MOUNT/disaster-recovery-do-not-use.txt" ]] || return 0
+
+	# This is safety check to prevent people from formatting their device
+	# for not legitimate reasons. This ensures that only users that truly
+	# do need this functionality can use it.
+	# The hash corresponds to a file that contains a warning message.
+	# Users must create this file manually to confirm they understand
+	# the consequences of using this feature. As such this feature
+	# is also intentionally hidden and not documented.
+	#
+	# The file contents using LF line endings.
+	# As such the below cannot be normally created on Windows due to line endings.
+	#
+	# echo "WARNING: This file confirms that I understand that using this recovery option will ERASE ALL DATA on the device, including OEM and USERDATA partitions. I understand that this action is NOT REVERSIBLE."
+	#
+	if ! echo "f2b699e8fdec3856d924c2465774f12b35c170877f1e58d30ade2d82b3113e79  $USB_MOUNT/disaster-recovery-do-not-use.txt" | sha256sum --check --status; then
+		fb_text black red "FORMAT ALL DATA" "The recovery file is corrupted or invalid"
+		sleep 5
+		return 0
+	fi
+
+	mv "$USB_MOUNT/disaster-recovery-do-not-use.txt" "$USB_MOUNT/disaster-recovery-do-not-use-done.txt"
+
+	fb_text_timer 60 black yellow "FORMAT ALL DATA" \
+		"THIS ACTION IS NOT REVERSIBLE" \
+		"THIS WILL ERASE ALL DATA" \
+		"DO NOT POWER OFF"
+
+	if [[ -b "$OEM_DEV" ]]; then
+		fb_text black white "Formatting oem..." --red "DO NOT POWER OFF"
+		umount "$OEM_DEV"
+		mkfs.ext4 -F -L oem -m 0 "$OEM_DEV"
+		sleep 1
+	else
+		log "OEM partition device not found, skipping format"
+	fi
+
+	if [[ -b "$USERDATA_DEV" ]]; then
+		fb_text black white "Formatting userdata..." --red "DO NOT POWER OFF"
+		umount "$USERDATA_DEV"
+		mkfs.ext4 -F -L userdata -m 0 "$USERDATA_DEV"
+		sleep 1
+	else
+		log "Userdata partition device not found, skipping format"
+	fi
+
+	sync
+	fb_text_timer 5 black green "Format Complete" "All data has been erased" "Printer will restart"
+	reboot
+}
+
+check_extended_recover() {
+	[[ -f "$USB_MOUNT/extended-recover.txt" ]] || return 0
+	mv "$USB_MOUNT/extended-recover.txt" "$USB_MOUNT/extended-recover-done.txt"
+
+	fb_text_timer 10 black white "RESET CONFIG" --yellow "Extended config will be backed up" "Debug mode will be disabled"
+
+	local extended_dir="/oem/printer_data/config/extended"
+	if [[ -d "$extended_dir" ]]; then
+		local backup_num=1
+		while [[ -d "$extended_dir.backup.$backup_num" ]]; do
+			backup_num=$((backup_num + 1))
+		done
+		fb_text black white "RESET CONFIG" --yellow "Backing up extended config to $extended_dir.backup.$backup_num" "Please wait"
+		mv "$extended_dir" "$extended_dir.backup.$backup_num"
+		sleep 3
+	fi
+
+	fb_text black white "RESET CONFIG" --yellow "Resetting printer changes to default" "Please wait"
+	rm -f /oem/.printer_data
+	sleep 1
+
+	if [[ -e /oem/.debug ]]; then
+		fb_text black white "RESET CONFIG" --yellow "Disabling Debug..." "Please wait"
+		rm -f /oem/.debug
+		sleep 1
+	fi
+
+	sync
+	fb_text_timer 5 black green "Config Reset" "Extended config backed up" "Debug mode disabled"
+}
+
+check_wpa_supplicant() {
+	[[ -f "$USB_MOUNT/wpa_supplicant.txt" ]] || return 0
+	[[ -d /oem/printer_data/gui ]] || return 0
+
+	fb_text_timer 10 black white "APPLY WIFI CONFIG" --yellow "WiFi settings will be updated"
+
+	fb_text black white "Applying WiFi..." --yellow "Please wait"
+	cp "$USB_MOUNT/wpa_supplicant.txt" /oem/printer_data/gui/wpa_supplicant.conf
+	mv "$USB_MOUNT/wpa_supplicant.txt" "$USB_MOUNT/wpa_supplicant-done.txt"
+	chmod 644 /oem/printer_data/gui/wpa_supplicant.conf
+	chown root:root /oem/printer_data/gui/wpa_supplicant.conf
+	sync
+	sleep 3
+
+	fb_text_timer 5 black green "WiFi Configured" "New settings applied"
+}
+
+check_firmware_upgrade() {
+	[[ -f "$USB_MOUNT/i_want_to_upgrade_my_u1.bin" ]] || return 0
+
+	fb_text_timer 10 black white "FIRMWARE UPGRADE" --yellow "System firmware will be updated"
+
+	fb_text black white "Upgrading Firmware..." --red "Do not power off" "This will take a few minutes"
+	if /home/lava/bin/systemUpgrade.sh upgrade all "$USB_MOUNT/i_want_to_upgrade_my_u1.bin" 2>&1 | tee "$USB_MOUNT/i_want_to_upgrade_my_u1.log"; then
+		fb_text black green "Upgrade Complete" "Firmware has been updated" "System will restart in a few seconds"
+	else
+		fb_text black green "Upgrade Failed" "Firmware has failed to be updated" "System will restart in a few seconds"
+	fi
+	mv "$USB_MOUNT/i_want_to_upgrade_my_u1.bin" "$USB_MOUNT/i_want_to_upgrade_my_u1-done.bin"
+	sync
+	sleep 5
+	reboot
+}
+
+start() {
+	log "Running USB recovery checks..."
+
+	if ! wait_for_usb; then
+		log "No USB device found within timeout, skipping USB recovery"
+		return 0
+	fi
+	if ! mount_usb; then
+		log "Failed to mount USB device, skipping USB recovery"
+		return 1
+	fi
+	trap umount_usb EXIT
+
+	if [[ -c "$FB_DEV" ]]; then
+		echo 0 > /sys/class/graphics/fb0/state
+		echo 0 > /sys/class/graphics/fb0/blank
+	else
+		log "Framebuffer device $FB_DEV not found, skipping framebuffer messages"
+	fi
+
+	[[ ! -f "$FONT" ]] && log "Font file $FONT not found, skipping framebuffer messages"
+
+	log "USB device mounted at $USB_MOUNT"
+	log "OEM partition device: $OEM_DEV"
+	log "Userdata partition device: $USERDATA_DEV"
+
+	check_format_everything
+	check_extended_recover
+	check_wpa_supplicant
+	check_firmware_upgrade
+
+	log "USB recovery checks complete"
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop|restart|reload|force-reload|status)
+		;;
+	*)
+		echo "Usage: $0 {start}" >&2
+		exit 3
+		;;
+esac

--- a/overlays/firmware-extended/10-usb-recovery/root/etc/init.d/S00z-usb-recovery
+++ b/overlays/firmware-extended/10-usb-recovery/root/etc/init.d/S00z-usb-recovery
@@ -109,6 +109,11 @@ check_format_everything() {
 		"DO NOT POWER OFF"
 
 	if [[ -b "$OEM_DEV" ]]; then
+		fb_text black white "Creating backup of oem..." --yellow "Please wait"
+		tar -czf "$USB_MOUNT/oem-backup.tar.gz" -C /oem . 2>/dev/null
+		sync
+		sleep 1
+
 		fb_text black white "Formatting oem..." --red "DO NOT POWER OFF"
 		umount "$OEM_DEV"
 		mkfs.ext4 -F -L oem -m 0 "$OEM_DEV"
@@ -118,6 +123,10 @@ check_format_everything() {
 	fi
 
 	if [[ -b "$USERDATA_DEV" ]]; then
+		fb_text black white "Creating backup of userdata..." --yellow "Please wait"
+		tar -czf "$USB_MOUNT/userdata-backup.tar.gz" -C /userdata . 2>/dev/null
+		sync
+		sleep 1
 		fb_text black white "Formatting userdata..." --red "DO NOT POWER OFF"
 		umount "$USERDATA_DEV"
 		mkfs.ext4 -F -L userdata -m 0 "$USERDATA_DEV"


### PR DESCRIPTION
## Summary

- Add USB-based recovery system that runs early in boot (after mountall, before overlayfs)                                                                     
- Display recovery status on screen using ffmpeg framebuffer rendering                                                                                         
- Support multiple recovery triggers via files on USB drive                                                                                                    
- Move extended config recovery from S49extended-config to early boot          
