### PR TITLE
firmware-extended: add opt-in klipper-router mode with isolated instance orchestration

### DIFF
--- a/overlays/firmware-extended/25-u1-router-led-events/README.md
+++ b/overlays/firmware-extended/25-u1-router-led-events/README.md
@@ -1,0 +1,52 @@
+# 25-u1-router-led-events
+
+Installs Klipper Router and adds LED status-event consumption for U1 extended Klipper config.
+
+## What it does
+
+- Installs pinned `klipper-router` from `https://github.com/paxx12/klipper-router` during firmware build:
+  - daemon: `/usr/local/sbin/klipper-routerd`
+  - reference include: `/usr/local/share/firmware-config/router/includes/router_api.cfg`
+- Installs init service:
+  - `/etc/init.d/S98klipper-router-instances` (starts/stops additional Klippy instances)
+  - `/etc/init.d/S99klipper-router`
+- Adds default router runtime config:
+  - `/usr/local/share/firmware-config/extended/router/klipper_router.cfg`
+  - copied to `/home/lava/printer_data/config/extended/router/klipper_router.cfg` on boot
+- Adds default additional-instance layout:
+  - `/usr/local/share/firmware-config/extended/router/instances/led/printer.cfg`
+  - `/usr/local/share/firmware-config/extended/router/instances/led/klipper/*.cfg`
+  - copied to `/home/lava/printer_data/config/extended/router/instances/led/` on boot
+- Adds default Klipper router API macro config:
+  - `/usr/local/share/firmware-config/extended/klipper/15_router_api.cfg`
+- Adds LED status subscription/state config:
+  - `/usr/local/share/firmware-config/extended/klipper/16_router_led_event_subscriptions.cfg`
+- Adds runtime migration script (`S50router-led-events`) to idempotently patch persisted router API config at:
+  - `/home/lava/printer_data/config/extended/klipper/15_router_api.cfg`
+- Adds firmware-config integration:
+  - `/usr/local/share/firmware-config/functions/25_settings_router.yaml`
+  - toggle router mode + basic runtime status visibility
+
+## Why runtime migration is included
+
+`/home/lava/printer_data/config/extended/*` is persistent and not overwritten by default updates. The migration script ensures existing installs receive the reconnect re-subscribe hook.
+
+## Opt-in enablement
+
+Router mode is disabled by default. Enable it in:
+
+`/home/lava/printer_data/config/extended/extended2.cfg`
+
+```ini
+[router]
+enabled: true
+```
+
+When enabled:
+- `S98klipper-router-instances` discovers and starts each instance under:
+  - `/home/lava/printer_data/config/extended/router/instances/<name>/printer.cfg`
+  - sockets: `/home/lava/printer_data/comms/klippy-router-<name>.sock`
+- `S99klipper-router` starts router daemon using:
+  - `/home/lava/printer_data/config/extended/router/klipper_router.cfg`
+  - auto-appends missing `[klippy <name>]` entries for discovered instances into:
+    - `/home/lava/printer_data/config/extended/router/klipper_router.runtime.cfg`

