### PR TITLE
Add Multi-tool support in Fluidd/Mainsail by emulating AFC

### DIFF
--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -62,7 +62,8 @@ Example payload:
   "min_temp": 190,
   "max_temp": 220,
   "bed_min_temp": 50,
-  "bed_max_temp": 60
+  "bed_max_temp": 60,
+  "spool_id": 1
 }
 ```
 
@@ -102,6 +103,7 @@ Using the non-standard OpenSpool `subtype` field it is possible to specify a mat
 - `additional_color_hexes` - Additional colors for multicolor spools (up to 4)
 - `weight` - Spool weight in grams
 - `diameter` - Filament diameter in mm (e.g., 1.75)
+- `spool_id` - Spoolman spool ID for integration with spool management systems
 
 ### Snapmaker Orca Naming Convention
 

--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -104,6 +104,7 @@ Using the non-standard OpenSpool `subtype` field it is possible to specify a mat
 - `weight` - Spool weight in grams
 - `diameter` - Filament diameter in mm (e.g., 1.75)
 - `spool_id` - Spoolman spool ID for integration with spool management systems
+- `lot_nr` - Lot number identifier for filament batch tracking (8-16 character hex string). Both tags from the same spool should be programmed with the same lot_nr value
 
 ### Snapmaker Orca Naming Convention
 

--- a/overlays/firmware-extended/13-rfid-support/patches/03-add-spool-id-support.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/03-add-spool-id-support.patch
@@ -1,0 +1,47 @@
+--- a/home/lava/klipper/klippy/extras/print_task_config.py
++++ b/home/lava/klipper/klippy/extras/print_task_config.py
+@@ -24,6 +24,7 @@
+     'filament_edit': [True] * PHYSICAL_EXTRUDER_NUM,
+     'filament_exist': [False] * PHYSICAL_EXTRUDER_NUM,
+     'filament_soft': [False] * PHYSICAL_EXTRUDER_NUM,
++    'filament_spool_id': [0] * PHYSICAL_EXTRUDER_NUM,
+     'extruder_map_table': [i for i in range(PHYSICAL_EXTRUDER_NUM)] + [0] * (LOGICAL_EXTRUDER_NUM - PHYSICAL_EXTRUDER_NUM),
+     'extruders_used' : [False] * PHYSICAL_EXTRUDER_NUM,
+     'extruders_replenished': [i for i in range(PHYSICAL_EXTRUDER_NUM)],
+@@ -181,6 +183,7 @@
+         self.print_task_config['filament_color_rgba'][channel] = filament_color_rgba
+         self.print_task_config['filament_official'][channel] = info['OFFICIAL']
+         self.print_task_config['filament_sku'][channel] = info['SKU']
++        self.print_task_config['filament_spool_id'][channel] = info.get('SPOOL_ID', 0)
+         if self.filament_param_obj is not None:
+             self.print_task_config['filament_soft'][channel] = \
+                 self.filament_param_obj.get_is_soft(info['VENDOR'], info['MAIN_TYPE'], info['SUB_TYPE'])
+@@ -343,6 +347,8 @@
+         filament_sub_type = gcmd.get('FILAMENT_SUBTYPE', None)
+         filament_color = gcmd.get_int('FILAMENT_COLOR', None)
+         filament_color_rgba = gcmd.get('FILAMENT_COLOR_RGBA', None)
++        filament_spool_id = gcmd.get_int('FILAMENT_SPOOL_ID', None)
++        force = gcmd.get_int('FORCE', 0)
+         logging.info("[print_task_config] PRINT_FILAMENT_CONFIG %s",
+                         gcmd.get_raw_command_parameters())
+
+@@ -359,8 +365,8 @@
+         if config_extruder < 0 or config_extruder >= PHYSICAL_EXTRUDER_NUM:
+             raise gcmd.error("[print_task_config] extruder{} is out of range[0, {}]".format(config_extruder, PHYSICAL_EXTRUDER_NUM -1))
+ 
+-        if self.print_task_config['filament_official'][config_extruder]:
+-            raise gcmd.error("[print_task_config] filament_config, official filament, not configurable!")
++        if self.print_task_config['filament_official'][config_extruder] and not force:
++            raise gcmd.error("[print_task_config] filament_config, official filament, use FORCE=1 to overwrite")
+ 
+         if filament_type is not None:
+             self.print_task_config['filament_vendor'][config_extruder] = filament_vendor
+@@ -403,6 +411,8 @@
+ 
+         self.print_task_config['filament_official'][config_extruder] = False
+         self.print_task_config['filament_sku'][config_extruder] = 0
++        if filament_spool_id is not None:
++            self.print_task_config['filament_spool_id'][config_extruder] = filament_spool_id
+ 
+         if not self.printer.update_snapmaker_config_file(self.config_path,
+                 self.print_task_config, DEFAULT_PRINT_TASK_CONFIG):

--- a/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -224,6 +224,11 @@ def openspool_parse_payload(payload, card_uid=[]):
         info['OFFICIAL'] = True
         info['CARD_UID'] = card_uid
 
+        try:
+            info['SPOOL_ID'] = int(data.get('spool_id', 0))
+        except (ValueError, TypeError):
+            info['SPOOL_ID'] = 0
+
         return filament_protocol.FILAMENT_PROTO_OK, info
 
     except json.JSONDecodeError as e:

--- a/overlays/firmware-extended/13-rfid-support/test/openspool-pla-basic.json
+++ b/overlays/firmware-extended/13-rfid-support/test/openspool-pla-basic.json
@@ -7,5 +7,6 @@
   "min_temp": 190,
   "max_temp": 220,
   "bed_min_temp": 50,
-  "bed_max_temp": 60
+  "bed_max_temp": 60,
+  "spool_id": 1
 }

--- a/overlays/firmware-extended/23-klipper-afc-module/patches/03-add-spoolman-proxy-to-moonraker.patch
+++ b/overlays/firmware-extended/23-klipper-afc-module/patches/03-add-spoolman-proxy-to-moonraker.patch
@@ -1,0 +1,58 @@
+#
+# Author: @unlucio
+# Source: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/163
+#
+--- rootfs.original/home/lava//moonraker/moonraker/components/spoolman.py	2025-12-30 05:40:53
++++ rootfs/home/lava//moonraker/moonraker/components/spoolman.py	2026-01-15 02:15:08
+@@ -5,7 +5,7 @@
+ # This file may be distributed under the terms of the GNU GPLv3 license.
+ 
+ from __future__ import annotations
+-import asyncio
++import asyncio, json
+ import logging
+ import re
+ import contextlib
+@@ -69,8 +69,42 @@
+         self._register_endpoints()
+         self.server.register_remote_method(
+             "spoolman_set_active_spool", self.set_active_spool
++        )
++
++
++        self.server.register_remote_method(
++            "spoolman_proxy", self.rpc_spoolman_proxy
++        )
++
++    async def rpc_spoolman_proxy(self, cb_endpoint, request_method, path, query=None, body=None):
++        query_str = f"?{query}" if query else ""
++        full_url = f"{self.spoolman_url}{path}{query_str}"
++
++        logging.info(f"Spoolman proxy: {full_url}")
++
++        response = await self.http_client.request(
++            method=request_method,
++            url=full_url,
++            body=body
+         )
+ 
++        if response.has_error():
++            payload = None
++            error = {"status_code": response.status_code, "message": str(response.error)}
++            logging.info(f"Spoolman proxy: error {json.dumps(error)}")
++        else:
++            payload = response.json()
++            logging.info(f"Spoolman proxy: payload {json.dumps(payload)}")
++            error = None
++
++        await self.klippy_apis._send_klippy_request(
++            cb_endpoint,
++            {"payload": payload, "error": error},
++            default=None
++        )
++
++        return None
++
+     def _get_spoolman_urls(self, config: ConfigHelper) -> None:
+         orig_url = config.get('server')
+         url_match = re.match(r"(?i:(?P<scheme>https?)://)?(?P<host>.+)", orig_url)

--- a/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC.py
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC.py
@@ -1,0 +1,90 @@
+class AFCLaneState:
+    EMPTY = "empty"
+    LOADING = "loading"
+    LOADED = "loaded"
+    UNLOADING = "unloading"
+    TOOL_LOADED = "tool_loaded"
+    ERROR = "error"
+
+class AFCState:
+    IDLE = "idle"
+    LOADING = "loading"
+    UNLOADING = "unloading"
+    TOOL_CHANGE = "tool_change"
+    ERROR = "error"
+
+class AFC:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        config.get("enabled", "True")
+        self.gcode = self.printer.lookup_object("gcode")
+        self.reactor = self.printer.get_reactor()
+
+        self.current_state = AFCState.IDLE
+        self.current = None
+        self.current_loading = None
+        self.next_lane_load = None
+        self.error_state = False
+        self.bypass_state = False
+        self.quiet_mode = False
+        self.current_toolchange = 0
+        self.number_of_toolchanges = 0
+        self.spoolman = True
+        self.td1_present = False
+        self.lane_data_enabled = False
+        self.position_saved = False
+        self.message = ""
+        self.led_state = ""
+
+        self.units = {}
+        self.lanes = {}
+
+        self.printer.register_event_handler("klippy:connect", self._handle_connect)
+
+    def _handle_connect(self):
+        for name, obj in self.printer.lookup_objects("AFC_unit"):
+            unit_name = name.replace("AFC_", "", 1)
+            self.units[unit_name] = obj
+
+        for name, obj in self.printer.lookup_objects("AFC_lane"):
+            lane_name = name.split(None, 1)[1] if " " in name else name
+            self.lanes[lane_name] = obj
+
+    def _get_current_lane(self):
+        try:
+            toolhead = self.printer.lookup_object('toolhead')
+            current_extruder = toolhead.extruder.name
+            for lane_name, lane in self.lanes.items():
+                if lane.extruder == current_extruder:
+                    return lane_name
+        except:
+            pass
+        return None
+
+    def get_status(self, eventtime=None):
+        str = {}
+        str['current_load'] = self.current
+        str['current_lane'] = self._get_current_lane()
+        str['next_lane'] = self.next_lane_load
+        str['current_state'] = self.current_state
+        str["current_toolchange"] = self.current_toolchange if self.current_toolchange >= 0 else 0
+        str["number_of_toolchanges"] = self.number_of_toolchanges
+        str['spoolman'] = self.spoolman
+        str["td1_present"] = self.td1_present
+        str["lane_data_enabled"] = self.lane_data_enabled
+        str['error_state'] = self.error_state
+        str["bypass_state"] = bool(self.bypass_state)
+        str["quiet_mode"] = bool(self.quiet_mode)
+        str["position_saved"] = self.position_saved
+
+        str['units'] = list(self.units.keys())
+        str['lanes'] = list(self.lanes.keys())
+        str["extruders"] = []
+        str["hubs"] = []
+        str["buffers"] = []
+        str["message"] = self.message
+        str["led_state"] = self.led_state
+        return str
+
+def load_config(config):
+    return AFC(config)

--- a/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -1,0 +1,132 @@
+class AFCLaneState:
+    EMPTY = "empty"
+    LOADING = "loading"
+    LOADED = "loaded"
+    UNLOADING = "unloading"
+    TOOL_LOADED = "tool_loaded"
+    ERROR = "error"
+
+class AFCLane:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.name = config.get_name().replace("AFC_lane ", "", 1)
+
+        self.unit = config.get("unit", "")
+        self.channel = config.getint("channel", 0)
+        self.extruder = config.get("extruder", None)
+        self.toolhead_sensor = config.get("toolhead_sensor", None)
+
+        self.status = AFCLaneState.EMPTY
+        self.tool_loaded = False
+
+        self.connect_done = False
+        self.print_task_config = None
+        self.sensor = None
+
+        self.weight = -1 # -1 means weight is not supported/configured
+        self.filament_density = 1.24
+        self.filament_diameter = 1.75
+        self.empty_spool_weight = 0
+
+        self.printer.register_event_handler("klippy:connect", self._handle_connect)
+
+    def _handle_connect(self):
+        self.connect_done = True
+        try:
+            self.print_task_config = self.printer.lookup_object("print_task_config")
+        except:
+            self.print_task_config = None
+
+        # Lookup toolhead sensor if configured
+        if self.toolhead_sensor:
+            try:
+                self.sensor = self.printer.lookup_object(self.toolhead_sensor)
+            except:
+                self.sensor = None
+
+    def _get_filament_info(self):
+        """Get filament info from print_task_config based on channel index"""
+        if not self.print_task_config:
+            return {}
+
+        try:
+            status = self.print_task_config.get_status()
+            filament_exist = status.get('filament_exist', [False])[self.channel] if self.channel < len(status.get('filament_exist', [])) else False
+
+            # Return empty dict if no filament exists
+            if not filament_exist:
+                return {}
+
+            config = {
+                'map': f"T{self.channel}",
+                'material': 'NONE',
+                'color': 'FFFFFFFF',
+                'vendor': 'NONE',
+                'sub_type': 'NONE',
+                'runout_lane': '?',
+                'spool_id': None,
+                'filament_exist': True
+            }
+
+            config['material'] = dict(enumerate(status.get('filament_type', []))).get(self.channel, 'NONE')
+            config['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.channel, 'FFFFFFFF')
+            config['vendor'] = dict(enumerate(status.get('filament_vendor', []))).get(self.channel, 'NONE')
+            config['sub_type'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.channel, 'NONE')
+            config['spool_id'] = dict(enumerate(status.get('filament_spool_id', []))).get(self.channel, None)
+
+            tool_to_extruder = dict(enumerate(status.get('extruder_map_table', [])))
+            for tool_idx, extruder_name in tool_to_extruder.items():
+                if extruder_name == self.channel:
+                    config['map'] = f"T{tool_idx}"
+                    break
+
+            return config
+        except:
+            return {}
+
+    def _tool_loaded(self, eventtime=None):
+        if not self.sensor:
+            return False
+        try:
+            sensor_status = self.sensor.get_status(eventtime)
+            return sensor_status.get('filament_detected', False)
+        except:
+            return False
+
+    def get_status(self, eventtime=None):
+        response = {}
+        if not self.connect_done:
+            return response
+
+        filament_info = self._get_filament_info()
+        filament_exist = filament_info.get('filament_exist', False)
+
+        response['name'] = self.name
+        response['unit'] = self.unit
+        response['channel'] = self.channel
+        response['extruder'] = self.extruder
+        response['map'] = filament_info.get('map', f"T{self.channel}")
+        response['load'] = filament_exist
+        response['prep'] = True
+        response['tool_loaded'] = self._tool_loaded(eventtime)
+        response['loaded_to_hub'] = False
+        response['material'] = filament_info.get('material', 'NONE')
+        response['filament_vendor'] = filament_info.get('vendor', 'NONE')
+        response['filament_sub_type'] = filament_info.get('sub_type', 'NONE')
+        response['density'] = self.filament_density
+        response['diameter'] = self.filament_diameter
+        response['empty_spool_weight'] = self.empty_spool_weight
+        response['spool_id'] = filament_info.get('spool_id', None)
+        response['color'] = f"#{filament_info.get('color', 'FFFFFFFF')}"
+        response['weight'] = self.weight
+        response['runout_lane'] = filament_info.get('runout_lane', '?')
+        response['filament_exist'] = filament_exist
+        response['filament_status'] = 'unknown'
+        response['filament_status_led'] = 'gray'
+        response['status'] = self.status
+
+        return response
+
+def load_config_prefix(config):
+    return AFCLane(config)

--- a/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -1,3 +1,5 @@
+SPOOLMAN_PROXY_ENDPOINT_BASE = "klippy/spoolman_proxy"
+
 class AFCLaneState:
     EMPTY = "empty"
     LOADING = "loading"
@@ -10,6 +12,7 @@ class AFCLane:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
+        self.webhooks = self.printer.lookup_object('webhooks')
         self.name = config.get_name().replace("AFC_lane ", "", 1)
 
         self.unit = config.get("unit", "")
@@ -23,13 +26,30 @@ class AFCLane:
         self.connect_done = False
         self.print_task_config = None
         self.sensor = None
+        self.pending_refresh = False
 
         self.weight = -1 # -1 means weight is not supported/configured
         self.filament_density = 1.24
         self.filament_diameter = 1.75
         self.empty_spool_weight = 0
+        self.pending_spool_id = None
 
         self.printer.register_event_handler("klippy:connect", self._handle_connect)
+
+        self.gcode.register_mux_command(
+            "SET_SPOOL_ID", "LANE", self.name,
+            self.cmd_SET_SPOOL_ID,
+            desc=self.cmd_SET_SPOOL_ID_help)
+
+        self.gcode.register_mux_command(
+            "REFRESH_SPOOL", "LANE", self.name,
+            self.cmd_REFRESH_SPOOL,
+            desc=self.cmd_REFRESH_SPOOL_help)
+
+        self.find_by_spool_id_callback = f"{SPOOLMAN_PROXY_ENDPOINT_BASE}/find_by_spool_id/{config.get_name()}"
+        self.webhooks.register_endpoint(
+            self.find_by_spool_id_callback,
+            self._handle_find_by_spool_id_callback)
 
     def _handle_connect(self):
         self.connect_done = True
@@ -44,6 +64,102 @@ class AFCLane:
                 self.sensor = self.printer.lookup_object(self.toolhead_sensor)
             except:
                 self.sensor = None
+
+    cmd_SET_SPOOL_ID_help = "Set spool ID and fetch filament data from Spoolman"
+    def cmd_SET_SPOOL_ID(self, gcmd):
+        """Set spool ID and fetch filament info from spoolman"""
+        spool_id = gcmd.get_int('SPOOL_ID')
+
+        gcmd.respond_info(f"Fetching spool {spool_id} data for lane {self.name}...")
+
+        self.pending_refresh = False
+        self.pending_spool_id = spool_id
+
+        try:
+            self.webhooks.call_remote_method(
+                "spoolman_proxy",
+                cb_endpoint=self.find_by_spool_id_callback,
+                request_method="GET",
+                path=f"/v1/spool/{spool_id}"
+            )
+        except Exception as e:
+            gcmd.respond_error(f"Failed to query spoolman: {e}")
+
+    def _handle_find_by_spool_id_callback(self, web_request):
+        try:
+            payload = web_request.get_dict('payload', {})
+            error = web_request.get('error', None)
+
+            if error:
+                self.gcode.respond_error(f"Spoolman error: {error}")
+                return
+
+            self._apply_spool_data_from_webhook(payload)
+        except Exception as e:
+            raise web_request.error(f"Failed to process spoolman response: {e}")
+
+    cmd_REFRESH_SPOOL_help = "Refresh current spool data from Spoolman"
+    def cmd_REFRESH_SPOOL(self, gcmd):
+        filament_info = self._get_filament_info()
+        spool_id = filament_info.get('spool_id', None)
+
+        if not spool_id:
+            gcmd.respond_error(f"No spool configured for lane {self.name}")
+            return
+
+        self.pending_refresh = True
+
+        try:
+            self.webhooks.call_remote_method(
+                "spoolman_proxy",
+                cb_endpoint=self.find_by_spool_id_callback,
+                request_method="GET",
+                path=f"/v1/spool/{spool_id}"
+            )
+        except Exception as e:
+            gcmd.respond_error(f"Failed to query spoolman: {e}")
+
+    def _apply_spool_data_from_webhook(self, response):
+        """Apply spool data from spoolman response via webhook"""
+        if not response:
+            self.gcode.respond_error("Empty response from spoolman")
+            return
+
+        filament = response.get('filament', {})
+        material = filament.get('material', 'PLA')
+        vendor = filament.get('vendor', {}).get('name', 'Generic')
+        color_hex = filament.get('color_hex', 'FFFFFFFF')
+        sub_type = filament.get('extra', {}).get('sub_type', 'Basic')
+
+        spool_id = response.get('id', 0)
+        self.weight = response.get('remaining_weight', -1)
+        self.filament_diameter = filament.get('diameter', 1.75)
+        self.filament_density = filament.get('density', 1.24)
+        self.empty_spool_weight = filament.get('spool_weight', 0)
+        self.pending_spool_id = spool_id
+
+        if self.pending_refresh:
+            self.pending_refresh = False
+            return
+
+        material = material.replace('"', '\\"').replace("'", "\\'")
+        vendor = vendor.replace('"', '\\"').replace("'", "\\'")
+        sub_type = sub_type.replace('"', '\\"').replace("'", "\\'")
+
+        gcode_cmd = (
+            f'SET_PRINT_FILAMENT_CONFIG '
+            f'CONFIG_EXTRUDER={self.channel} '
+            f'FILAMENT_TYPE="{material}" '
+            f'VENDOR="{vendor}" '
+            f'FILAMENT_SUBTYPE="{sub_type}" '
+            f'FILAMENT_COLOR_RGBA="{color_hex}" '
+            f'FILAMENT_SPOOL_ID={spool_id} '
+            'FORCE=1'
+        )
+
+        self.gcode.respond_info(f"Applying spool {spool_id} to lane {self.name}: {vendor} {material} ({sub_type}) #{color_hex}")
+        self.gcode.run_script(f"M118 {gcode_cmd}")
+        self.gcode.run_script(gcode_cmd)
 
     def _get_filament_info(self):
         """Get filament info from print_task_config based on channel index"""
@@ -85,6 +201,29 @@ class AFCLane:
         except:
             return {}
 
+    def _update(self, spool_id):
+        """Update lane state when spool_id changes"""
+        if spool_id == self.pending_spool_id:
+            return
+
+        # Weight tracking is supported only by spoolman
+        if spool_id == 0:
+            self.weight = -1
+            return
+
+        try:
+            self.pending_refresh = True
+            self.webhooks.call_remote_method(
+                "spoolman_proxy",
+                cb_endpoint=self.find_by_spool_id_callback,
+                request_method="GET",
+                path=f"/v1/spool/{spool_id}"
+            )
+        except Exception:
+            self.pending_refresh = False
+        finally:
+            self.pending_spool_id = spool_id
+
     def _tool_loaded(self, eventtime=None):
         if not self.sensor:
             return False
@@ -101,6 +240,8 @@ class AFCLane:
 
         filament_info = self._get_filament_info()
         filament_exist = filament_info.get('filament_exist', False)
+
+        self._update(filament_info.get('spool_id', 0))
 
         response['name'] = self.name
         response['unit'] = self.unit

--- a/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC_unit.py
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/home/lava/klipper/klippy/extras/AFC_unit.py
@@ -1,0 +1,28 @@
+class AFCUnit:
+    def __init__(self, config):
+        # Prevent klipper error
+        config.get("enabled", True)
+
+        self.printer = config.get_printer()
+        self.fullname = config.get_name()
+        self.name = self.fullname.split()[-1]
+
+        self.lanes = {}
+        self.printer.register_event_handler("klippy:connect", self._handle_connect)
+
+    def _handle_connect(self):
+        for name, obj in self.printer.lookup_objects("AFC_lane"):
+            if hasattr(obj, 'unit') and obj.unit == self.name:
+                lane_name = name.split()[-1] if " " in name else name.replace("AFC_lane_", "", 1)
+                self.lanes[lane_name] = obj
+
+    def get_status(self, eventtime=None):
+        response = {}
+        response['lanes'] = [lane.name for lane in self.lanes.values()]
+        response["extruders"] = []
+        response["hubs"] = []
+        response["buffers"] = []
+        return response
+
+def load_config_prefix(config):
+    return AFCUnit(config)

--- a/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/extended/moonraker/spoolman.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/extended/moonraker/spoolman.cfg
@@ -1,0 +1,7 @@
+# Spoolman Integration
+# Uncomment and configure the following section to enable Spoolman support.
+# See: https://moonraker.readthedocs.io/en/latest/configuration/#spoolman
+
+#[spoolman]
+#server: http://localhost:7912
+#sync_rate: 5

--- a/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/functions/23_settings_tweaks_afc.yaml
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/functions/23_settings_tweaks_afc.yaml
@@ -1,0 +1,31 @@
+settings:
+  tweaks:
+    label: Tweaks
+    items:
+      afc:
+        label: AFC Stub via Fluidd/Mainsail
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/afc.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable AFC Stub component? This adds support for multi-lane filament management with CHANGE_TOOL and LANE_UNLOAD macros."
+            cmd:
+              - bash
+              - -xc
+              - |
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/afc.cfg /oem/printer_data/config/extended/klipper/afc.cfg &&
+                echo "AFC enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -vf /oem/printer_data/config/extended/klipper/afc.cfg &&
+                echo "AFC disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -1,0 +1,105 @@
+# AFC (Automated Filament Changer) Configuration and Macros
+
+[AFC]
+enabled: True
+
+[AFC_unit U1]
+enabled: True
+
+[AFC_lane E0]
+unit: U1
+channel: 0
+extruder: extruder
+toolhead_sensor: filament_motion_sensor e0_filament
+
+[AFC_lane E1]
+unit: U1
+channel: 1
+extruder: extruder1
+toolhead_sensor: filament_motion_sensor e1_filament
+
+[AFC_lane E2]
+unit: U1
+channel: 2
+extruder: extruder2
+toolhead_sensor: filament_motion_sensor e2_filament
+
+[AFC_lane E3]
+unit: U1
+channel: 3
+extruder: extruder3
+toolhead_sensor: filament_motion_sensor e3_filament
+
+[gcode_macro SET_COLOR]
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set color = params.COLOR|default('FFFFFFFF') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER='{channel}' FILAMENT_COLOR_RGBA='{color}' SAVE='1'
+
+[gcode_macro SET_MATERIAL]
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set material = params.MATERIAL|default('PLA') %}
+    {% set subtype = params.SUBTYPE|default('') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    {% set vendor = printer.print_task_config.filament_vendor[channel|int]|default('NONE') %}
+    {% if vendor == 'NONE' %}{% set vendor = 'Generic' %}{% endif %}
+    SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER='{channel}' FILAMENT_TYPE='{material}' FILAMENT_SUBTYPE='{subtype}' VENDOR='{vendor}' SAVE='1'
+
+[gcode_macro SET_WEIGHT]
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set weight = params.WEIGHT|default('1000') %}
+    RESPOND MSG="Weight {weight}g set for {lane}"
+
+[gcode_macro SET_VENDOR]
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set vendor = params.VENDOR|default('NONE') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER='{channel}' VENDOR='{vendor}' SAVE='1'
+
+[gcode_macro SET_MAP]
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set new_map = params.MAP|default('T0') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    {% set current_map = printer['AFC_lane ' + lane].map %}
+    {% set new_logical = new_map[1:] if new_map.startswith('T') else '0' %}
+    {% set current_logical = current_map[1:] if current_map.startswith('T') else '0' %}
+    
+    # Get the extruder_map_table to find what's currently mapped to new_logical
+    {% set map_table = printer.print_task_config.extruder_map_table %}
+    {% set old_channel = map_table[new_logical|int] if new_logical|int < map_table|length else channel %}
+    
+    # Swap: set new_logical -> channel and current_logical -> old_channel
+    SET_PRINT_EXTRUDER_MAP CONFIG_EXTRUDER='{new_logical}' MAP_EXTRUDER='{channel}'
+    SET_PRINT_EXTRUDER_MAP CONFIG_EXTRUDER='{current_logical}' MAP_EXTRUDER='{old_channel}'
+
+[gcode_macro CHANGE_TOOL]
+description: Change tool/lane with automatic load/unload
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    M118 Changing to {lane} (channel {channel})...
+    AUTO_FEEDING EXTRUDER={channel} LOAD=1
+    M118 Tool change to {lane} complete
+
+[gcode_macro LANE_UNLOAD]
+description: Unload filament for specified lane
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    M118 Unloading {lane} (channel {channel})...
+    AUTO_FEEDING EXTRUDER={channel} UNLOAD=1
+    M118 Unload {lane} complete
+
+[gcode_macro TOOL_UNLOAD]
+description: Unload filament for specified tool
+gcode:
+    {% set lane = params.LANE|default('E0') %}
+    {% set channel = printer['AFC_lane ' + lane].channel %}
+    M118 Unloading {lane} (channel {channel})...
+    AUTO_FEEDING EXTRUDER={channel} UNLOAD=1
+    M118 Unload {lane} complete

--- a/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -103,3 +103,35 @@ gcode:
     M118 Unloading {lane} (channel {channel})...
     AUTO_FEEDING EXTRUDER={channel} UNLOAD=1
     M118 Unload {lane} complete
+
+[gcode_macro _AFC_SPOOLMAN_UPDATE]
+variable_last_spool_id: -1
+gcode:
+    {% set current_lane = printer.AFC.current_lane %}
+    {% set spool_id = 0 %}
+    {% if current_lane %}
+        {% set lane = printer['AFC_lane ' ~ current_lane] %}
+        {% set spool_id = lane.spool_id|default(0) %}
+    {% endif %}
+
+    {% if spool_id != last_spool_id %}
+        {action_call_remote_method("spoolman_set_active_spool", spool_id=spool_id)}
+        SET_GCODE_VARIABLE MACRO=_AFC_SPOOLMAN_UPDATE VARIABLE=last_spool_id VALUE={spool_id}
+    {% endif %}
+
+[delayed_gcode _AFC_SPOOLMAN_MONITOR]
+initial_duration: 1.0
+gcode:
+    _AFC_SPOOLMAN_UPDATE
+    UPDATE_DELAYED_GCODE ID=_AFC_SPOOLMAN_MONITOR DURATION=1.0
+
+[delayed_gcode _AFC_REFRESH_ALL_SPOOLS]
+initial_duration: 15.0
+gcode:
+    {% for lane_name in ['E0', 'E1', 'E2', 'E3'] %}
+        {% set lane = printer['AFC_lane ' ~ lane_name] %}
+        {% if lane.spool_id %}
+            REFRESH_SPOOL LANE={lane_name}
+        {% endif %}
+    {% endfor %}
+    UPDATE_DELAYED_GCODE ID=_AFC_REFRESH_ALL_SPOOLS DURATION=15.0

--- a/overlays/firmware-extended/23-klipper-afc-module/test/printer.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-module/test/printer.cfg
@@ -1,0 +1,14 @@
+[mcu]
+serial: /tmp/klipper_host_mcu
+
+[printer]
+kinematics: none
+max_velocity: 1
+max_accel: 1
+max_logical_extruder_num: 32
+max_physical_extruder_num: 4
+
+[print_task_config]
+
+# Load AFC configuration and macros
+[include ../root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg]

--- a/overlays/firmware-extended/23-klipper-afc-module/test/restart.sh
+++ b/overlays/firmware-extended/23-klipper-afc-module/test/restart.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ROOT_DIR="$(dirname "$(realpath "$0")")/.."
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <host>"
+  exit 1
+fi
+
+set -xeo pipefail
+
+scp -r "$ROOT_DIR/root/." "$1":/
+ssh -t "$1" /etc/init.d/S60klipper restart

--- a/overlays/firmware-extended/23-klipper-afc-module/test/run.sh
+++ b/overlays/firmware-extended/23-klipper-afc-module/test/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ROOT_DIR="$(dirname "$(realpath "$0")")/.."
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <host>"
+  exit 1
+fi
+
+set -xeo pipefail
+
+scp -r "$ROOT_DIR/root/." "$1":/
+scp "$ROOT_DIR/../../../scripts/dev/run-klipper.sh" "$ROOT_DIR/test/printer.cfg" "$1":/tmp/
+ssh -t "$1" /tmp/run-klipper.sh /tmp/printer.cfg

--- a/overlays/firmware-extended/23-klipper-afc-module/test/spoolman.sh
+++ b/overlays/firmware-extended/23-klipper-afc-module/test/spoolman.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <url> <method> <path> [key=value ...]"
+    echo ""
+    echo "Arguments:"
+    echo "  url     Spoolman base URL (e.g., http://localhost:7912)"
+    echo "  method  HTTP method: GET, POST, PATCH"
+    echo "  path    API path (e.g., spool/1)"
+    echo "  args    Key=value pairs (query params for GET, JSON for POST/PATCH)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 http://localhost:7912 GET spool/1"
+    echo "  $0 http://localhost:7912 POST spool filament_id=1 remaining_weight=800"
+    echo "  $0 http://localhost:7912 PATCH spool/1 remaining_weight=750"
+    exit 1
+}
+
+build_query() {
+    local query=""
+    for arg in "$@"; do
+        key="${arg%%=*}"
+        value="${arg#*=}"
+        value=$(printf '%s' "$value" | jq -sRr @uri)
+        if [[ -z "$query" ]]; then
+            query="?${key}=${value}"
+        else
+            query="${query}&${key}=${value}"
+        fi
+    done
+    echo "$query"
+}
+
+build_json() {
+    local json="{}"
+    for arg in "$@"; do
+        key="${arg%%=*}"
+        value="${arg#*=}"
+        if [[ "$value" =~ ^[0-9]+$ ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" == "true" || "$value" == "false" ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" == "null" ]]; then
+            json=$(echo "$json" | jq --arg k "$key" '. + {($k): null}')
+        else
+            json=$(echo "$json" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}')
+        fi
+    done
+    echo "$json"
+}
+
+if [[ $# -lt 3 ]]; then
+    usage
+fi
+
+url="$1"
+method="$2"
+path="$3"
+shift 3
+
+endpoint="${url}/api/v1/${path}"
+
+case "${method^^}" in
+    GET)
+        query=$(build_query "$@")
+        echo ">> GET ${endpoint}${query}"
+        curl -s -X GET "${endpoint}${query}" | jq
+        ;;
+    POST|PATCH)
+        json=$(build_json "$@")
+        echo ">> ${method^^} $endpoint"
+        curl -s -X "${method^^}" -H "Content-Type: application/json" -d "$json" "$endpoint" | jq
+        ;;
+    *)
+        echo "Error: Unsupported method '$method'. Use GET, POST, or PATCH."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Make U1 to behave as AFC enabled with Spoolman integration for multi-material printing support

### What it does

- **AFC status in UI** - Lane information (material, color, vendor, spool ID) visible in AFC-compatible frontends
- **Spoolman integration** - Assign spools to lanes with `SET_SPOOL_ID LANE=E0 SPOOL_ID=123`, automatically fetches filament data
- **Active spool tracking** - Current lane's spool ID synced to Spoolman
- **RFID spool detection** - OpenSpool tags with `spool_id` field link physical spools to Spoolman entries

### How it works

The AFC stub module is a read-only facade over the printer's existing `print_task_config` data structure. It does not implement its own filament tracking - all lane properties (material, color, vendor) are read from and written to the internal configuration that the printer already uses. Macros like `CHANGE_TOOL` and `LANE_UNLOAD` call the existing `AUTO_FEEDING` command.

Spoolman queries go through Moonraker's spoolman component via a new proxy RPC, with responses applied to `print_task_config` using the standard `SET_PRINT_FILAMENT_CONFIG` command.

### Configuration

Enable via firmware-config web interface under `Tweaks → AFC Stub`. Then edit `moonraker/spoolman.cfg` to enable a spoolman integration.

### Caveats

- The AFC component can only map lane (extruder) to a tool. There's no support to map many tools to a single lane (extruder) as Snapmaker Orca is doing.
- The runout logic cannot be controlled, as this is not configurable by Snapmaker, so it fails now.
- The weight tracking is not working if not used in Spoolman mode.
- The list of tools is derived fom `lane.map` instead of defined explicitly, so user can choose only from `T0..T3` tools.

### Integration with Snapmaker Orca

![snorca_sync](https://github.com/user-attachments/assets/fec2dcbb-f08f-4fae-b71e-8d282e84a780)

### Re-order tools

![edit_tools](https://github.com/user-attachments/assets/2f1d594f-f8dc-4d45-870e-429266c7cfa3)

### RFID support

![rfid_read](https://github.com/user-attachments/assets/ab001cea-afb6-4e8c-abed-8e158fe59b55)

### Spoolman support

![spoolman](https://github.com/user-attachments/assets/11328b2c-ac71-4b15-a953-9cd7d4806ae4)

