### PR TITLE
Add pluggable RFID NDEF format support

### DIFF
--- a/overlays/firmware-extended/13-rfid-support/patches/02-add-ndef-protocol.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/02-add-ndef-protocol.patch
@@ -1,20 +1,27 @@
 diff -uNr rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py rootfs/home/lava/klipper/klippy/extras/filament_detect.py
---- rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py	2025-11-06 05:01:19.000000000 +0100
-+++ rootfs/home/lava/klipper/klippy/extras/filament_detect.py	2025-12-01 23:11:18.373585258 +0100
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_detect.py
 @@ -1,5 +1,6 @@
  import logging, copy, os
  from . import filament_protocol
-+from . import filament_protocol_ndef
++from . import filament_protocol_openspool
  from . import fm175xx_reader
  from . import filament_feed
- 
-@@ -124,6 +125,14 @@
+
+@@ -118,12 +119,20 @@
+         if (fm175xx_reader.FM175XX_CARD_INFO_READ == operation):
+             if (fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_M1 == card_type and  fm175xx_reader.FM175XX_OK == result):
+                 logging.info("channel[%d] m1 card data parsing....", channel)
+-                error, info = filament_protocol.m1_proto_data_parse(card_data)
++                error, info = filament_protocol_openspool.m1_proto_data_parse(card_data)
+                 if (error == filament_protocol.FILAMENT_PROTO_OK):
+                     logging.info("channel[%d] m1 parse ok....", channel)
                      filament_info = info
                  else:
                      logging.error("channel[%d] m1 parse err: %d", channel, error)
 +            elif fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_NTAG == card_type and fm175xx_reader.FM175XX_OK == result:
 +                logging.info("channel[%d] trying NDEF parsing....", channel)
-+                error, info = filament_protocol_ndef.ndef_proto_data_parse(card_data)
++                error, info = filament_protocol_openspool.ndef_proto_data_parse(card_data)
 +                if (error == filament_protocol.FILAMENT_PROTO_OK):
 +                    logging.info("channel[%d] NDEF parse ok....", channel)
 +                    filament_info = info
@@ -22,4 +29,3 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py roo
 +                    logging.error("channel[%d] NDEF parse err....", channel)
          else:
              is_clear = True
- 

