### PR TITLE
chroot_firmware: use trap for cleanup

### DIFF
--- a/scripts/helpers/chroot_firmware.sh
+++ b/scripts/helpers/chroot_firmware.sh
@@ -15,8 +15,9 @@ if [[ -e ./etc/resolv.conf ]]; then
   exit 1
 fi
 
+set -euo pipefail
+
 echo "nameserver 1.1.1.1" > ./etc/resolv.conf
+trap 'rm -f ./etc/resolv.conf' EXIT
 
 chroot "$ROOTFS" "$@"
-
-rm -f ./etc/resolv.conf


### PR DESCRIPTION
Use `set -euo pipefail` and a trap to ensure `resolv.conf` is cleaned up even if chroot fails.