--- a/overlays/firmware-extended/25-u1-router-led-events/root/etc/init.d/S50router-led-events
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/etc/init.d/S50router-led-events
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+CFG="/home/lava/printer_data/config/extended/klipper/router_api.cfg"
+HOOK_LINE="UPDATE_DELAYED_GCODE ID=ROUTER_LED_STATUS_SUBSCRIBE_INIT DURATION=0.5"
+
+patch_router_on_connected() {
+    [ -f "$CFG" ] || return 0
+
+    # Already patched.
+    grep -Fq "$HOOK_LINE" "$CFG" && return 0
+
+    tmp_cfg="$(mktemp)" || return 1
+
+    awk '
+    BEGIN {
+        in_target = 0
+        inserted = 0
+    }
+    /^\[gcode_macro ROUTER_ON_CONNECTED\]$/ {
+        in_target = 1
+        print
+        next
+    }
+    /^\[gcode_macro / {
+        if (in_target == 1) {
+            in_target = 0
+        }
+    }
+    {
+        print
+        if (in_target == 1 && inserted == 0 && $0 ~ /M118 Router: \{params.PRINTER\} connected/) {
+            print "    {% if '\''PRINTER'\'' in params and params.PRINTER|lower == \"led\" %}"
+            print "        UPDATE_DELAYED_GCODE ID=ROUTER_LED_STATUS_SUBSCRIBE_INIT DURATION=0.5"
+            print "    {% endif %}"
+            inserted = 1
+        }
+    }
+    END {
+        if (inserted == 0) {
+            exit 2
+        }
+    }
+    ' "$CFG" > "$tmp_cfg"
+
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        rm -f "$tmp_cfg"
+        return 0
+    fi
+
+    mv "$tmp_cfg" "$CFG"
+    chown lava:lava "$CFG" 2>/dev/null || true
+}
+
+start() {
+    patch_router_on_connected
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        ;;
+    restart|reload)
+        start
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/overlays/firmware-extended/25-u1-router-led-events/root/etc/init.d/S98klipper-router-instances
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/etc/init.d/S98klipper-router-instances
@@ -1,0 +1,158 @@
+#!/bin/sh
+
+EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
+INSTANCES_DIR="/home/lava/printer_data/config/extended/router/instances"
+PID_DIR="/var/run"
+LOG_DIR="/home/lava/printer_data/logs"
+KLIPPY="/home/lava/klipper/klippy/klippy.py"
+
+router_enabled() {
+    /usr/local/bin/extended-config.py get "$EXTENDED_CFG" router enabled false 2>/dev/null
+}
+
+instance_pidfile() {
+    echo "$PID_DIR/klippy-router-$1.pid"
+}
+
+instance_cfg() {
+    echo "$INSTANCES_DIR/$1/printer.cfg"
+}
+
+instance_sock() {
+    echo "/home/lava/printer_data/comms/klippy-router-$1.sock"
+}
+
+instance_serial() {
+    echo "/home/lava/printer_data/comms/klippy-router-$1.serial"
+}
+
+instance_log() {
+    echo "$LOG_DIR/klippy-router-$1.log"
+}
+
+is_expected_instance_pid() {
+    name="$1"
+    pid="$2"
+    cfg="$(instance_cfg "$name")"
+    sock="$(instance_sock "$name")"
+
+    [ -n "$pid" ] || return 1
+    [ -r "/proc/$pid/cmdline" ] || return 1
+
+    cmdline="$(tr '\000' ' ' < "/proc/$pid/cmdline")"
+    echo "$cmdline" | grep -Fq "$KLIPPY" || return 1
+    echo "$cmdline" | grep -Fq "$cfg" || return 1
+    echo "$cmdline" | grep -Fq "$sock" || return 1
+    return 0
+}
+
+start_instance() {
+    name="$1"
+    cfg="$(instance_cfg "$name")"
+    pidfile="$(instance_pidfile "$name")"
+
+    [ -f "$cfg" ] || return 0
+
+    if [ -f "$pidfile" ]; then
+        pid="$(cat "$pidfile" 2>/dev/null)"
+        if kill -0 "$pid" 2>/dev/null; then
+            if is_expected_instance_pid "$name" "$pid"; then
+                echo "Klippy router instance '$name' already running"
+                return 0
+            fi
+            echo "Ignoring stale/mismatched pidfile for '$name' (pid=$pid)"
+        fi
+        rm -f "$pidfile"
+    fi
+
+    echo "Starting Klippy router instance: $name"
+    start-stop-daemon -S -b -m -u lava \
+        -p "$pidfile" \
+        -x /usr/bin/python3 -- "$KLIPPY" \
+        "$cfg" \
+        -I "$(instance_serial "$name")" \
+        -a "$(instance_sock "$name")" \
+        -l "$(instance_log "$name")" \
+        -u lava
+}
+
+stop_instance() {
+    name="$1"
+    pidfile="$(instance_pidfile "$name")"
+
+    if [ -f "$pidfile" ]; then
+        pid="$(cat "$pidfile" 2>/dev/null)"
+        if kill -0 "$pid" 2>/dev/null && is_expected_instance_pid "$name" "$pid"; then
+            echo "Stopping Klippy router instance: $name"
+            start-stop-daemon -K -p "$pidfile" -s TERM
+        else
+            echo "Skipping stale/mismatched pidfile for '$name' (pid=$pid)"
+        fi
+        rm -f "$pidfile"
+    fi
+}
+
+for_each_instance() {
+    [ -d "$INSTANCES_DIR" ] || return 0
+    find "$INSTANCES_DIR" -mindepth 1 -maxdepth 1 -type d | sort | while read -r dir; do
+        basename "$dir"
+    done
+}
+
+start() {
+    if [ "$(router_enabled)" != "true" ]; then
+        echo "[router] disabled in extended2.cfg, not starting router Klippy instances."
+        return 0
+    fi
+
+    mkdir -p "$LOG_DIR" "/home/lava/printer_data/comms"
+    for_each_instance | while read -r name; do
+        start_instance "$name"
+    done
+}
+
+stop() {
+    stopped=0
+    for_each_instance | while read -r name; do
+        stop_instance "$name"
+    done
+
+    for pidfile in "$PID_DIR"/klippy-router-*.pid; do
+        [ -f "$pidfile" ] || continue
+        name="$(basename "$pidfile" .pid)"
+        name="${name#klippy-router-}"
+        pid="$(cat "$pidfile" 2>/dev/null)"
+        if kill -0 "$pid" 2>/dev/null; then
+            if is_expected_instance_pid "$name" "$pid"; then
+                echo "Stopping stale Klippy router instance pid: $(basename "$pidfile" .pid)"
+                start-stop-daemon -K -p "$pidfile" -s TERM
+            else
+                echo "Skipping stale pidfile targeting unrelated process: $(basename "$pidfile") pid=$pid"
+            fi
+        fi
+        rm -f "$pidfile"
+        stopped=1
+    done
+
+    [ "$stopped" -eq 1 ] || echo "No Klippy router instances running"
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|reload)
+        stop
+        sleep 1
+        start
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/overlays/firmware-extended/25-u1-router-led-events/root/etc/init.d/S99klipper-router
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/etc/init.d/S99klipper-router
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+ROUTER_PY="/usr/local/sbin/klipper-routerd"
+ROUTER_CFG="/home/lava/printer_data/config/extended/router/klipper_router.cfg"
+ROUTER_RUNTIME_CFG="/home/lava/printer_data/config/extended/router/klipper_router.runtime.cfg"
+INSTANCES_DIR="/home/lava/printer_data/config/extended/router/instances"
+PIDFILE="/var/run/klipper-router.pid"
+LOGFILE="/home/lava/printer_data/logs/klipper-router.log"
+EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
+
+router_enabled() {
+    /usr/local/bin/extended-config.py get "$EXTENDED_CFG" router enabled false 2>/dev/null
+}
+
+is_running() {
+    [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null
+}
+
+build_runtime_cfg() {
+    runtime_cfg="$ROUTER_RUNTIME_CFG"
+    cp "$ROUTER_CFG" "$runtime_cfg" || return 1
+
+    if [ -d "$INSTANCES_DIR" ]; then
+        find "$INSTANCES_DIR" -mindepth 1 -maxdepth 1 -type d | sort | while read -r dir; do
+            name="$(basename "$dir")"
+            if ! grep -q "^\[klippy $name\]$" "$runtime_cfg"; then
+                cat >> "$runtime_cfg" <<EOF
+
+[klippy $name]
+sock: /home/lava/printer_data/comms/klippy-router-$name.sock
+on_connect: M118 Router connected to $name
+EOF
+            fi
+        done
+    fi
+
+    echo "$runtime_cfg"
+}
+
+start() {
+    if [ "$(router_enabled)" != "true" ]; then
+        echo "[router] disabled in extended2.cfg, not starting Klipper Router."
+        return 0
+    fi
+
+    if [ ! -x "$ROUTER_PY" ]; then
+        echo "Klipper Router is not installed"
+        return 1
+    fi
+
+    if [ ! -f "$ROUTER_CFG" ]; then
+        echo "Klipper Router config not found: $ROUTER_CFG"
+        return 0
+    fi
+
+    if is_running; then
+        echo "Klipper Router already running"
+        return 0
+    fi
+
+    mkdir -p /home/lava/printer_data/logs
+
+    runtime_cfg="$(build_runtime_cfg)"
+    if [ -z "$runtime_cfg" ] || [ ! -f "$runtime_cfg" ]; then
+        echo "Failed to prepare runtime router config"
+        return 1
+    fi
+
+    echo "Starting Klipper Router"
+    start-stop-daemon -S -b -m -u lava \
+        -p "$PIDFILE" \
+        -x /usr/bin/python3 -- "$ROUTER_PY" -c "$runtime_cfg" >> "$LOGFILE" 2>&1
+}
+
+stop() {
+    echo "Stopping Klipper Router"
+    if [ -f "$PIDFILE" ]; then
+        start-stop-daemon -K -p "$PIDFILE" -s TERM
+        rm -f "$PIDFILE"
+    else
+        echo "Klipper Router not running"
+    fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|reload)
+        stop
+        sleep 1
+        start
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/klipper/router_api.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/klipper/router_api.cfg
@@ -1,0 +1,102 @@
+[gcode_macro ROUTER_GCODE_SCRIPT]
+gcode:
+    {% if 'TARGET' not in params %}
+        {action_raise_error("ROUTER_GCODE_SCRIPT requires TARGET")}
+    {% endif %}
+    {% if 'SCRIPT' not in params %}
+        {action_raise_error("ROUTER_GCODE_SCRIPT requires SCRIPT")}
+    {% endif %}
+    {action_call_remote_method("router/gcode/script", target=params.TARGET, script=params.SCRIPT)}
+
+[gcode_macro ROUTER_EVENT_SUBSCRIBE]
+gcode:
+    {% if 'EVENT' not in params %}
+        {action_raise_error("ROUTER_EVENT_SUBSCRIBE requires EVENT")}
+    {% endif %}
+    {% if 'GCODE' not in params %}
+        {action_raise_error("ROUTER_EVENT_SUBSCRIBE requires GCODE")}
+    {% endif %}
+    {action_call_remote_method("router/event/subscribe", event=params.EVENT, gcode=params.GCODE)}
+
+[gcode_macro ROUTER_EVENT_TRIGGER]
+gcode:
+    {% if 'EVENT' not in params %}
+        {action_raise_error("ROUTER_EVENT_TRIGGER requires EVENT")}
+    {% endif %}
+    {action_call_remote_method("router/event/trigger", event=params.EVENT)}
+
+[gcode_macro ROUTER_PRINTERS_LIST]
+gcode:
+    {action_call_remote_method("router/printers/list", gcode_callback="ROUTER_PRINTERS_RESPONSE")}
+
+[gcode_macro ROUTER_PRINTERS_RESPONSE]
+gcode:
+    M118 Printers: {rawparams}
+
+[gcode_macro ROUTER_OBJECTS_LIST]
+gcode:
+    {% if 'TARGET' not in params %}
+        {action_raise_error("ROUTER_OBJECTS_LIST requires TARGET")}
+    {% endif %}
+    {action_call_remote_method("router/objects/list", target=params.TARGET, gcode_callback="ROUTER_OBJECTS_LIST_RESPONSE")}
+
+[gcode_macro ROUTER_OBJECTS_LIST_RESPONSE]
+gcode:
+    M118 Objects: {rawparams}
+
+[gcode_macro ROUTER_OBJECTS_QUERY]
+gcode:
+    {% if 'TARGET' not in params %}
+        {action_raise_error("ROUTER_OBJECTS_QUERY requires TARGET")}
+    {% endif %}
+    {% if 'OBJECTS' not in params %}
+        {action_raise_error("ROUTER_OBJECTS_QUERY requires OBJECTS")}
+    {% endif %}
+    {% set obj_list = params.OBJECTS.split(',') %}
+    {% set objects_dict = {} %}
+    {% for obj in obj_list %}
+        {% set _ = objects_dict.update({obj.strip(): None}) %}
+    {% endfor %}
+    {action_call_remote_method("router/objects/query", target=params.TARGET, objects=objects_dict, gcode_callback="ROUTER_OBJECTS_QUERY_RESPONSE")}
+
+[gcode_macro ROUTER_OBJECTS_QUERY_RESPONSE]
+gcode:
+    M118 Status: {rawparams}
+
+[gcode_macro ROUTER_OBJECTS_SUBSCRIBE]
+gcode:
+    {% if 'TARGET' not in params %}
+        {action_raise_error("ROUTER_OBJECTS_SUBSCRIBE requires TARGET")}
+    {% endif %}
+    {% if 'OBJECTS' not in params %}
+        {action_raise_error("ROUTER_OBJECTS_SUBSCRIBE requires OBJECTS")}
+    {% endif %}
+    {% set obj_list = params.OBJECTS.split(',') %}
+    {% set objects_dict = {} %}
+    {% for obj in obj_list %}
+        {% set _ = objects_dict.update({obj.strip(): None}) %}
+    {% endfor %}
+    {action_call_remote_method("router/objects/subscribe", target=params.TARGET, objects=objects_dict, gcode_callback=params.CALLBACK|default("ROUTER_OBJECTS_UPDATE"))}
+
+[gcode_macro ROUTER_OBJECTS_UPDATE]
+description: Called when subscribed objects change
+gcode:
+    M118 Update: {rawparams}
+
+[gcode_macro ROUTER_ON_READY]
+description: Called when this printer is ready
+gcode:
+    M118 Router ready
+
+[gcode_macro ROUTER_ON_CONNECTED]
+description: Called when another printer connects (PRINTER=name)
+gcode:
+    M118 Router: {params.PRINTER} connected
+    {% if 'PRINTER' in params and params.PRINTER|lower == "led" %}
+        UPDATE_DELAYED_GCODE ID=ROUTER_LED_STATUS_SUBSCRIBE_INIT DURATION=0.5
+    {% endif %}
+
+[gcode_macro ROUTER_ON_DISCONNECTED]
+description: Called when another printer disconnects (PRINTER=name)
+gcode:
+    M118 Router: {params.PRINTER} disconnected

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/klipper/router_led_event_subscriptions.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/klipper/router_led_event_subscriptions.cfg
@@ -1,0 +1,96 @@
+# Router LED status event subscriptions/state cache for extended instance
+
+[gcode_macro _ROUTER_LED_STATE]
+variable_last_status: "unknown"
+variable_last_event: ""
+variable_last_update: 0.0
+gcode:
+
+[gcode_macro _ROUTER_LED_SET_STATUS]
+description: Internal status cache setter (STATUS=<value>)
+gcode:
+    {% if 'STATUS' not in params %}
+        {action_raise_error("_ROUTER_LED_SET_STATUS requires STATUS")}
+    {% endif %}
+    {% set state = printer["gcode_macro _ROUTER_LED_STATE"] %}
+    {% set now = printer.toolhead.print_time|float %}
+    {% set last_update = state.last_update|float %}
+    {% set old_status = state.last_status|string|lower %}
+    {% set new_status = params.STATUS|string|lower %}
+    {% if new_status != old_status %}
+        {% set transient_states = ["ready", "homing", "leveling"] %}
+        {% set transient_pair = (old_status in transient_states) and (new_status in transient_states) %}
+        {% set should_log = (not transient_pair) or ((now - last_update) >= 2.0) %}
+        SET_GCODE_VARIABLE MACRO=_ROUTER_LED_STATE VARIABLE=last_status VALUE='"{new_status}"'
+        SET_GCODE_VARIABLE MACRO=_ROUTER_LED_STATE VARIABLE=last_event VALUE='"{new_status}"'
+        SET_GCODE_VARIABLE MACRO=_ROUTER_LED_STATE VARIABLE=last_update VALUE={now}
+        {% if should_log %}
+            M118 [LED_EVENT] {old_status} -> {new_status}
+        {% endif %}
+    {% endif %}
+
+[gcode_macro SUBSCRIBE_LED_STATUS_EVENTS]
+description: Subscribe to router LED status events
+gcode:
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_ready GCODE=ON_LED_STATUS_READY
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_running GCODE=ON_LED_STATUS_RUNNING
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_warning GCODE=ON_LED_STATUS_WARNING
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_error GCODE=ON_LED_STATUS_ERROR
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_heating GCODE=ON_LED_STATUS_HEATING
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_homing GCODE=ON_LED_STATUS_HOMING
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_leveling GCODE=ON_LED_STATUS_LEVELING
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_complete GCODE=ON_LED_STATUS_COMPLETE
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_paused GCODE=ON_LED_STATUS_PAUSED
+    ROUTER_EVENT_SUBSCRIBE EVENT=led/status_off GCODE=ON_LED_STATUS_OFF
+    M118 [LED_EVENT] subscribed
+
+[delayed_gcode ROUTER_LED_STATUS_SUBSCRIBE_INIT]
+initial_duration: 2.5
+gcode:
+    SUBSCRIBE_LED_STATUS_EVENTS
+
+[gcode_macro LED_STATUS_STATE]
+description: Show cached router LED status state
+gcode:
+    {% set state = printer["gcode_macro _ROUTER_LED_STATE"] %}
+    M118 [LED_EVENT] status={state.last_status} event={state.last_event} update={state.last_update}
+
+[gcode_macro ON_LED_STATUS_READY]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=ready
+
+[gcode_macro ON_LED_STATUS_RUNNING]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=running
+
+[gcode_macro ON_LED_STATUS_WARNING]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=warning
+
+[gcode_macro ON_LED_STATUS_ERROR]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=error
+
+[gcode_macro ON_LED_STATUS_HEATING]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=heating
+
+[gcode_macro ON_LED_STATUS_HOMING]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=homing
+
+[gcode_macro ON_LED_STATUS_LEVELING]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=leveling
+
+[gcode_macro ON_LED_STATUS_COMPLETE]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=complete
+
+[gcode_macro ON_LED_STATUS_PAUSED]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=paused
+
+[gcode_macro ON_LED_STATUS_OFF]
+gcode:
+    _ROUTER_LED_SET_STATUS STATUS=off

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/10_disco_effects.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/10_disco_effects.cfg
@@ -1,0 +1,94 @@
+# ==== DISCO PARTY ====
+
+[gcode_macro DISCO_PARTY]
+variable_active: 0
+gcode:
+    DISCO_STOP
+    SET_GCODE_VARIABLE MACRO=DISCO_PARTY VARIABLE=active VALUE=1
+    UPDATE_DELAYED_GCODE ID=party_loop DURATION=0.1
+
+[gcode_macro DISCO_BREATHING]
+variable_active: 0
+variable_brightness: 0.1
+variable_direction: 1
+gcode:
+    DISCO_STOP
+    SET_GCODE_VARIABLE MACRO=DISCO_BREATHING VARIABLE=active VALUE=1
+    UPDATE_DELAYED_GCODE ID=breathing_loop DURATION=0.1
+
+[delayed_gcode party_loop]
+gcode:
+    {% if printer["gcode_macro DISCO_PARTY"].active %}
+        {% set r = (range(0, 100) | random) / 100.0 %}
+        {% set g = (range(0, 100) | random) / 100.0 %}
+        {% set b = (range(0, 100) | random) / 100.0 %}
+        SET_LED LED=disco_led RED={r} GREEN={g} BLUE={b}
+        UPDATE_DELAYED_GCODE ID=party_loop DURATION=0.1
+    {% endif %}
+
+[delayed_gcode breathing_loop]
+gcode:
+    {% if printer["gcode_macro DISCO_BREATHING"].active %}
+        {% set brightness = printer["gcode_macro DISCO_BREATHING"].brightness %}
+        {% set direction = printer["gcode_macro DISCO_BREATHING"].direction %}
+        {% if brightness >= 1.0 %}
+            {% set direction = -1 %}
+        {% elif brightness <= 0.1 %}
+            {% set direction = 1 %}
+        {% endif %}
+        {% set next_brightness = brightness + (0.05 * direction) %}
+        {% if next_brightness > 1.0 %}
+            {% set next_brightness = 1.0 %}
+        {% elif next_brightness < 0.0 %}
+            {% set next_brightness = 0.0 %}
+        {% endif %}
+        SET_GCODE_VARIABLE MACRO=DISCO_BREATHING VARIABLE=brightness VALUE={next_brightness}
+        SET_GCODE_VARIABLE MACRO=DISCO_BREATHING VARIABLE=direction VALUE={direction}
+        SET_LED LED=disco_led RED=0 GREEN={next_brightness} BLUE={next_brightness}
+        UPDATE_DELAYED_GCODE ID=breathing_loop DURATION=0.1
+    {% endif %}
+
+[gcode_macro DISCO_STOP]
+gcode:
+    SET_GCODE_VARIABLE MACRO=DISCO_PARTY VARIABLE=active VALUE=0
+    UPDATE_DELAYED_GCODE ID=party_loop DURATION=0
+    SET_GCODE_VARIABLE MACRO=DISCO_BREATHING VARIABLE=active VALUE=0
+    UPDATE_DELAYED_GCODE ID=breathing_loop DURATION=0
+    {% set ready = params.READY|default(0)|int %}
+    {% if ready == 1 %}
+      STATUS_READY
+    {% endif %}
+
+# Disco macros
+[gcode_macro DISCO_IDLE]
+gcode:
+  DISCO_STOP
+  SET_LED LED=disco_led RED=0 GREEN=0 BLUE=0.3
+
+[gcode_macro DISCO_PRINTING]
+gcode:
+  DISCO_STOP
+  SET_LED LED=disco_led RED=0 GREEN=0.5 BLUE=0
+
+[gcode_macro DISCO_HEATING]
+gcode:
+  DISCO_STOP
+  SET_LED LED=disco_led RED=0.8 GREEN=0.2 BLUE=0
+
+[gcode_macro DISCO_COMPLETE]
+gcode:
+  DISCO_STOP
+  {% for i in range(20) %}
+    SET_LED LED=disco_led RED={(i % 3) / 3.0} GREEN={((i+1) % 3) / 3.0} BLUE={((i+2) % 3) / 3.0}
+    G4 P100
+  {% endfor %}
+
+[gcode_macro DISCO_ERROR]
+gcode:
+  DISCO_STOP
+  {% for i in range(10) %}
+    SET_LED LED=disco_led RED=1 GREEN=0 BLUE=0
+    G4 P200
+    SET_LED LED=disco_led RED=0 GREEN=0 BLUE=0
+    G4 P200
+  {% endfor %}

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/20_status_macros.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/20_status_macros.cfg
@@ -1,0 +1,147 @@
+# ==== ANDON TOWER STATUS LIGHT ====
+
+[gcode_macro STATUS_RUNTIME]
+variable_heating_active: 0
+variable_heating_phase: 0
+variable_homing_active: 0
+variable_homing_phase: 0
+variable_leveling_active: 0
+variable_leveling_phase: 0
+gcode:
+
+[gcode_macro _STATUS_STOP_LOOPS]
+gcode:
+  SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=heating_active VALUE=0
+  SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=homing_active VALUE=0
+  SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=leveling_active VALUE=0
+  UPDATE_DELAYED_GCODE ID=status_heating_loop DURATION=0
+  UPDATE_DELAYED_GCODE ID=status_homing_loop DURATION=0
+  UPDATE_DELAYED_GCODE ID=status_leveling_loop DURATION=0
+
+[delayed_gcode status_heating_loop]
+gcode:
+  {% if printer["gcode_macro STATUS_RUNTIME"].heating_active|int == 1 %}
+    {% set phase = printer["gcode_macro STATUS_RUNTIME"].heating_phase|int %}
+    {% if phase == 0 %}
+      SET_LED LED=disco_led RED=1.0 GREEN=0.85 BLUE=0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=heating_phase VALUE=1
+    {% else %}
+      SET_LED LED=disco_led RED=1.0 GREEN=0.45 BLUE=0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=heating_phase VALUE=0
+    {% endif %}
+    UPDATE_DELAYED_GCODE ID=status_heating_loop DURATION=0.35
+  {% endif %}
+
+[delayed_gcode status_homing_loop]
+gcode:
+  {% if printer["gcode_macro STATUS_RUNTIME"].homing_active|int == 1 %}
+    {% set phase = printer["gcode_macro STATUS_RUNTIME"].homing_phase|int %}
+    {% if phase == 0 %}
+      SET_LED LED=disco_led RED=0 GREEN=0 BLUE=1.0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=homing_phase VALUE=1
+    {% else %}
+      SET_LED LED=disco_led RED=0 GREEN=0 BLUE=0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=homing_phase VALUE=0
+    {% endif %}
+    UPDATE_DELAYED_GCODE ID=status_homing_loop DURATION=0.2
+  {% endif %}
+
+[delayed_gcode status_leveling_loop]
+gcode:
+  {% if printer["gcode_macro STATUS_RUNTIME"].leveling_active|int == 1 %}
+    {% set phase = printer["gcode_macro STATUS_RUNTIME"].leveling_phase|int %}
+    {% if phase == 0 %}
+      SET_LED LED=disco_led RED=0 GREEN=0 BLUE=1.0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=leveling_phase VALUE=1
+    {% elif phase == 1 %}
+      SET_LED LED=disco_led RED=1.0 GREEN=0.8 BLUE=0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=leveling_phase VALUE=2
+    {% else %}
+      SET_LED LED=disco_led RED=0 GREEN=1.0 BLUE=0
+      SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=leveling_phase VALUE=0
+    {% endif %}
+    UPDATE_DELAYED_GCODE ID=status_leveling_loop DURATION=0.25
+  {% endif %}
+
+[gcode_macro STATUS_READY]
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_LED LED=disco_led RED=0 GREEN=0 BLUE=1.0
+  {action_call_remote_method("router/event/trigger", event="led/status_ready")}
+
+[gcode_macro STATUS_RUNNING]
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_LED LED=disco_led RED=0 GREEN=1.0 BLUE=0
+  {action_call_remote_method("router/event/trigger", event="led/status_running")}
+
+[gcode_macro STATUS_WARNING]
+description: Needs attention (low filament, bed leveling, etc)
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_LED LED=disco_led RED=1.0 GREEN=0.8 BLUE=0
+  {action_call_remote_method("router/event/trigger", event="led/status_warning")}
+
+[gcode_macro STATUS_ERROR]
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_LED LED=disco_led RED=1.0 GREEN=0 BLUE=0
+  {action_call_remote_method("router/event/trigger", event="led/status_error")}
+
+[gcode_macro STATUS_HEATING]
+description: Pulsing yellow while heating
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=heating_active VALUE=1
+  UPDATE_DELAYED_GCODE ID=status_heating_loop DURATION=0.1
+  {action_call_remote_method("router/event/trigger", event="led/status_heating")}
+
+[gcode_macro STATUS_HOMING]
+description: Flashing blue during homing
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=homing_active VALUE=1
+  UPDATE_DELAYED_GCODE ID=status_homing_loop DURATION=0.1
+  {action_call_remote_method("router/event/trigger", event="led/status_homing")}
+
+[gcode_macro STATUS_LEVELING]
+description: Rotating colors during bed leveling
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_GCODE_VARIABLE MACRO=STATUS_RUNTIME VARIABLE=leveling_active VALUE=1
+  UPDATE_DELAYED_GCODE ID=status_leveling_loop DURATION=0.1
+  {action_call_remote_method("router/event/trigger", event="led/status_leveling")}
+
+[gcode_macro STATUS_COMPLETE]
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  {% for i in range(5) %}
+    SET_LED LED=disco_led RED=0 GREEN=1.0 BLUE=0
+    G4 P200
+    SET_LED LED=disco_led RED=0 GREEN=0.3 BLUE=0
+    G4 P200
+  {% endfor %}
+  {action_call_remote_method("router/event/trigger", event="led/status_complete")}
+  STATUS_READY
+
+[gcode_macro STATUS_PAUSED]
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_LED LED=disco_led RED=1.0 GREEN=0.8 BLUE=0
+  {action_call_remote_method("router/event/trigger", event="led/status_paused")}
+
+[gcode_macro STATUS_OFF]
+gcode:
+  DISCO_STOP
+  _STATUS_STOP_LOOPS
+  SET_LED LED=disco_led RED=0 GREEN=0 BLUE=0
+  {action_call_remote_method("router/event/trigger", event="led/status_off")}

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/30_router_event_subscriptions.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/30_router_event_subscriptions.cfg
@@ -1,0 +1,162 @@
+# ==== ROUTER OBJECT SUBSCRIPTIONS (LED instance) ====
+
+[gcode_macro SUBSCRIBE_MAIN_STATUS]
+description: Subscribe LED instance to main print_stats updates
+gcode:
+    {% set objects = {
+        "webhooks": ["state"],
+        "print_stats": ["state"],
+        "pause_resume": ["is_paused"],
+        "idle_timeout": ["state"],
+        "toolhead": ["homed_axes"],
+        "probe": ["last_z_result"],
+        "extruder": ["temperature", "target"],
+        "heater_bed": ["temperature", "target"]
+    } %}
+    {action_call_remote_method("router/objects/subscribe", target="main", objects=objects, gcode_callback="ON_STATUS_UPDATE")}
+    UPDATE_DELAYED_GCODE ID=LED_SYNC_MAIN_STATUS_ONCE DURATION=0.2
+    M118 [LED] Subscribed: main print_stats/pause/idle/toolhead/heaters
+
+[gcode_macro ON_STATUS_UPDATE]
+description: Handle routed print_stats state from main
+variable_last_status: "unknown"
+variable_last_webhooks_state: "ready"
+variable_last_state: "standby"
+variable_last_paused: "false"
+variable_last_idle_state: "ready"
+variable_last_homed_axes: ""
+variable_last_e_temp: 0.0
+variable_last_e_target: 0.0
+variable_last_b_temp: 0.0
+variable_last_b_target: 0.0
+variable_last_probe_z: 0.0
+gcode:
+    {% set webhooks_state = params.WEBHOOKS_STATE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_webhooks_state)|lower %}
+    {% set state = params.PRINT_STATS_STATE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_state)|lower %}
+    {% set paused_raw = params.PAUSE_RESUME_IS_PAUSED|default(printer["gcode_macro ON_STATUS_UPDATE"].last_paused)|string|lower %}
+    {% set paused = paused_raw in ["true", "1"] %}
+    {% set idle_state = params.IDLE_TIMEOUT_STATE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_idle_state)|string|lower %}
+    {% set homed_axes = params.TOOLHEAD_HOMED_AXES|default(printer["gcode_macro ON_STATUS_UPDATE"].last_homed_axes)|string|lower %}
+    {% set e_temp = params.EXTRUDER_TEMPERATURE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_e_temp)|float %}
+    {% set e_target = params.EXTRUDER_TARGET|default(printer["gcode_macro ON_STATUS_UPDATE"].last_e_target)|float %}
+    {% set b_temp = params.HEATER_BED_TEMPERATURE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_b_temp)|float %}
+    {% set b_target = params.HEATER_BED_TARGET|default(printer["gcode_macro ON_STATUS_UPDATE"].last_b_target)|float %}
+    {% set probe_z = params.PROBE_LAST_Z_RESULT|default(printer["gcode_macro ON_STATUS_UPDATE"].last_probe_z)|float %}
+    {% set probe_updated = params.PROBE_LAST_Z_RESULT is defined %}
+    {% set was_error = printer["gcode_macro ON_STATUS_UPDATE"].last_status == "error" %}
+    {% set heating = (not was_error)
+        and (not paused)
+        and (webhooks_state != "shutdown")
+        and (state not in ["error", "cancelled", "complete", "paused"])
+        and ((e_target > 0 and (e_target - e_temp) > 2.0) or (b_target > 0 and (b_target - b_temp) > 2.0)) %}
+    {% set desired = "ready" %}
+
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_webhooks_state VALUE="'{webhooks_state}'"
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_state VALUE="'{state}'"
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_paused VALUE="'{paused_raw}'"
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_idle_state VALUE="'{idle_state}'"
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_homed_axes VALUE="'{homed_axes}'"
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_e_temp VALUE={e_temp}
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_e_target VALUE={e_target}
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_b_temp VALUE={b_temp}
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_b_target VALUE={b_target}
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_probe_z VALUE={probe_z}
+
+    {% if state == "error" %}
+        {% set desired = "error" %}
+    {% elif state == "cancelled" %}
+        {% set desired = "error" %}
+    {% elif webhooks_state == "shutdown" %}
+        {% if state in ["printing", "paused"] %}
+            {% set desired = "error" %}
+        {% else %}
+            {% set desired = "shutdown" %}
+        {% endif %}
+    {% elif paused or state == "paused" %}
+        {% set desired = "paused" %}
+    {% elif heating %}
+        {% set desired = "heating" %}
+    {% elif state == "printing" %}
+        {% set desired = "running" %}
+    {% elif state == "complete" %}
+        {% set desired = "complete" %}
+    {% elif probe_updated and state in ["standby", "printing"] %}
+        {% set desired = "leveling" %}
+    {% elif homed_axes != "" and homed_axes != "xyz" %}
+        {% set desired = "homing" %}
+    {% elif idle_state == "idle" %}
+        {% set desired = "idle" %}
+    {% elif idle_state in ["ready", "printing"] or state == "standby" %}
+        {% set desired = "ready" %}
+    {% endif %}
+
+    {% if desired != printer["gcode_macro ON_STATUS_UPDATE"].last_status %}
+        SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_status VALUE="'{desired}'"
+        {% if desired == "running" %}
+            STATUS_RUNNING
+        {% elif desired == "paused" %}
+            STATUS_PAUSED
+        {% elif desired == "complete" %}
+            STATUS_COMPLETE
+        {% elif desired == "warning" %}
+            STATUS_WARNING
+        {% elif desired == "error" %}
+            DISCO_STOP
+            DISCO_ERROR
+            STATUS_ERROR
+        {% elif desired == "shutdown" %}
+            DISCO_BREATHING
+        {% elif desired == "heating" %}
+            STATUS_HEATING
+        {% elif desired == "homing" %}
+            STATUS_HOMING
+        {% elif desired == "leveling" %}
+            STATUS_LEVELING
+        {% elif desired == "idle" %}
+            DISCO_IDLE
+        {% else %}
+            STATUS_READY
+        {% endif %}
+    {% endif %}
+
+[gcode_macro ROUTER_ON_READY]
+description: Router callback when LED instance is ready
+gcode:
+    M118 LED controller ready
+    UPDATE_DELAYED_GCODE ID=LED_INIT_MAIN_STATUS_SUBSCRIPTION DURATION=2.0
+
+[gcode_macro ROUTER_ON_CONNECTED]
+description: Router callback when another printer connects
+gcode:
+    {% if params.PRINTER|lower == "main" %}
+        UPDATE_DELAYED_GCODE ID=LED_MAIN_DISCONNECT_FALLBACK DURATION=0
+        SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_webhooks_state VALUE="'ready'"
+        SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_status VALUE="'unknown'"
+        M118 Registering for main printer status updates
+        UPDATE_DELAYED_GCODE ID=LED_INIT_MAIN_STATUS_SUBSCRIPTION DURATION=0.5
+    {% endif %}
+
+[gcode_macro ROUTER_ON_DISCONNECTED]
+description: Router callback when another printer disconnects
+gcode:
+    {% if params.PRINTER|lower == "main" %}
+        # Delay breathing fallback to avoid transient reconnect flaps while main is still on.
+        UPDATE_DELAYED_GCODE ID=LED_MAIN_DISCONNECT_FALLBACK DURATION=8.0
+    {% endif %}
+
+[delayed_gcode LED_INIT_MAIN_STATUS_SUBSCRIPTION]
+initial_duration: 0
+gcode:
+    SUBSCRIBE_MAIN_STATUS
+
+[delayed_gcode LED_SYNC_MAIN_STATUS_ONCE]
+initial_duration: 0
+gcode:
+    {action_call_remote_method("router/objects/query", target="main", objects={"webhooks": ["state"], "print_stats": ["state"], "pause_resume": ["is_paused"], "idle_timeout": ["state"], "toolhead": ["homed_axes"], "probe": ["last_z_result"], "extruder": ["temperature", "target"], "heater_bed": ["temperature", "target"]}, gcode_callback="ON_STATUS_UPDATE")}
+
+[delayed_gcode LED_MAIN_DISCONNECT_FALLBACK]
+initial_duration: 0
+gcode:
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_webhooks_state VALUE="'shutdown'"
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_status VALUE="'shutdown'"
+    DISCO_BREATHING

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/30_router_event_subscriptions.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/klipper/30_router_event_subscriptions.cfg
@@ -30,19 +30,31 @@ variable_last_e_target: 0.0
 variable_last_b_temp: 0.0
 variable_last_b_target: 0.0
 variable_last_probe_z: 0.0