--- a/overlays/firmware-extended/13-rfid-support/patches/03-add-mifare-plugin-auth.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/03-add-mifare-plugin-auth.patch
@@ -1,0 +1,83 @@
+diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
+--- rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py
++++ rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
+@@ -1,4 +1,5 @@
+ import logging, time, threading, copy
++from . import filament_protocol_plugin
+ import spidev
+ import hmac, hashlib
+ 
+@@ -923,7 +924,7 @@
+         return ret
+ 
+     # Reader-A: M1, read all data
+-    def __reader_a_m1_read_all_data(self, uid:list, auth_mode:int, auth_key:list, retry_times = 3) -> Fm175xxReturnVal:
++    def __reader_a_m1_read_all_data(self, uid:list, auth_mode:int, auth_key_a:list, auth_key_b:list, retry_times = 3) -> Fm175xxReturnVal:
+         ret = Fm175xxReturnVal()
+         card_data_tmp = [0] * FM175XX_M1_CARD_EEPROM_SIZE
+         area = 0
+@@ -933,7 +934,7 @@
+             # Authentication
+             result = FM175XX_ERR
+             for retry in range(retry_times):
+-                result = self.__reader_a_mifare_auth(auth_mode, sector_no, auth_key[sector_no], uid)
++                result = self.__reader_a_mifare_auth(auth_mode, sector_no, auth_key_a[sector_no], uid)
+                 if (result == FM175XX_OK):
+                     break
+             if (FM175XX_OK != result):
+@@ -957,7 +958,7 @@
+ 
+             area = sector_no * FM175XX_M1_CARD_BYTES_PER_SEC + 3 * FM175XX_M1_CARD_BYTES_PER_BLK
+             card_data_tmp[area : area + FM175XX_M1_CARD_BYTES_PER_BLK] = \
+-                    self._hkdf_key_a[sector_no] + FM175XX_M1_CARD_ACCESS_CODE + self._hkdf_key_b[sector_no]
++                    auth_key_a[sector_no] + FM175XX_M1_CARD_ACCESS_CODE + auth_key_b[sector_no]
+ 
+         ret.err_code = FM175XX_OK
+         ret.out_param = card_data_tmp
+@@ -1030,6 +1031,14 @@
+                             card_op_result = FM175XX_CARD_ACTIVATE_ERR
+                             break
+ 
++                        plugin_keys = []
++                        try:
++                            plugin_keys = filament_protocol_plugin.plugin_m1_auth_all(self.__picc_a.UID[0:4])
++                            if plugin_keys:
++                                logging.info(f"Got {len(plugin_keys)} plugin auth key set(s)")
++                        except Exception as e:
++                            logging.warning(f"Plugin auth error: {e}")
++
+                         try:
+                             ikm = copy.copy(self.__picc_a.UID[0:4])
+                             ikm = bytearray(ikm)
+@@ -1048,11 +1057,26 @@
+                         if (FM175XX_MIFARE_CARD_TYPE_M1 == self.__picc_a.SAK[0]):
+                             card_type = FM175XX_MIFARE_CARD_TYPE_M1
+                             logging.info("M1 card detected (SAK=0x%02X)", self.__picc_a.SAK[0])
+-                            ret = self.__reader_a_m1_read_all_data(self.__picc_a.UID,
+-                                                                   FM175XX_M1_CARD_AUTH_MODE_A,
+-                                                                   self._hkdf_key_a,
+-                                                                   retry_times_3)
+-                            if (FM175XX_OK != ret.err_code):
++                            ret = Fm175xxReturnVal()
++                            ret.err_code = FM175XX_ERR
++
++                            for idx, (key_a, key_b) in enumerate(plugin_keys):
++                                logging.info(f"Trying plugin auth keys #{idx+1}")
++                                ret = self.__reader_a_m1_read_all_data(self.__picc_a.UID,
++                                                                       FM175XX_M1_CARD_AUTH_MODE_A,
++                                                                       key_a,
++                                                                       key_b if key_b else key_a,
++                                                                       retry_times_3)
++                                if FM175XX_OK == ret.err_code:
++                                    break
++                            if FM175XX_OK != ret.err_code:
++                                logging.info("Trying HKDF auth keys")
++                                ret = self.__reader_a_m1_read_all_data(self.__picc_a.UID,
++                                                                       FM175XX_M1_CARD_AUTH_MODE_A,
++                                                                       self._hkdf_key_a,
++                                                                       self._hkdf_key_b,
++                                                                       retry_times_3)
++                            if FM175XX_OK != ret.err_code:
+                                 card_op_result = FM175XX_CARD_READ_ERR
+                             else:
+                                 card_data = ret.out_param[0:FM175XX_M1_CARD_EEPROM_SIZE]

