### PR TITLE
firmware-config: add klipper TMC driver tweaks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ Heavily expanded firmware with extensive features and customization. Includes al
 - [Firmware Configuration](firmware_config.md) - Customize firmware behavior via web interface or config file
 - [Camera Support](camera_support.md) - Hardware-accelerated camera stack with WebRTC streaming for internal and USB cameras
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
+- [Klipper Tweaks](tweaks.md) - Experimental TMC driver optimizations (firmware-config only)
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
 - [Remote Screen](remote_screen.md) - View and control printer screen remotely via web browser
 - [Monitoring](monitoring.md) - Integration with Prometheus, Home Assistant, DataDog, and other monitoring systems

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -1,0 +1,74 @@
+---
+title: Klipper Tweaks
+---
+
+# Klipper Tweaks
+
+Advanced experimental tweaks for Klipper stepper motor driver configuration. These settings can **only** be configured via the [Firmware Configuration](firmware_config.md) web interface under **Settings → Tweaks**.
+
+> **Warning**: These are experimental features that modify low-level stepper driver parameters. Use with caution and monitor your printer carefully after enabling.
+
+## TMC AutoTune
+
+Applies optimized stepper motor driver settings for TMC2240 drivers.
+
+**What it does:**
+- Optimizes PWM settings for quieter operation
+- Configures StallGuard and CoolStep parameters
+- Adjusts timing parameters for better heat management
+- Fine-tunes driver parameters for improved performance
+
+**Risks:**
+- May cause motors to overheat if cooling is insufficient
+- Could result in reduced torque or skipped steps under heavy load
+- Incorrect settings may affect print quality
+- Changes low-level driver parameters that override defaults
+
+**Recommendation:**
+- Monitor motor temperatures during first use
+- Test with simple prints before production work
+- Revert to disabled if you experience issues
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
+## TMC Reduced Current
+
+Lowers the stepper motor run current from 1.2A to 1.0A for X and Y axes.
+
+**What it does:**
+- Reduces X and Y axis motor current to 1.0A
+- Lowers motor heat generation
+- Results in quieter motor operation
+
+**Risks:**
+- May cause skipped steps under heavy load or fast movements
+- Could result in layer shifts on demanding prints
+- May reduce positioning accuracy under high acceleration
+
+**Recommendation:**
+- Monitor print quality after enabling
+- Watch for layer shifts or positioning issues
+- Disable if you experience motion problems
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
+## How to Configure
+
+1. Open the printer's web interface (Fluidd or Mainsail)
+2. Navigate to **Firmware Config** in the menu
+3. Go to **Settings → Tweaks**
+4. Select the desired option for each tweak
+5. Confirm the warning dialog
+6. Klipper will automatically restart to apply changes
+
+Changes take effect immediately after Klipper restarts (no reboot required).
+
+## Technical Details
+
+These tweaks work by adding or removing configuration files from `/oem/printer_data/config/extended/klipper/`:
+- `tmc_autotune.cfg` - TMC AutoTune parameters
+- `tmc_current.cfg` - Reduced current settings
+
+These files are automatically included by the main printer configuration if present. Manual editing of these files is not recommended as they will be overwritten by the Firmware Configuration interface.

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
@@ -1,0 +1,31 @@
+settings:
+  tweaks:
+    label: Tweaks
+    items:
+      tmc_autotune:
+        label: TMC AutoTune
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/tmc_autotune.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable TMC AutoTune? This optimizes TMC2240 driver settings for quieter operation and better performance. Warning: May cause motors to overheat if cooling is insufficient. Monitor temperatures during first use."
+            cmd:
+              - bash
+              - -xc
+              - |
+                cp /usr/local/share/firmware-config/tweaks/klipper/tmc_autotune.cfg /oem/printer_data/config/extended/klipper/tmc_autotune.cfg &&
+                echo "TMC AutoTune enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/tmc_autotune.cfg &&
+                echo "TMC AutoTune disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
@@ -1,0 +1,31 @@
+settings:
+  tweaks:
+    label: Tweaks
+    items:
+      tmc_reduce_current:
+        label: TMC Reduced Current
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/tmc_current.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable TMC Reduced Current? This lowers X/Y motor current from 1.2A to 1.0A for quieter operation and less heat. Warning: May cause skipped steps or layer shifts under heavy load. Monitor print quality after enabling."
+            cmd:
+              - bash
+              - -xc
+              - |
+                cp -v /usr/local/share/firmware-config/tweaks/klipper/tmc_current.cfg /oem/printer_data/config/extended/klipper/tmc_current.cfg &&
+                echo "TMC Reduced Current enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -vf /oem/printer_data/config/extended/klipper/tmc_current.cfg &&
+                echo "TMC Reduced Current disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_autotune.cfg
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_autotune.cfg
@@ -1,0 +1,52 @@
+# TMC AutoTune Configuration - Driver Parameters
+# Origin: https://github.com/Argolein/SnapmakerU1/blob/main/SnapmakerU1-CustomConfig/01_ArgoConfig.cfg
+# This configuration provides optimized TMC2240 stepper driver settings for better
+# motor performance, noise reduction, and heat management.
+#
+# WARNING: These settings modify low-level stepper driver parameters. Incorrect
+# configuration may cause motor overheating, reduced print quality, or mechanical issues.
+# Use at your own risk and monitor temperatures during initial use.
+
+[tmc2240 stepper_x]
+# ---- tmc autotune ----
+driver_TOFF: 5
+driver_HSTRT: 7
+driver_HEND: 9
+driver_TBL: 1
+driver_TPFD: 2
+driver_PWM_AUTOSCALE: True
+driver_PWM_AUTOGRAD: True
+driver_PWM_OFS: 22
+driver_PWM_GRAD: 13
+driver_PWM_REG: 15
+driver_PWM_LIM: 4
+driver_SEMIN: 2
+driver_SEUP: 3
+driver_SEMAX: 4
+driver_SEDN: 2
+driver_SEIMIN: 1
+driver_MULTISTEP_FILT: True
+driver_IHOLDDELAY: 12
+driver_IRUNDELAY: 0
+
+[tmc2240 stepper_y]
+# ---- tmc autotune ----
+driver_TOFF: 5
+driver_HSTRT: 7
+driver_HEND: 9
+driver_TBL: 1
+driver_TPFD: 2
+driver_PWM_AUTOSCALE: True
+driver_PWM_AUTOGRAD: True
+driver_PWM_OFS: 22
+driver_PWM_GRAD: 13
+driver_PWM_REG: 15
+driver_PWM_LIM: 4
+driver_SEMIN: 2
+driver_SEUP: 3
+driver_SEMAX: 4
+driver_SEDN: 2
+driver_SEIMIN: 1
+driver_MULTISTEP_FILT: True
+driver_IHOLDDELAY: 12
+driver_IRUNDELAY: 0

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_current.cfg
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_current.cfg
@@ -1,0 +1,13 @@
+# TMC Reduced Current Configuration
+# This configuration reduces the stepper motor run current for lower heat generation
+# and quieter operation.
+#
+# WARNING: Reduced current may cause skipped steps under heavy load or fast movements.
+# Monitor print quality and increase current if you experience layer shifts or other
+# motion issues.
+
+[tmc2240 stepper_x]
+run_current: 1.0  # reduced from default 1.2
+
+[tmc2240 stepper_y]
+run_current: 1.0  # reduced from default 1.2


### PR DESCRIPTION
Add experimental TMC2240 driver optimization features configurable via firmware-config web interface:

- TMC AutoTune: Optimizes PWM, StallGuard, CoolStep, and timing parameters for quieter operation and better performance
- TMC Reduced Current: Lowers X/Y motor current from 1.2A to 1.0A for reduced heat and noise

Authors of the parameters:

- @Argolein and `@SuperCow`