### PR TITLE
Improve recovery actions with extended-recover trigger

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,10 @@ Quick steps:
 2. On the printer go to `Settings` > `About` > `Firmware Version` > `Local Update`
 3. Select `.bin` and confirm.
 
+## Troubleshooting
+
+- **Klipper failed to start**: Open Firmware Config at `http://IP/firmware-config`, go to `Recovery` and select `Reset Extended to Defaults`. This will reset all extended settings and reboot the printer.
+
 ## Revert
 
 1. Download `.bin` from the [Snapmaker U1 Wiki](https://wiki.snapmaker.com/en/snapmaker_u1/firmware/release_notes).

--- a/docs/install.md
+++ b/docs/install.md
@@ -56,4 +56,5 @@ If you need to revert to the original Snapmaker firmware:
 - **Update fails**: Ensure the USB drive is formatted as FAT32
 - **File not found**: Make sure the `.bin` file is in the root directory of the USB drive
 - **Printer won't boot**: Try reverting to stock firmware
+- **Klipper failed to start** (Extended only): Open Firmware Config at `http://IP/firmware-config`, go to `Recovery` and select `Reset Extended to Defaults`. This will reset all extended settings and reboot the printer.
 - For additional help, open an issue on the [GitHub repository](https://github.com/paxx12/SnapmakerU1/issues)

--- a/overlays/firmware-extended/10-firmware-config/root/etc/init.d/S49extended-config
+++ b/overlays/firmware-extended/10-firmware-config/root/etc/init.d/S49extended-config
@@ -4,7 +4,7 @@ DEFAULT_DIR="/usr/local/share/firmware-config/extended"
 EXTENDED_DIR="/home/lava/printer_data/config/extended"
 
 start() {
-    if [ -f /mnt/udisk/extended-recover.txt ]; then
+    if [ -f /mnt/udisk/extended-recover.txt ] || [ -f /oem/.extended-recover ]; then
         # Move existing extended config to a backup location
         # find the next available backup number
         if [ -d "$EXTENDED_DIR" ]; then
@@ -14,7 +14,7 @@ start() {
             done
             mv "$EXTENDED_DIR" "$EXTENDED_DIR.backup.$BACKUP_NUM"
         fi
-        rm -f /mnt/udisk/extended-recover.txt
+        rm -f /mnt/udisk/extended-recover.txt /oem/.extended-recover
     fi
 
     mkdir -p "$EXTENDED_DIR"

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
@@ -23,21 +23,35 @@ actions:
   recovery:
     label: Recovery
     items:
-      revert-changes:
-        label: Revert Changes
-        confirm: "Remove printer configuration changes, disable data persistence and reboot?"
+      reset-extended-to-defaults:
+        label: Reset Extended to Defaults
+        confirm: "Reset all extended settings to defaults and reboot?"
         background: true
         cmd:
           - /bin/bash
           - -xc
           - |
             rm -f /oem/.printer_data /oem/.debug &&
+            touch /oem/.extended-recover &&
             /sbin/reboot
-        message: "Reverting changes..."
+        message: "Resetting extended to defaults..."
 
-      recover-to-backup-firmware:
-        label: Recover to Backup Firmware
-        confirm: "Restore previous firmware version, remove printer configuration changes, disable data persistence and reboot?"
+      reset-to-backup-firmware:
+        label: Reset Extended to Backup Firmware
+        confirm: "Reset all extended settings to defaults, switch to backup firmware and reboot?"
+        background: true
+        cmd:
+          - /bin/bash
+          - -xc
+          - |
+            rm -f /oem/.printer_data /oem/.debug &&
+            touch /oem/.extended-recover &&
+            updateEngine --misc=other --reboot
+        message: "Resetting to backup firmware..."
+
+      switch-to-backup-firmware:
+        label: Switch to Backup Firmware
+        confirm: "Switch to backup firmware and reboot?"
         background: true
         cmd:
           - /bin/bash
@@ -45,4 +59,4 @@ actions:
           - |
             rm -f /oem/.printer_data /oem/.debug &&
             updateEngine --misc=other --reboot
-        message: "Recovering to backup firmware..."
+        message: "Switching to backup firmware..."


### PR DESCRIPTION
- Rename "Revert Changes" to "Reset Extended to Defaults"
- Rename "Recover to Backup Firmware" to "Reset to Backup Firmware"

Reset actions now create /oem/.extended-recover to trigger extended config recovery on reboot. S49extended-config handles this file alongside the USB-based recovery.