--- a/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_plugin.py
+++ b/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_plugin.py
@@ -1,0 +1,127 @@
+import logging
+import os
+import subprocess
+
+PLUGIN_DIR_NTAG = '/oem/printer_data/config/extended/rfid/ntag'
+PLUGIN_DIR_MIFARE = '/oem/printer_data/config/extended/rfid/mifare'
+PLUGIN_TIMEOUT = 1.0
+
+def run_plugin(plugin_path, args):
+    try:
+        result = subprocess.run(
+            [plugin_path] + args,
+            capture_output=True,
+            timeout=PLUGIN_TIMEOUT,
+            text=True
+        )
+        if result.returncode == 0:
+            return True, result.stdout
+        return False, None
+    except subprocess.TimeoutExpired:
+        logging.warning(f"Plugin '{plugin_path}' timed out after {PLUGIN_TIMEOUT}s")
+        return False, None
+    except Exception as e:
+        logging.warning(f"Plugin '{plugin_path}' failed: {e}")
+        return False, None
+
+def run_plugins_in_dir(plugin_dir, args):
+    if not os.path.isdir(plugin_dir):
+        logging.debug(f"Plugin directory '{plugin_dir}' does not exist")
+        return None
+
+    try:
+        entries = os.listdir(plugin_dir)
+    except OSError as e:
+        logging.warning(f"Failed to list plugin directory: {e}")
+        return None
+
+    for entry in sorted(entries):
+        plugin_path = os.path.join(plugin_dir, entry)
+        if not os.path.isfile(plugin_path):
+            continue
+        if not os.access(plugin_path, os.X_OK):
+            continue
+
+        logging.info(f"Trying plugin '{entry}'")
+        success, output = run_plugin(plugin_path, args)
+        if success and output:
+            logging.info(f"Plugin '{entry}' parsed successfully: {output.strip()}")
+            return output.encode('utf-8')
+
+    logging.debug("No plugin could parse the records")
+    return None
+
+def run_all_plugins_in_dir(plugin_dir, args):
+    results = []
+
+    if not os.path.isdir(plugin_dir):
+        logging.debug(f"Plugin directory '{plugin_dir}' does not exist")
+        return results
+
+    try:
+        entries = os.listdir(plugin_dir)
+    except OSError as e:
+        logging.warning(f"Failed to list plugin directory: {e}")
+        return results
+
+    for entry in sorted(entries):
+        plugin_path = os.path.join(plugin_dir, entry)
+        if not os.path.isfile(plugin_path):
+            continue
+        if not os.access(plugin_path, os.X_OK):
+            continue
+
+        logging.info(f"Trying plugin '{entry}'")
+        success, output = run_plugin(plugin_path, args)
+        if success and output:
+            logging.info(f"Plugin '{entry}' returned auth keys")
+            results.append(output.encode('utf-8'))
+
+    return results
+
+def plugin_ndef_parse(records):
+    args = []
+
+    for record in records:
+        mime_type = record.get('mime_type', '')
+        payload = record.get('payload', b'')
+        args.append(mime_type)
+        args.append(payload.hex())
+
+    return run_plugins_in_dir(PLUGIN_DIR_NTAG, args)
+
+def plugin_m1_parse(data_buf):
+    if data_buf is None or not isinstance(data_buf, list):
+        return None
+
+    hex_payload = bytes(data_buf).hex()
+    args = ['parse', hex_payload]
+
+    return run_plugins_in_dir(PLUGIN_DIR_MIFARE, args)
+
+def plugin_m1_auth_all(card_uid):
+    import json
+
+    if card_uid is None or not isinstance(card_uid, (list, bytes, bytearray)):
+        return []
+
+    if isinstance(card_uid, list):
+        card_uid = bytes(card_uid)
+    hex_uid = card_uid.hex()
+    args = ['auth', hex_uid]
+
+    results = []
+    for output in run_all_plugins_in_dir(PLUGIN_DIR_MIFARE, args):
+        try:
+            auth_data = json.loads(output.decode('utf-8'))
+            if 'key_a' not in auth_data:
+                continue
+            key_a = [[int(k[i:i+2], 16) for i in range(0, 12, 2)] for k in auth_data['key_a']]
+            key_b = None
+            if 'key_b' in auth_data:
+                key_b = [[int(k[i:i+2], 16) for i in range(0, 12, 2)] for k in auth_data['key_b']]
+            results.append((key_a, key_b))
+        except (json.JSONDecodeError, ValueError, KeyError) as e:
+            logging.warning(f"Plugin auth parse error: {e}")
+
+    return results