+variable_last_probe_time: 0.0
+variable_last_partial_home_time: 0.0
 gcode:
+    {% set now = printer.toolhead.print_time|float %}
     {% set webhooks_state = params.WEBHOOKS_STATE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_webhooks_state)|lower %}
     {% set state = params.PRINT_STATS_STATE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_state)|lower %}
     {% set paused_raw = params.PAUSE_RESUME_IS_PAUSED|default(printer["gcode_macro ON_STATUS_UPDATE"].last_paused)|string|lower %}
     {% set paused = paused_raw in ["true", "1"] %}
     {% set idle_state = params.IDLE_TIMEOUT_STATE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_idle_state)|string|lower %}
     {% set homed_axes = params.TOOLHEAD_HOMED_AXES|default(printer["gcode_macro ON_STATUS_UPDATE"].last_homed_axes)|string|lower %}
+    {% set homed_axes_updated = params.TOOLHEAD_HOMED_AXES is defined %}
     {% set e_temp = params.EXTRUDER_TEMPERATURE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_e_temp)|float %}
     {% set e_target = params.EXTRUDER_TARGET|default(printer["gcode_macro ON_STATUS_UPDATE"].last_e_target)|float %}
     {% set b_temp = params.HEATER_BED_TEMPERATURE|default(printer["gcode_macro ON_STATUS_UPDATE"].last_b_temp)|float %}
     {% set b_target = params.HEATER_BED_TARGET|default(printer["gcode_macro ON_STATUS_UPDATE"].last_b_target)|float %}
     {% set probe_z = params.PROBE_LAST_Z_RESULT|default(printer["gcode_macro ON_STATUS_UPDATE"].last_probe_z)|float %}
     {% set probe_updated = params.PROBE_LAST_Z_RESULT is defined %}
