### PR TITLE
fix: `extended-config.py` `set_value` displacing last line when adding a new section

### DIFF
--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/bin/extended-config.py
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/bin/extended-config.py
@@ -33,8 +33,10 @@ def set_value(cfg_file, section, key, value, create_section=True, create_key=Tru
 
     section_found = False
     key_found = False
+    i = 0
 
-    for i, line in enumerate(lines):
+    while i < len(lines):
+        line = lines[i]
         if any_section_re.match(line) and section_found:
             break
         if section_re.match(line):
@@ -47,12 +49,16 @@ def set_value(cfg_file, section, key, value, create_section=True, create_key=Tru
                 sys.exit(1)
             lines[i] = f"{key}: {value}\n"
             key_found = True
+        i += 1
 
     if not section_found:
         if not create_section:
             print(f"ERROR: Section '{section}' does not exist for update", file=sys.stderr)
             sys.exit(1)
-        lines.insert(i, f"\n[{section}]\n")
+        if i > 0:
+            lines.insert(i, "\n")
+            i += 1
+        lines.insert(i, f"[{section}]\n")
         i += 1
 
     if not key_found:


### PR DESCRIPTION
When adding a key to a non-existent section, `extended-config.py`'s `set_value` used `lines.insert(i, ...)` where `i` was the last index from the `for`-loop. This inserted the new section *before* the final line of the file, displacing it below the new section header.

For example, adding `[router]` to a file ending with `[monitoring]` would move `klipper_exporter: :9101` under `[router]` instead of keeping it under `[monitoring]`.

**Fix**: append the new section at the end of the file instead of inserting at the loop's last index. Also handle edge cases for files with trailing blank lines, no trailing newline, or empty files.