### PR TITLE
Add ccache support for faster CI builds

### DIFF
--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:trixie
 
+# The ccache is installed separately
+# as otherwise not all symlinks are created
 RUN apt-get update -y && \
     apt-get install -y \
       build-essential \
@@ -21,8 +23,12 @@ RUN apt-get update -y && \
       golang-go \
       ffmpeg \
       u-boot-tools \
+    && apt-get -y install ccache \
     && git config --global --add safe.directory '*' \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/lib/ccache:${PATH}"
+ENV CCACHE_MAXSIZE="512M"
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update -y && \

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -54,7 +54,16 @@ jobs:
         path: tmp/kernel/
         key: kernels-${{ runner.os }}-${{ runner.arch }}-${{ env.KERNEL_SHA }}
 
-    - name: Set GET_VERSION (for branch)
+    - name: Restore ccache
+      id: cache-ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: tmp/ccache/
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}
+        restore-keys: |
+          ccache-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Set GIT_VERSION (for branch)
       shell: bash
       if: github.event_name == 'push'
       run: |
@@ -163,3 +172,9 @@ jobs:
       with:
         path: tmp/kernel/
         key: kernels-${{ runner.os }}-${{ runner.arch }}-${{ env.KERNEL_SHA }}
+
+    - name: Save ccache
+      uses: actions/cache/save@v4
+      with:
+        path: tmp/ccache/
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include vars.mk
 
+export CCACHE_DIR ?= $(CURDIR)/tmp/ccache
+
 all: tools
 
 # ================= Build Tools =================


### PR DESCRIPTION
Configure ccache in Docker image and cache it in CI workflows using branch-based keys for efficient cache reuse.