--- a/overlays/firmware-extended/13-rfid-support/root/usr/local/share/firmware-config/extended/rfid/mifare/creality.py
+++ b/overlays/firmware-extended/13-rfid-support/root/usr/local/share/firmware-config/extended/rfid/mifare/creality.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Creality Mifare Classic 1K filament tag plugin.
+
+Reference implementation for parsing Creality filament tags.
+
+Usage:
+  creality.py auth <card-uid-hex>
+  creality.py parse <hex-payload>
+
+For auth: outputs JSON with key_a/key_b arrays (16 sectors, 6 bytes each hex).
+For parse: outputs OpenSpool JSON on success (exit 0), exits non-zero on failure.
+"""
+
+import json
+import sys
+
+CREALITY_KEY_A = 'FFFFFFFFFFFF'
+CREALITY_KEY_B = 'FFFFFFFFFFFF'
+
+MATERIAL_TYPES = {
+    0x00: 'PLA',
+    0x01: 'ABS',
+    0x02: 'PETG',
+    0x03: 'TPU',
+    0x04: 'PA',
+    0x05: 'PC',
+    0x06: 'ASA',
+    0x07: 'PVA',
+    0x08: 'HIPS',
+    0x09: 'PLA+',
+    0x0A: 'PLA-CF',
+    0x0B: 'PA-CF',
+    0x0C: 'PETG-CF',
+}
+
+def cmd_auth(card_uid_hex):
+    """Return authentication keys for Creality tags."""
+    keys = {
+        'key_a': [CREALITY_KEY_A] * 16,
+        'key_b': [CREALITY_KEY_B] * 16,
+    }
+    print(json.dumps(keys))
+    return 0
+
+def cmd_parse(hex_payload):
+    """Parse Creality tag data and output OpenSpool JSON."""
+    try:
+        data = bytes.fromhex(hex_payload)
+    except ValueError:
+        return 1
+
+    if len(data) < 1024:
+        return 1
+
+    vendor_bytes = data[16:32]
+    vendor = vendor_bytes.rstrip(b'\x00').decode('utf-8', errors='replace').strip()
+    if not vendor or vendor.lower() not in ('creality', 'ender', 'cr'):
+        if not any(v in vendor.lower() for v in ('creality', 'ender', 'cr', 'hyper')):
+            return 1
+
+    material_type = data[64]
+    color_r = data[65]
+    color_g = data[66]
+    color_b = data[67]
+
+    min_temp = data[68] + 150 if data[68] > 0 else 0
+    max_temp = data[69] + 150 if data[69] > 0 else 0
+    bed_temp = data[70]
+
+    weight_lo = data[72]
+    weight_hi = data[73]
+    weight = (weight_hi << 8) | weight_lo
+
+    result = {
+        'protocol': 'openspool',
+        'version': '1.0',
+        'brand': vendor if vendor else 'Creality',
+        'type': MATERIAL_TYPES.get(material_type, 'PLA'),
+        'color_hex': f'{color_r:02X}{color_g:02X}{color_b:02X}',
+    }
+
+    if min_temp > 0:
+        result['min_temp'] = min_temp
+    if max_temp > 0:
+        result['max_temp'] = max_temp
+    if bed_temp > 0:
+        result['bed_temp'] = bed_temp
+    if weight > 0:
+        result['weight'] = weight
+
+    print(json.dumps(result))
+    return 0
+
+def main():
+    if len(sys.argv) < 3:
+        return 1
+
+    cmd = sys.argv[1]
+    arg = sys.argv[2]
+
+    if cmd == 'auth':
+        return cmd_auth(arg)
+    elif cmd == 'parse':
+        return cmd_parse(arg)
+
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/overlays/firmware-extended/13-rfid-support/root/usr/local/share/firmware-config/extended/rfid/ntag/opentag3d.py
+++ b/overlays/firmware-extended/13-rfid-support/root/usr/local/share/firmware-config/extended/rfid/ntag/opentag3d.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+OpenTag3D NDEF plugin for RFID filament tags.
+
+Reference implementation for parsing OpenTag3D binary format.
+https://opentag3d.info/spec
+
+Usage: opentag3d.py <mime-type> <hex-payload> [mime-type2] [hex-payload2] ...
+
+Outputs OpenSpool JSON on success (exit 0), exits non-zero on failure.
+"""
+
+import json
+import struct
+import sys
+
+OPENTAG3D_MIME = 'application/opentag3d'
+OPENTAG3D_CORE_SIZE = 0x70
+
+def read_utf8(data, offset, length):
+    if offset + length > len(data):
+        return ''
+    return data[offset:offset + length].rstrip(b'\x00').decode('utf-8', errors='replace').strip()
+
+def read_u8(data, offset):
+    if offset >= len(data):
+        return 0
+    return data[offset]
+
+def read_u16_be(data, offset):
+    if offset + 2 > len(data):
+        return 0
+    return struct.unpack('>H', data[offset:offset + 2])[0]
+
+def parse_opentag3d(data):
+    """
+    Parse OpenTag3D binary format per https://opentag3d.info/spec
+
+    Core fields (0x00-0x6F):
+      0x00  2  Tag Version (÷0.001)
+      0x02  5  Base Material (UTF-8)
+      0x07  5  Material Modifiers (UTF-8)
+      0x1B 16  Manufacturer (UTF-8)
+      0x2B 32  Color Name (UTF-8)
+      0x4B  4  Color 1 RGBA
+      0x50  4  Color 2 RGBA
+      0x54  4  Color 3 RGBA
+      0x58  4  Color 4 RGBA
+      0x5C  2  Target Diameter (mm ÷ 0.001)
+      0x5E  2  Target Weight (grams)
+      0x60  1  Print Temperature (°C ÷ 5)
+      0x61  1  Bed Temperature (°C ÷ 5)
+
+    Extended fields (0x70+):
+      0xB4  1  Min Print Temp (°C ÷ 5)
+      0xB5  1  Max Print Temp (°C ÷ 5)
+      0xB6  1  Min Bed Temp (°C ÷ 5)
+      0xB7  1  Max Bed Temp (°C ÷ 5)
+    """
+    if len(data) < OPENTAG3D_CORE_SIZE:
+        return None
+
+    version = read_u16_be(data, 0x00)
+    if version == 0:
+        return None
+
+    base_material = read_utf8(data, 0x02, 5)
+    if not base_material:
+        return None
+
+    material_modifiers = read_utf8(data, 0x07, 5)
+    manufacturer = read_utf8(data, 0x1B, 16)
+
+    colors = []
+    for offset in (0x4B, 0x50, 0x54, 0x58):
+        r = read_u8(data, offset)
+        g = read_u8(data, offset + 1)
+        b = read_u8(data, offset + 2)
+        a = read_u8(data, offset + 3)
+        if r > 0 or g > 0 or b > 0:
+            colors.append((r, g, b, a))
+
+    diameter_raw = read_u16_be(data, 0x5C)
+    weight = read_u16_be(data, 0x5E)
+    print_temp_raw = read_u8(data, 0x60)
+    bed_temp_raw = read_u8(data, 0x61)
+
+    if not colors:
+        colors = [(255, 255, 255, 255)]
+
+    r, g, b, a = colors[0]
+    result = {
+        'protocol': 'openspool',
+        'version': '1.0',
+        'type': base_material.upper(),
+        'brand': manufacturer if manufacturer else 'Generic',
+        'color_hex': f'{r:02X}{g:02X}{b:02X}',
+    }
+
+    if material_modifiers:
+        result['subtype'] = material_modifiers
+
+    if a < 255:
+        result['alpha'] = a
+
+    if len(colors) > 1:
+        result['additional_color_hexes'] = [
+            f'{c[0]:02X}{c[1]:02X}{c[2]:02X}' for c in colors[1:]
+        ]
+
+    if diameter_raw > 0:
+        result['diameter'] = diameter_raw / 1000.0
+
+    if weight > 0:
+        result['weight'] = weight
+
+    if print_temp_raw > 0:
+        print_temp = print_temp_raw * 5
+        result['min_temp'] = print_temp
+        result['max_temp'] = print_temp
+
+    if bed_temp_raw > 0:
+        bed_temp = bed_temp_raw * 5
+        result['bed_min_temp'] = bed_temp
+        result['bed_max_temp'] = bed_temp
+
+    if len(data) > 0xB7:
+        min_print = read_u8(data, 0xB4)
+        max_print = read_u8(data, 0xB5)
+        min_bed = read_u8(data, 0xB6)
+        max_bed = read_u8(data, 0xB7)
+
+        if min_print > 0:
+            result['min_temp'] = min_print * 5
+        if max_print > 0:
+            result['max_temp'] = max_print * 5
+        if min_bed > 0:
+            result['bed_min_temp'] = min_bed * 5
+        if max_bed > 0:
+            result['bed_max_temp'] = max_bed * 5
+
+    return result
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit(1)
+
+    args = sys.argv[1:]
+    for i in range(0, len(args) - 1, 2):
+        mime_type = args[i]
+        hex_payload = args[i + 1]
+
+        if mime_type != OPENTAG3D_MIME:
+            continue
+
+        try:
+            payload = bytes.fromhex(hex_payload)
+        except ValueError:
+            continue
+
+        result = parse_opentag3d(payload)
+        if result:
+            print(json.dumps(result))
+            sys.exit(0)
+
+    sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/overlays/firmware-extended/13-rfid-support/test/app/cli.py
+++ b/overlays/firmware-extended/13-rfid-support/test/app/cli.py
@@ -5,7 +5,7 @@ import logging
 import json
 
 from . import filament_protocol