+    {% set last_probe_time = printer["gcode_macro ON_STATUS_UPDATE"].last_probe_time|float %}
+    {% set last_partial_home_time = printer["gcode_macro ON_STATUS_UPDATE"].last_partial_home_time|float %}
+    {% if probe_updated and state in ["standby", "printing"] %}
+        {% set last_probe_time = now %}
+    {% endif %}
+    {% if homed_axes_updated and homed_axes != "" and homed_axes != "xyz" %}
+        {% set last_partial_home_time = now %}
+    {% endif %}
     {% set was_error = printer["gcode_macro ON_STATUS_UPDATE"].last_status == "error" %}
     {% set heating = (not was_error)
         and (not paused)
@@ -61,6 +73,8 @@ gcode:
     SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_b_temp VALUE={b_temp}
     SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_b_target VALUE={b_target}
     SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_probe_z VALUE={probe_z}
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_probe_time VALUE={last_probe_time}
+    SET_GCODE_VARIABLE MACRO=ON_STATUS_UPDATE VARIABLE=last_partial_home_time VALUE={last_partial_home_time}
 
     {% if state == "error" %}
         {% set desired = "error" %}
@@ -80,9 +94,9 @@ gcode:
         {% set desired = "running" %}
     {% elif state == "complete" %}
         {% set desired = "complete" %}
-    {% elif probe_updated and state in ["standby", "printing"] %}
+    {% elif (now - last_probe_time) < 2.0 and state in ["standby", "printing"] %}
         {% set desired = "leveling" %}
-    {% elif homed_axes != "" and homed_axes != "xyz" %}
+    {% elif (now - last_partial_home_time) < 1.5 %}
         {% set desired = "homing" %}
     {% elif idle_state == "idle" %}
         {% set desired = "idle" %}

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/printer.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/instances/led/printer.cfg
@@ -1,0 +1,26 @@
+# LED Instance Config (STANDALONE)
+
+[include klipper/*.cfg]
+
+[mcu]
+serial: /dev/serial/by-path/platform-fed00000.usb-usb-0:1.3:1.0
+
+[neopixel disco_led]
+pin: gpio16
+chain_count: 1
+color_order: RGB
+initial_RED: 0.1
+initial_GREEN: 0.0
+initial_BLUE: 0.0
+
+[printer]
+kinematics: none
+max_velocity: 100
+max_accel: 100
+max_logical_extruder_num: 32
+max_physical_extruder_num: 4
+
+[respond]
+[display_status]
+[pause_resume]
+[idle_timeout]

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/klipper_router.cfg
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/extended/router/klipper_router.cfg
@@ -1,0 +1,9 @@
+# Klipper Router configuration for U1 router-enabled setups
+
+[klippy main]
+sock: /home/lava/printer_data/comms/klippy.sock
+on_connect: M118 Router connected to main
+
+[klippy led]
+sock: /home/lava/printer_data/comms/klippy-router-led.sock
+on_connect: M118 Router connected to LED

--- a/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/functions/25_settings_router.yaml
+++ b/overlays/firmware-extended/25-u1-router-led-events/root/usr/local/share/firmware-config/functions/25_settings_router.yaml
@@ -1,0 +1,44 @@
+status:
+  router:
+    title: Klipper Router
+    items:
+      - label: Router Service
+        cmd: if [ -f /var/run/klipper-router.pid ] && kill -0 "$(cat /var/run/klipper-router.pid)" 2>/dev/null; then echo "running"; else echo "stopped"; fi
+      - label: Instances Running
+        cmd: ls /var/run/klippy-router-*.pid 2>/dev/null | wc -l
+      - label: Router Log
+        cmd: test -f /home/lava/printer_data/logs/klipper-router.log && echo "/home/lava/printer_data/logs/klipper-router.log" || echo "-"
+
+settings:
+  router:
+    label: Router Mode
+    items:
+      enabled:
+        label: Enable Klipper Router
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /home/lava/printer_data/config/extended/extended2.cfg
+          - router
+          - enabled
+          - "false"
+        options:
+          "false":
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg router enabled false
+                /etc/init.d/S99klipper-router stop
+                /etc/init.d/S98klipper-router-instances stop
+          "true":
+            label: Enabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg router enabled true
+                /etc/init.d/S98klipper-router-instances restart
+                /etc/init.d/S99klipper-router restart
+        default: "false"

--- a/overlays/firmware-extended/25-u1-router-led-events/scripts/01-install-klipper-router.sh
+++ b/overlays/firmware-extended/25-u1-router-led-events/scripts/01-install-klipper-router.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+GIT_URL=https://github.com/paxx12/klipper-router.git
+GIT_SHA=c350612121cb71e914ecbcff0523a46cfab07e36
+
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
+set -eo pipefail
+
+TARGET_DIR="$CACHE_DIR/klipper-router"
+cache_git.sh "$TARGET_DIR" "$GIT_URL" "$GIT_SHA"
+
+install -m 0755 "$TARGET_DIR/src/klipper_router.py" "$1/usr/local/sbin/klipper-routerd"
+
+# Optional reference copy for future config/macro syncing
+mkdir -p "$1/usr/local/share/firmware-config/router/includes"
+install -m 0644 "$TARGET_DIR/includes/router_api.cfg" "$1/usr/local/share/firmware-config/router/includes/router_api.cfg"
+
+echo ">> klipper-router installed successfully"


### PR DESCRIPTION
**Description**  
This PR builds on #247 and adds an opt-in Klipper Router mode to Extended Firmware to separate failure domains between core motion control and optional peripherals.

Today, optional subsystems (MMU/AMS/feeder/sensors/toolchanger controllers) often share the same Klippy failure domain as motion control. A peripheral reset/timeout can abort an otherwise healthy print. This change introduces infrastructure for running peripherals as independent Klippy instances, with routing between instances handled by [`klipper-router`](https://github.com/paxx12/klipper-router).

No Klipper fork or core motion-control patching is required.

**What this PR adds**

- New overlay: `overlays/firmware-extended/25-u1-router-led-events`
- Pinned install of upstream `klipper-router` during firmware build
  - daemon: `/usr/local/sbin/klipper-routerd`
- Opt-in router mode toggle in firmware-config
  - `functions/25_settings_router.yaml`
  - setting: `[router] enabled` in `extended2.cfg`
  - basic runtime status visibility (router service, instance count, log path)
- Service orchestration
  - `S98klipper-router-instances`: discovers and runs additional Klippy instances from:
    - `/home/lava/printer_data/config/extended/router/instances/<name>/printer.cfg`
    - per-instance sockets: `/home/lava/printer_data/comms/klippy-router-<name>.sock`
  - `S99klipper-router`: runs router daemon and builds runtime router config with discovered instances
- Default router filesystem layout under extended config defaults
  - router config: `extended/router/klipper_router.cfg`
  - default LED instance template and macros:
    - `extended/router/instances/led/**`
- Extended-side router macro API + LED status event consumption
  - `extended/klipper/15_router_api.cfg`
  - `extended/klipper/16_router_led_event_subscriptions.cfg`
- Boot-time migration hook for persisted config
  - `S50router-led-events` ensures LED re-subscribe hook exists in `15_router_api.cfg`
- LED instance MCU path updated to stable USB `by-path` device on U1 template

**Why this helps**

- Peripheral faults can be isolated from the main motion-control Klippy process.
- Non-critical subsystems can restart/reconnect without forcing a full print abort by default.
- Enables scaling to multiple optional controllers without tightly coupling everything into one Klippy instance.

**Scope boundaries**

This PR provides infrastructure only:
- router mode enablement
- service orchestration
- instance discovery/layout
- status visibility
- one concrete LED routed-state example

It does **not** define MMU/device policy semantics or rewrite print lifecycle logic globally.

**Operational model**

- Default state: disabled (`[router] enabled: false`)
- Enabling router mode starts isolated instance service + router service
- Disabling router mode stops both cleanly

**Validation focus for review**

- Enable/disable path via firmware-config
- Service start order and idempotency (`S49` -> `S50` -> `S98` -> `S99`)
- Router and instance socket/log creation
- LED routed status event state updates and duplicate suppression
- Clean behavior when auxiliary instance disconnects/reconnects