### PR TITLE
Add snapmaker compatibility fix patch for Klipper v1.1.0

### DIFF
--- a/overlays/firmware-extended/20-klipper-patches/README.md
+++ b/overlays/firmware-extended/20-klipper-patches/README.md
@@ -1,12 +1,24 @@
 # This overlay integrates upstream klipper changes
 
-## Upstream commmits:
+## Upstream commits:
 
-1. [toolhead: Reduce LOOKAHEAD_FLUSH_TIME to 0.150 seconds](https://github.com/Klipper3d/klipper/commit/16fc46fe5)
 1. [resonance_tester: Fix chips selection, add accel_per_hz selection](https://github.com/Klipper3d/klipper/commit/6d1256ddc)
-1. [resonance_tester: Added a new sweeping_vibrations resonance test method](https://github.com/Klipper3d/klipper/commit/16b4b6b30)
+2. [toolhead: Use delta_v2 when calculating centripetal force](https://github.com/Klipper3d/klipper/commit/8291788f4)
+3. [toolhead: Remove arbitrary constants controlling junction deviation](https://github.com/Klipper3d/klipper/commit/847331260)
+4. [resonance_tester: Added a new sweeping_vibrations resonance test method](https://github.com/Klipper3d/klipper/commit/16b4b6b30)
+5. [toolhead: Reduce LOOKAHEAD_FLUSH_TIME to 0.150 seconds](https://github.com/Klipper3d/klipper/commit/16fc46fe5)
+6. snapmaker: Fix self.test references after upstream refactor
+
+## How patches were generated
+
+These patches were generated from the `snapmaker-lava/snapmaker-klipper` repository
+on the `patches-v1.1.0` branch. The commit order and details follow the cherry-pick
+sequence documented in `snapmaker-lava/snapmaker-klipper/SUMMARY.md`.
+
+To regenerate patches, use `git format-patch` on each commit from snapmaker-klipper,
+excluding docs/ directory changes to keep patches minimal and focused on code changes.
 
 ## Formatting of patches
 
-Patches are ordered, they are stripped of config changes, and minimal amount of amendments are done
-to make them as close to upstream as possible.
+Patches are ordered per SUMMARY.md, stripped of docs/ changes, and minimal amount of
+amendments are done to make them as close to upstream as possible.

--- a/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/01_6d1256ddc.patch
+++ b/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/01_6d1256ddc.patch
@@ -1,4 +1,4 @@
-From 6d1256ddcc51cc62ab403fdc29d0b2688116a29e Mon Sep 17 00:00:00 2001
+From 8543899d3c9d84923a748056fa8d17f37ffbdbb7 Mon Sep 17 00:00:00 2001
 From: MRX8024 <57844100+MRX8024@users.noreply.github.com>
 Date: Wed, 13 Nov 2024 02:55:32 +0200
 Subject: [PATCH] resonance_tester: Fix chips selection, add accel_per_hz
@@ -13,16 +13,14 @@ docs: Update TEST_RESONANCES + SHAPER_CALIBRATE with missing parameters and brac
 
 Signed-off-by: Maksim Bolgov <maksim8024@gmail.com>
 ---
- docs/Config_Changes.md            |  4 ++++
- docs/G-Codes.md                   | 18 +++++++++---------
- klippy/extras/resonance_tester.py |  8 +++-----
- 3 files changed, 16 insertions(+), 14 deletions(-)
+ klippy/extras/resonance_tester.py | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
 
 diff --git a/klippy/extras/resonance_tester.py b/klippy/extras/resonance_tester.py
-index fe8717d58545..e9d4e9d92c53 100644
+index 5657adbe2..d6048cddf 100644
 --- a/klippy/extras/resonance_tester.py
 +++ b/klippy/extras/resonance_tester.py
-@@ -65,6 +65,8 @@ def prepare_test(self, gcmd):
+@@ -70,6 +70,8 @@ class VibrationPulseTest:
          self.freq_start = gcmd.get_float("FREQ_START", self.min_freq, minval=1.)
          self.freq_end = gcmd.get_float("FREQ_END", self.max_freq,
                                         minval=self.freq_start, maxval=300.)
@@ -31,7 +29,7 @@ index fe8717d58545..e9d4e9d92c53 100644
          self.hz_per_sec = gcmd.get_float("HZ_PER_SEC", self.hz_per_sec,
                                           above=0., maxval=2.)
      def run_test(self, axis, gcmd):
-@@ -212,11 +214,7 @@ def _run_test(self, gcmd, axes, helper, raw_name_suffix=None,
+@@ -231,11 +233,7 @@ class ResonanceTester:
      def _parse_chips(self, accel_chips):
          parsed_chips = []
          for chip_name in accel_chips.split(','):
@@ -44,3 +42,6 @@ index fe8717d58545..e9d4e9d92c53 100644
              parsed_chips.append(chip)
          return parsed_chips
      def _get_max_calibration_freq(self):
+-- 
+2.47.3
+

--- a/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/02_8291788f4.patch
+++ b/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/02_8291788f4.patch
@@ -1,4 +1,4 @@
-From 8291788f40a677b11d6e0e0283411bc5f96936f7 Mon Sep 17 00:00:00 2001
+From 1001abc34a46326904ad8c5917d2ff10efc08cb3 Mon Sep 17 00:00:00 2001
 From: Kevin O'Connor <kevin@koconnor.net>
 Date: Wed, 27 Nov 2024 22:45:27 -0500
 Subject: [PATCH] toolhead: Use delta_v2 when calculating centripetal force
@@ -16,10 +16,10 @@ Signed-off-by: Kevin O'Connor <kevin@koconnor.net>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/klippy/toolhead.py b/klippy/toolhead.py
-index 4149d53b12f6..948ea974fd70 100644
+index 7c4950469..363959ed0 100644
 --- a/klippy/toolhead.py
 +++ b/klippy/toolhead.py
-@@ -76,10 +76,11 @@ def calc_junction(self, prev_move):
+@@ -104,10 +104,11 @@ class Move:
          sin_theta_d2 = math.sqrt(0.5*(1.0-junction_cos_theta))
          R_jd = sin_theta_d2 / (1. - sin_theta_d2)
          # Approximated circle must contact moves no further away than mid-move
@@ -35,3 +35,6 @@ index 4149d53b12f6..948ea974fd70 100644
          # Apply limits
          self.max_start_v2 = min(
              R_jd * self.junction_deviation * self.accel,
+-- 
+2.47.3
+

--- a/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/03_847331260.patch
+++ b/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/03_847331260.patch
@@ -1,4 +1,4 @@
-From 847331260c84e9de00404aa98f0029184150a897 Mon Sep 17 00:00:00 2001
+From d0ea78a438ad29dd9dac2b9d6511f8d5f8d12a45 Mon Sep 17 00:00:00 2001
 From: Kevin O'Connor <kevin@koconnor.net>
 Date: Wed, 27 Nov 2024 22:34:17 -0500
 Subject: [PATCH] toolhead: Remove arbitrary constants controlling junction
@@ -22,10 +22,10 @@ Signed-off-by: Kevin O'Connor <kevin@koconnor.net>
  1 file changed, 19 insertions(+), 19 deletions(-)
 
 diff --git a/klippy/toolhead.py b/klippy/toolhead.py
-index 948ea974fd70..ed26092f651d 100644
+index 363959ed0..6f21e5a71 100644
 --- a/klippy/toolhead.py
 +++ b/klippy/toolhead.py
-@@ -64,33 +64,33 @@ def calc_junction(self, prev_move):
+@@ -92,33 +92,33 @@ class Move:
              return
          # Allow extruder to calculate its maximum junction
          extruder_v2 = self.toolhead.extruder.calc_junction(prev_move, self)
@@ -78,3 +78,6 @@ index 948ea974fd70..ed26092f651d 100644
      def set_junction(self, start_v2, cruise_v2, end_v2):
          # Determine accel, cruise, and decel portions of the move distance
          half_inv_accel = .5 / self.accel
+-- 
+2.47.3
+

--- a/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/04_16b4b6b30.patch
+++ b/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/04_16b4b6b30.patch
@@ -1,4 +1,4 @@
-From 16b4b6b302ac3ffcd55006cd76265aad4e26ecc8 Mon Sep 17 00:00:00 2001
+From 352a5bac393d53f90e1496ed71330fdc37365a7e Mon Sep 17 00:00:00 2001
 From: Dmitry Butyugin <dmbutyugin@google.com>
 Date: Fri, 6 Dec 2024 11:54:26 +0900
 Subject: [PATCH] resonance_tester: Added a new sweeping_vibrations resonance
@@ -8,19 +8,16 @@ This adds a new resonance test method that can help if a user has some mechanica
 
 Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>
 ---
- docs/Config_Changes.md            |   8 ++
- docs/Config_Reference.md          |  12 ++-
- docs/Measuring_Resonances.md      |  18 ++++
  klippy/extras/resonance_tester.py | 167 ++++++++++++++++++++++--------
  klippy/extras/shaper_calibrate.py |   4 +-
  klippy/toolhead.py                |  13 ++-
- 6 files changed, 171 insertions(+), 51 deletions(-)
+ 3 files changed, 134 insertions(+), 50 deletions(-)
 
 diff --git a/klippy/extras/resonance_tester.py b/klippy/extras/resonance_tester.py
-index e9d4e9d92c53..76e56f536b9a 100644
+index d6048cddf..9b8bbf449 100644
 --- a/klippy/extras/resonance_tester.py
 +++ b/klippy/extras/resonance_tester.py
-@@ -45,42 +45,96 @@ def _parse_axis(gcmd, raw_axis):
+@@ -50,42 +50,96 @@ def _parse_axis(gcmd, raw_axis):
                  "Unable to parse axis direction '%s'" % (raw_axis,))
      return TestAxis(vib_dir=(dir_x, dir_y))
  
@@ -137,7 +134,7 @@ index e9d4e9d92c53..76e56f536b9a 100644
          self.gcode.run_script_from_command(
              "SET_VELOCITY_LIMIT ACCEL=%.3f MINIMUM_CRUISE_RATIO=0"
              % (max_accel,))
-@@ -90,24 +144,46 @@ def run_test(self, axis, gcmd):
+@@ -95,24 +149,46 @@ class VibrationPulseTest:
              gcmd.respond_info("Disabled [input_shaper] for resonance testing")
          else:
              input_shaper = None
@@ -200,7 +197,7 @@ index e9d4e9d92c53..76e56f536b9a 100644
          # Restore the original acceleration values
          self.gcode.run_script_from_command(
              "SET_VELOCITY_LIMIT ACCEL=%.3f MINIMUM_CRUISE_RATIO=%.3f"
-@@ -116,14 +192,13 @@ def run_test(self, axis, gcmd):
+@@ -121,14 +197,13 @@ class VibrationPulseTest:
          if input_shaper is not None:
              input_shaper.enable_shaping()
              gcmd.respond_info("Re-enabled [input_shaper]")
@@ -217,7 +214,7 @@ index e9d4e9d92c53..76e56f536b9a 100644
          self.state = STATE_IDLE
          if not config.get('accel_chip_x', None):
              self.accel_chip_names = [('xy', config.get('accel_chip').strip())]
-@@ -133,6 +208,8 @@ def __init__(self, config):
+@@ -139,6 +214,8 @@ class ResonanceTester:
              if self.accel_chip_names[0][1] == self.accel_chip_names[1][1]:
                  self.accel_chip_names = [('xy', self.accel_chip_names[0][1])]
          self.max_smoothing = config.getfloat('max_smoothing', None, minval=0.05)
@@ -226,7 +223,7 @@ index e9d4e9d92c53..76e56f536b9a 100644
          self.delta_freq = config.getfloat('delta_freq', 10., minval=5.)
          self.log_path = config.get('log_path', None)
          debug = config.getint('debug', 0)
-@@ -156,12 +233,9 @@ def _run_test(self, gcmd, axes, helper, raw_name_suffix=None,
+@@ -175,12 +252,9 @@ class ResonanceTester:
          toolhead = self.printer.lookup_object('toolhead')
          calibration_data = {axis: None for axis in axes}
  
@@ -241,7 +238,7 @@ index e9d4e9d92c53..76e56f536b9a 100644
  
          for point in test_points:
              toolhead.manual_move(point, self.move_speed)
-@@ -186,7 +260,8 @@ def _run_test(self, gcmd, axes, helper, raw_name_suffix=None,
+@@ -205,7 +279,8 @@ class ResonanceTester:
                          raw_values.append((axis, aclient, chip.name))
  
                  # Generate moves
@@ -251,7 +248,7 @@ index e9d4e9d92c53..76e56f536b9a 100644
                  for chip_axis, aclient, chip_name in raw_values:
                      aclient.finish_measurements()
                      if raw_name_suffix is not None:
-@@ -218,7 +293,7 @@ def _parse_chips(self, accel_chips):
+@@ -237,7 +312,7 @@ class ResonanceTester:
              parsed_chips.append(chip)
          return parsed_chips
      def _get_max_calibration_freq(self):
@@ -261,10 +258,10 @@ index e9d4e9d92c53..76e56f536b9a 100644
      def check_homed(self):
          curtime = self.printer.get_reactor().monotonic()
 diff --git a/klippy/extras/shaper_calibrate.py b/klippy/extras/shaper_calibrate.py
-index 6891fefb3bf9..f497171f67c0 100644
+index 2830be6b7..dd69efb20 100644
 --- a/klippy/extras/shaper_calibrate.py
 +++ b/klippy/extras/shaper_calibrate.py
-@@ -48,7 +48,9 @@ def normalize_to_frequencies(self):
+@@ -48,7 +48,9 @@ class CalibrationData:
              # Avoid division by zero errors
              psd /= self.freq_bins + .1
              # Remove low-frequency noise
@@ -276,10 +273,10 @@ index 6891fefb3bf9..f497171f67c0 100644
          return self._psd_map[axis]
  
 diff --git a/klippy/toolhead.py b/klippy/toolhead.py
-index ed26092f651d..256915daabf9 100644
+index 6f21e5a71..6cb130b13 100644
 --- a/klippy/toolhead.py
 +++ b/klippy/toolhead.py
-@@ -47,6 +47,7 @@ def __init__(self, toolhead, start_pos, end_pos, speed):
+@@ -50,6 +50,7 @@ class Move:
          self.delta_v2 = 2.0 * move_d * self.accel
          self.max_smoothed_v2 = 0.
          self.smooth_delta_v2 = 2.0 * move_d * toolhead.max_accel_to_decel
@@ -287,7 +284,7 @@ index ed26092f651d..256915daabf9 100644
      def limit_speed(self, speed, accel):
          speed2 = speed**2
          if speed2 < self.max_cruise_v2:
-@@ -55,6 +56,8 @@ def limit_speed(self, speed, accel):
+@@ -58,6 +59,8 @@ class Move:
          self.accel = min(self.accel, accel)
          self.delta_v2 = 2.0 * self.move_d * self.accel
          self.smooth_delta_v2 = min(self.smooth_delta_v2, self.delta_v2)
@@ -296,7 +293,7 @@ index ed26092f651d..256915daabf9 100644
      def move_error(self, msg="Move out of range"):
          ep = self.end_pos
          m = "%s: %.3f %.3f %.3f [%.3f]" % (msg, ep[0], ep[1], ep[2], ep[3])
-@@ -64,9 +67,9 @@ def calc_junction(self, prev_move):
+@@ -92,9 +95,9 @@ class Move:
              return
          # Allow extruder to calculate its maximum junction
          extruder_v2 = self.toolhead.extruder.calc_junction(prev_move, self)
@@ -309,7 +306,7 @@ index ed26092f651d..256915daabf9 100644
          # Find max velocity using "approximated centripetal velocity"
          axes_r = self.axes_r
          prev_axes_r = prev_move.axes_r
-@@ -462,6 +465,10 @@ def set_position(self, newpos, homing_axes=()):
+@@ -518,6 +521,10 @@ class ToolHead:
          self.commanded_pos[:] = newpos
          self.kin.set_position(newpos, homing_axes)
          self.printer.send_event("toolhead:set_position")
@@ -320,3 +317,6 @@ index ed26092f651d..256915daabf9 100644
      def move(self, newpos, speed, line=None):
          move = Move(self, self.commanded_pos, newpos, speed, line)
          if not move.move_d:
+-- 
+2.47.3
+

--- a/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/05_16fc46fe5.patch
+++ b/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/05_16fc46fe5.patch
@@ -1,4 +1,4 @@
-From 16fc46fe5ff0dbbc5188ee6a7829eee5976c1eb9 Mon Sep 17 00:00:00 2001
+From f92f452dcec89c7ec7909b7e75acfd52e1e32955 Mon Sep 17 00:00:00 2001
 From: Kevin O'Connor <kevin@koconnor.net>
 Date: Tue, 30 Sep 2025 19:32:49 -0400
 Subject: [PATCH] toolhead: Reduce LOOKAHEAD_FLUSH_TIME to 0.150 seconds
@@ -15,10 +15,10 @@ Signed-off-by: Kevin O'Connor <kevin@koconnor.net>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/klippy/toolhead.py b/klippy/toolhead.py
-index 9163e82cc7a8..da297e966be4 100644
+index ef055f0d5..7c4950469 100644
 --- a/klippy/toolhead.py
 +++ b/klippy/toolhead.py
-@@ -113,7 +113,7 @@ def set_junction(self, start_v2, cruise_v2, end_v2):
+@@ -134,7 +134,7 @@ class Move:
          self.cruise_t = cruise_d / cruise_v
          self.decel_t = decel_d / ((end_v + cruise_v) * 0.5)
  
@@ -27,3 +27,6 @@ index 9163e82cc7a8..da297e966be4 100644
  
  # Class to track a list of pending move requests and to facilitate
  # "look-ahead" across moves to reduce acceleration between moves.
+-- 
+2.47.3
+

--- a/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/06_snapmaker_fix.patch
+++ b/overlays/firmware-extended/20-klipper-patches/patches/home/lava/klipper/06_snapmaker_fix.patch
@@ -1,0 +1,49 @@
+From 1c8804c1b0b490765ec91c6cb479c8013fb363f0 Mon Sep 17 00:00:00 2001
+From: paxx12 <245230251+paxx12@users.noreply.github.com>
+Date: Sun, 1 Feb 2026 16:42:02 +0100
+Subject: [PATCH] snapmaker: Fix self.test references after upstream refactor
+
+Update SM_FAST_SHAPER_CALIBRATE to use self.generator.vibration_generator
+instead of removed self.test attribute.
+---
+ klippy/extras/resonance_tester.py | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/klippy/extras/resonance_tester.py b/klippy/extras/resonance_tester.py
+index 9b8bbf449..394994971 100644
+--- a/klippy/extras/resonance_tester.py
++++ b/klippy/extras/resonance_tester.py
+@@ -529,22 +529,22 @@ class ResonanceTester:
+ 
+         # axis X
+         freq_start = input_shaper.shapers[0].params.shaper_freq - abs(self.delta_freq)
+-        if (freq_start < self.test.min_freq):
+-            freq_start = self.test.min_freq
++        if (freq_start < self.generator.vibration_generator.min_freq):
++            freq_start = self.generator.vibration_generator.min_freq
+         freq_end = input_shaper.shapers[0].params.shaper_freq + abs(self.delta_freq)
+-        if (freq_end > self.test.max_freq):
+-            freq_end = self.test.max_freq
++        if (freq_end > self.generator.vibration_generator.max_freq):
++            freq_end = self.generator.vibration_generator.max_freq
+         shaper_type = input_shaper.shapers[0].params.shaper_type
+         command = "SHAPER_CALIBRATE AXIS=x SHAPER_TYPES=%s FREQ_START=%d FREQ_END=%d" % (shaper_type, freq_start, freq_end)
+         gcode.run_script_from_command(command)
+ 
+         # axis Y
+         freq_start = input_shaper.shapers[1].params.shaper_freq - abs(self.delta_freq)
+-        if (freq_start < self.test.min_freq):
+-            freq_start = self.test.min_freq
++        if (freq_start < self.generator.vibration_generator.min_freq):
++            freq_start = self.generator.vibration_generator.min_freq
+         freq_end = input_shaper.shapers[1].params.shaper_freq + abs(self.delta_freq)
+-        if (freq_end > self.test.max_freq):
+-            freq_end = self.test.max_freq
++        if (freq_end > self.generator.vibration_generator.max_freq):
++            freq_end = self.generator.vibration_generator.max_freq
+         shaper_type = input_shaper.shapers[1].params.shaper_type
+         command = "SHAPER_CALIBRATE AXIS=y SHAPER_TYPES=%s FREQ_START=%d FREQ_END=%d" % (shaper_type, freq_start, freq_end)
+         gcode.run_script_from_command(command)
+-- 
+2.47.3
+


### PR DESCRIPTION
Add 06_snapmaker_fix.patch to restore Snapmaker compatibility after
upstream Klipper refactored resonance_tester and toolhead modules.

Also regenerate patches in correct order per snapmaker-klipper SUMMARY.md
and strip docs/ changes from all patches.