-from . import filament_protocol_ndef
+from . import filament_protocol_openspool
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -22,12 +22,12 @@ if __name__ == '__main__':
             try:
                 json.loads(data.decode('utf-8'))
                 logging.info("Detected JSON file, parsing as OpenSpool payload")
-                error_code, info = filament_protocol_ndef.openspool_parse_payload(data)
+                error_code, info = filament_protocol_openspool.openspool_parse_payload(data)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 logging.info("JSON parsing failed, treating as binary NDEF data")
-                error_code, info = filament_protocol_ndef.ndef_proto_data_parse(data)
+                error_code, info = filament_protocol_openspool.ndef_proto_data_parse(data)
         else:
-            error_code, info = filament_protocol_ndef.ndef_proto_data_parse(data)
+            error_code, info = filament_protocol_openspool.ndef_proto_data_parse(data)
 
         if error_code == filament_protocol.FILAMENT_PROTO_OK:
             print(info)


### PR DESCRIPTION
## Summary

- Add plugin system for handling unknown NDEF MIME types in RFID tags
- Executables in `/oem/printer_data/config/extended/rfid/ntag/` are called for unknown formats
- Plugins receive `<mime> <hex> [mime2] [hex2]...` args and output OpenSpool JSON
- 1 second timeout per plugin, exit 0 = success
- Include OpenTag3D reference implementation in `/usr/local/share/firmware-config/extended/rfid/ntag/`

## New Files

- `filament_protocol_plugin.py` - Plugin runner with directory scanning and timeout handling
- `opentag3d.py` - Reference plugin for OpenTag3D binary format (copy to `/oem/...` to enable)