### PR TITLE
Move object processing to firmware-config tweaks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,13 +52,12 @@ Heavily expanded firmware with extensive features and customization. Includes al
 - [Firmware Configuration](firmware_config.md) - Customize firmware behavior via web interface or config file
 - [Camera Support](camera_support.md) - Hardware-accelerated camera stack with WebRTC streaming for internal and USB cameras
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
-- [Klipper Tweaks](tweaks.md) - Experimental TMC driver optimizations (firmware-config only)
+- [Klipper Tweaks](tweaks.md) - Experimental TMC driver optimizations and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh) (firmware-config only)
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
 - [Remote Screen](remote_screen.md) - View and control printer screen remotely via web browser
 - [Monitoring](monitoring.md) - Integration with Prometheus, Home Assistant, DataDog, and other monitoring systems
 - [VPN Remote Access](vpn.md) - Secure remote access via Tailscale (Experimental)
 - [Fluidd or Mainsail](firmware_config.md#web) (selectable) with timelapse support
-- Moonraker Adaptive Mesh Support - Object processing for adaptive mesh features
 - Moonraker Apprise Notifications - Send print notifications to Discord, Telegram, Slack, and 90+ services
 - [Timelapse Recovery Tool](https://github.com/horzadome/snapmaker-u1-timelapse-recovery) - Recover unplayable timelapse videos
 

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -54,6 +54,38 @@ Lowers the stepper motor run current from 1.2A to 1.0A for X and Y axes.
 **Configuration:**
 This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
 
+## Object Processing for Adaptive Mesh
+
+Enables object processing in Moonraker's file manager to support adaptive mesh features.
+
+**What it does:**
+- Processes gcode files to extract object information
+- Generates boundaries for adaptive mesh leveling
+- Allows per-object print settings and controls
+
+**Risks:**
+- Can cause very long processing times for large gcode files (> 100MB)
+- May result in extended delays when uploading files
+- Snapmaker Orca may stay at 100% for a long time when sending prints
+- High memory usage during file processing
+- Can cause delays before prints can start
+
+**Important:**
+- Enabling this setting alone is not enough to use adaptive mesh
+- You must also update your slicer start gcode to use: `BED_MESH_CALIBRATE ADAPTIVE=1`
+- This tells Klipper to only mesh the area where objects will be printed
+
+**Recommendation:**
+- **Preferred approach:** Enable `Exclude Object` in your slicer settings instead of this option
+- Slicer-generated object labels are more reliable and don't require server-side processing
+- Only enable Moonraker object processing if your slicer doesn't support exclude object
+- Disable if you frequently print large gcode files
+- Monitor file upload times after enabling
+- Consider splitting large models into smaller prints if processing is too slow
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
 ## How to Configure
 
 1. Open the printer's web interface (Fluidd or Mainsail)
@@ -67,8 +99,9 @@ Changes take effect immediately after Klipper restarts (no reboot required).
 
 ## Technical Details
 
-These tweaks work by adding or removing configuration files from `/oem/printer_data/config/extended/klipper/`:
-- `tmc_autotune.cfg` - TMC AutoTune parameters
-- `tmc_current.cfg` - Reduced current settings
+These tweaks work by adding or removing configuration files from `/oem/printer_data/config/extended/`:
+- `klipper/tmc_autotune.cfg` - TMC AutoTune parameters
+- `klipper/tmc_current.cfg` - Reduced current settings
+- `moonraker/object_processing.cfg` - Moonraker object processing settings
 
 These files are automatically included by the main printer configuration if present. Manual editing of these files is not recommended as they will be overwritten by the Firmware Configuration interface.

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/force-cleanup.sha256
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/force-cleanup.sha256
@@ -1,2 +1,5 @@
 # This was fixed by https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/165
 b0b11ca9959f7d3b1fcd750498986f47ca0cefca3d817b34ee63c3eb64efdd60  klipper/mainsail_pause_resume.cfg
+
+# Moved to tweaks - enable_object_processing can cause issues with large gcodes
+cd4a5aea7afcaa88031490805217a8088aaf383555d8afb0151f3fdc36f91487  moonraker/04_adaptive_mesh.cfg

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_object_processing.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_object_processing.yaml
@@ -1,0 +1,32 @@
+settings:
+  tweaks:
+    label: Tweaks
+    items:
+      object_processing:
+        label: Object Processing for Adaptive Mesh
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/moonraker/object_processing.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable Moonraker object processing? Note: Enabling 'Exclude Object' in your slicer settings is preferred over this option. This can cause long processing times for large gcode files (> 100MB), delays when uploading files, and extended time stuck at 100% in Snapmaker Orca. Only enable if your slicer doesn't support exclude object."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/moonraker &&
+                ln -sf /usr/local/share/firmware-config/tweaks/moonraker/object_processing.cfg /oem/printer_data/config/extended/moonraker/object_processing.cfg &&
+                echo "Object processing enabled. Restarting Moonraker..." &&
+                /etc/init.d/S61moonraker restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/moonraker/object_processing.cfg &&
+                echo "Object processing disabled. Restarting Moonraker..." &&
+                /etc/init.d/S61moonraker restart
+        default: disabled

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/moonraker/object_processing.cfg
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/moonraker/object_processing.cfg
@@ -1,0 +1,16 @@
+# Enable Object Processing in Moonraker
+#
+# WARNING: Enabling object processing can cause problems for very large gcode files
+# (> 100MB). This feature processes gcode files to extract object information, which
+# can result in:
+# - Long processing times before a print can start
+# - Extended time stuck at 100% in Snapmaker Orca when sending the print
+# - High memory usage during file processing
+#
+# Only enable this if you need adaptive mesh features and are working with
+# reasonably-sized gcode files.
+#
+# IMPORTANT: Enabling 'Exclude Object' in your slicer settings is preferred over this option.
+
+[file_manager]
+enable_object_processing: True


### PR DESCRIPTION
Move enable_object_processing from always-on extended config to optional tweak. This feature can cause long processing times for large gcode files (>100MB) and delays in Snapmaker Orca when uploading.

Changes:

- Add object processing as configurable tweak (disabled by default)
- Use symlink to enable/disable the feature
- Add force-cleanup for old config file
- Document that slicer exclude object is preferred
- Explain `BED_MESH_CALIBRATE ADAPTIVE=1` requirement
