### PR TITLE
Add Generic RFID Tag Persistence for Filament Tracking and Spoolman

### DIFF
--- a/overlays/firmware-extended/13-rfid-support/patches/01-add-ntag215-support.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/01-add-ntag215-support.patch
@@ -1,6 +1,5 @@
-diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
---- rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py	2025-11-06 05:01:19.000000000 +0100
-+++ rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py	2025-12-01 23:11:18.401585041 +0100
+--- a/home/lava/klipper/klippy/extras/fm175xx_reader.py	2026-02-16 10:12:21.219599981 +0100
++++ b/home/lava/klipper/klippy/extras/fm175xx_reader.py	2026-02-16 10:18:59.102343533 +0100
 @@ -121,6 +121,14 @@
  # RFID card type
  FM175XX_MIFARE_CARD_TYPE_UNKNOWN        = 0xFF  # unknown type
@@ -16,7 +15,16 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
  
  # About M1 Card
  # EEPROM
-@@ -584,8 +592,22 @@
+@@ -579,7 +587,7 @@
+         cmd.bits_to_send = 7
+         cmd.bits_to_recv = 0
+         cmd.bytes_to_recv = 2
+-        cmd.timeout = 10
++        cmd.timeout = 50
+         cmd.cmd = FM175XX_CMD_TRANSCEIVE
+         result = self.__command_exe(cmd)
+         ret = result.err_code
+@@ -588,8 +596,22 @@
              if (result.out_param.bytes_recved == 2):
                  self.__picc_a.ATQA[0] = result.out_param.recv_buff[0]
                  self.__picc_a.ATQA[1] = result.out_param.recv_buff[1]
@@ -26,7 +34,7 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
 +        else:
 +            logging.info("Wakeup failed with error %d, trying REQA instead", ret)
 +            cmd.send_buff[0] = FM175XX_RF_CMD_REQA
-+            cmd.timeout = 10
++            cmd.timeout = 50
 +            result = self.__command_exe(cmd)
 +            ret = result.err_code
 +            if (result.err_code == FM175XX_OK):
@@ -39,7 +47,7 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
  
          return ret
  
-@@ -844,6 +866,60 @@
+@@ -850,6 +872,60 @@
  
          return ret
  
@@ -100,7 +108,18 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
      # Reader-A: M1, read all data
      def __reader_a_m1_read_all_data(self, uid:list, auth_mode:int, auth_key:list, retry_times = 3) -> Fm175xxReturnVal:
          ret = Fm175xxReturnVal()
-@@ -967,6 +1043,7 @@
+@@ -907,8 +983,8 @@
+                 self.__need_to_shutdown = False
+                 break
+ 
+-            retry_times_1 = 10
+-            retry_times_2 = 15
++            retry_times_1 = 5
++            retry_times_2 = 5
+             retry_times_3 = 10
+             if (self.__self_test_stage == FM175XX_SELF_TEST_STAGE_READY):
+                 self.__card_info_read_flag = (1 << self.__self_test_channel)
+@@ -975,6 +1051,7 @@
                          # M1 card
                          if (FM175XX_MIFARE_CARD_TYPE_M1 == self.__picc_a.SAK[0]):
                              card_type = FM175XX_MIFARE_CARD_TYPE_M1
@@ -108,7 +127,7 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
                              ret = self.__reader_a_m1_read_all_data(self.__picc_a.UID,
                                                                     FM175XX_M1_CARD_AUTH_MODE_A,
                                                                     self._hkdf_key_a,
-@@ -983,6 +1060,27 @@
+@@ -991,6 +1068,27 @@
                                      self.__self_test_success_cnt += 1
                                      if (self.__card_info_deal_cb != None):
                                          self.__card_info_deal_cb(ch, card_op, card_op_result, card_type, card_data)

--- a/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -30,10 +30,11 @@ def ndef_parse(data_buf):
     if None == data_buf or isinstance(data_buf, (list, bytes, bytearray)) == False:
         return NDEF_PARAMETER_ERR, [], []
 
+    card_uid = []
+
     try:
         data = bytes(data_buf) if isinstance(data_buf, list) else data_buf
 
-        card_uid = []
         if len(data) >= 8:
             card_uid = [data[0], data[1], data[2], data[4], data[5], data[6], data[7]]
 
@@ -128,7 +129,7 @@ def ndef_parse(data_buf):
 
     except Exception as e:
         logging.exception("NDEF parsing failed: %s", str(e))
-        return NDEF_ERR, [], []
+        return NDEF_ERR, [], card_uid
 
 def parse_color_hex(value):
     try:
@@ -237,12 +238,10 @@ def ndef_proto_data_parse(data_buf):
     error, records, card_uid = ndef_parse(data_buf)
 
     if error != NDEF_OK:
-        logging.error(f"NDEF parse failed: NDEF parsing error (code: {error})")
-        return filament_protocol.FILAMENT_PROTO_ERR, None
-
-    if not records:
-        logging.error("NDEF parse failed: No records found")
-        return filament_protocol.FILAMENT_PROTO_ERR, None
+        info = copy.copy(filament_protocol.FILAMENT_INFO_STRUCT)
+        info['CARD_UID'] = card_uid
+        logging.error(f"NDEF parse failed: NDEF parsing error (code: {error}). Treating as a generic tag. Card UID: {card_uid}")
+        return filament_protocol.FILAMENT_PROTO_OK, info
 
     for record in records:
         mime_type = record['mime_type']
@@ -261,8 +260,11 @@ def ndef_proto_data_parse(data_buf):
         else:
             logging.warning(f"Skipping unsupported MIME type '{mime_type}'")
 
-    logging.error("NDEF parse failed: No supported records found")
-    return filament_protocol.FILAMENT_PROTO_SIGN_CHECK_ERR, None
+    info = copy.copy(filament_protocol.FILAMENT_INFO_STRUCT)
+    info['CARD_UID'] = card_uid
+
+    logging.error(f"NDEF parse failed: No supported records found. Treating as a generic tag. Card UID: {card_uid}")
+    return filament_protocol.FILAMENT_PROTO_OK, info
 
 if __name__ == '__main__':
     import sys

--- a/overlays/firmware-extended/23-klipper-afc-lite/patches/03-add-spool-id-support.patch
+++ b/overlays/firmware-extended/23-klipper-afc-lite/patches/03-add-spool-id-support.patch
@@ -1,0 +1,57 @@
+--- a/home/lava/klipper/klippy/extras/print_task_config.py
++++ b/home/lava/klipper/klippy/extras/print_task_config.py
+@@ -24,6 +24,7 @@
+     'filament_edit': [True] * PHYSICAL_EXTRUDER_NUM,
+     'filament_exist': [False] * PHYSICAL_EXTRUDER_NUM,
+     'filament_soft': [False] * PHYSICAL_EXTRUDER_NUM,
++    'filament_spool_id': [0] * PHYSICAL_EXTRUDER_NUM,
+     'extruder_map_table': [i for i in range(PHYSICAL_EXTRUDER_NUM)] + [0] * (LOGICAL_EXTRUDER_NUM - PHYSICAL_EXTRUDER_NUM),
+     'extruders_used' : [False] * PHYSICAL_EXTRUDER_NUM,
+     'extruders_replenished': [i for i in range(PHYSICAL_EXTRUDER_NUM)],
+@@ -181,6 +182,7 @@
+         self.print_task_config['filament_color_rgba'][channel] = filament_color_rgba
+         self.print_task_config['filament_official'][channel] = info['OFFICIAL']
+         self.print_task_config['filament_sku'][channel] = info['SKU']
++        self.print_task_config['filament_spool_id'][channel] = info.get('SPOOL_ID', 0)
+         if self.filament_param_obj is not None:
+             self.print_task_config['filament_soft'][channel] = \
+                 self.filament_param_obj.get_is_soft(info['VENDOR'], info['MAIN_TYPE'], info['SUB_TYPE'])
+@@ -282,6 +284,8 @@
+             if self.print_task_config['filament_exist'][ch]:
+                 if self.print_task_config['filament_official'][ch] == True:
+                     allowd_edit = False
++                elif (self.print_task_config['filament_spool_id'][ch] or 0) > 0 and self.printer.lookup_object('webhooks').has_remote_method('spoolman_set_active_spool'):
++                    allowd_edit = False
+                 else:
+                     allowd_edit = True
+ 
+@@ -343,6 +347,8 @@
+         filament_sub_type = gcmd.get('FILAMENT_SUBTYPE', None)
+         filament_color = gcmd.get_int('FILAMENT_COLOR', None)
+         filament_color_rgba = gcmd.get('FILAMENT_COLOR_RGBA', None)
++        filament_spool_id = gcmd.get_int('FILAMENT_SPOOL_ID', None)
++        force = gcmd.get_int('FORCE', 0)
+         logging.info("[print_task_config] PRINT_FILAMENT_CONFIG %s",
+                         gcmd.get_raw_command_parameters())
+
+@@ -359,8 +365,10 @@
+         if config_extruder < 0 or config_extruder >= PHYSICAL_EXTRUDER_NUM:
+             raise gcmd.error("[print_task_config] extruder{} is out of range[0, {}]".format(config_extruder, PHYSICAL_EXTRUDER_NUM -1))
+ 
+-        if self.print_task_config['filament_official'][config_extruder]:
+-            raise gcmd.error("[print_task_config] filament_config, official filament, not configurable!")
++        if self.print_task_config['filament_official'][config_extruder] and not force:
++            raise gcmd.error("[print_task_config] filament_config, official filament, use FORCE=1 to overwrite")
++        if (self.print_task_config['filament_spool_id'][config_extruder] or 0) > 0 and not force and filament_spool_id == None and self.printer.lookup_object('webhooks').has_remote_method('spoolman_set_active_spool'):
++            raise gcmd.error("[print_task_config] filament_spool_id, is configured, use FORCE=1 to overwrite")
+
+         if filament_type is not None:
+             self.print_task_config['filament_vendor'][config_extruder] = filament_vendor
+@@ -403,6 +411,7 @@
+ 
+         self.print_task_config['filament_official'][config_extruder] = False
+         self.print_task_config['filament_sku'][config_extruder] = 0
++        self.print_task_config['filament_spool_id'][config_extruder] = filament_spool_id or 0
+ 
+         if not self.printer.update_snapmaker_config_file(self.config_path,
+                 self.print_task_config, DEFAULT_PRINT_TASK_CONFIG):

--- a/overlays/firmware-extended/23-klipper-afc-lite/patches/03-add-spoolman-proxy-to-moonraker.patch
+++ b/overlays/firmware-extended/23-klipper-afc-lite/patches/03-add-spoolman-proxy-to-moonraker.patch
@@ -1,0 +1,58 @@
+#
+# Author: @unlucio
+# Source: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/163
+#
+--- rootfs.original/home/lava//moonraker/moonraker/components/spoolman.py	2025-12-30 05:40:53
++++ rootfs/home/lava//moonraker/moonraker/components/spoolman.py	2026-01-15 02:15:08
+@@ -5,7 +5,7 @@
+ # This file may be distributed under the terms of the GNU GPLv3 license.
+ 
+ from __future__ import annotations
+-import asyncio
++import asyncio, json
+ import logging
+ import re
+ import contextlib
+@@ -69,8 +69,42 @@
+         self._register_endpoints()
+         self.server.register_remote_method(
+             "spoolman_set_active_spool", self.set_active_spool
++        )
++
++
++        self.server.register_remote_method(
++            "spoolman_proxy", self.rpc_spoolman_proxy
++        )
++
++    async def rpc_spoolman_proxy(self, cb_endpoint, request_method, path, query=None, body=None):
++        query_str = f"?{query}" if query else ""
++        full_url = f"{self.spoolman_url}{path}{query_str}"
++
++        logging.info(f"Spoolman proxy: {full_url}")
++
++        response = await self.http_client.request(
++            method=request_method,
++            url=full_url,
++            body=body
+         )
+ 
++        if response.has_error():
++            payload = None
++            error = {"status_code": response.status_code, "message": str(response.error)}
++            logging.info(f"Spoolman proxy: error {json.dumps(error)}")
++        else:
++            payload = response.json()
++            logging.info(f"Spoolman proxy: payload {json.dumps(payload)}")
++            error = None
++
++        await self.klippy_apis._send_klippy_request(
++            cb_endpoint,
++            {"payload": payload, "error": error},
++            default=None
++        )
++
++        return None
++
+     def _get_spoolman_urls(self, config: ConfigHelper) -> None:
+         orig_url = config.get('server')
+         url_match = re.match(r"(?i:(?P<scheme>https?)://)?(?P<host>.+)", orig_url)

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC.py
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC.py
@@ -10,6 +10,7 @@ class AFC:
         self.printer = config.get_printer()
         config.get("enabled", "True")
         self.gcode = self.printer.lookup_object("gcode")
+        self.webhooks = self.printer.lookup_object('webhooks')
 
         self.units = {}
         self.lanes = {}
@@ -44,7 +45,7 @@ class AFC:
         str['current_state'] = AFCState.IDLE
         str["current_toolchange"] = 0
         str["number_of_toolchanges"] = 0
-        str['spoolman'] = True
+        str['spoolman'] = self.webhooks.has_remote_method('spoolman_set_active_spool')
         str["td1_present"] = False
         str["lane_data_enabled"] = False
         str['error_state'] = False

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -54,10 +54,12 @@ class AFCLane:
         state = {
             'loaded': False,
             'tool_loaded': False,
-            'vendor': 'NONE',
-            'type': 'NONE',
-            'subtype': 'NONE',
-            'color': 'FFFFFFFF',
+            'spool': {
+                'vendor': 'NONE',
+                'type': 'NONE',
+                'subtype': 'NONE',
+                'color': 'FFFFFFFF'
+            },
             'map': f"T{self.lane_index}",
             'runout_lane': 'NONE',
         }
@@ -65,12 +67,14 @@ class AFCLane:
         try:
             status = self.print_task_config.get_status(eventtime)
             state['loaded'] = dict(enumerate(status.get('filament_exist', []))).get(self.lane_index, False)
-            state['vendor'] = dict(enumerate(status.get('filament_vendor', []))).get(self.lane_index, 'NONE')
-            state['type'] = dict(enumerate(status.get('filament_type', []))).get(self.lane_index, 'NONE')
-            state['subtype'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.lane_index, 'NONE')
-            state['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.lane_index, 'FFFFFFFF')
             if status.get('auto_replenish_filament', False):
                 state['runout_lane'] = 'AUTO'
+
+            spool = state['spool']
+            spool['vendor'] = dict(enumerate(status.get('filament_vendor', []))).get(self.lane_index, 'NONE')
+            spool['type'] = dict(enumerate(status.get('filament_type', []))).get(self.lane_index, 'NONE')
+            spool['subtype'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.lane_index, 'NONE')
+            spool['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.lane_index, 'FFFFFFFF')
 
             tool_to_extruder = dict(enumerate(status.get('extruder_map_table', [])))
             for tool_idx, extruder_idx in tool_to_extruder.items():
@@ -93,6 +97,7 @@ class AFCLane:
         response = {}
 
         state = self._get_state(eventtime)
+        spool = state.get('spool', {})
 
         response['name'] = self.name
         response['unit'] = self.unit_name
@@ -103,10 +108,10 @@ class AFCLane:
         response['prep'] = state.get('loaded', False)
         response['tool_loaded'] = state.get('tool_loaded', response['load'])
         response['loaded_to_hub'] = False
-        response['material'] = state.get('type', 'NONE')
-        response['spool_id'] = None
-        response['color'] = f"#{state.get('color', 'FFFFFFFF')[:6]}" # RGB only, ignore alpha
-        response['weight'] = 1000 # AFC doesn't track weight
+        response['material'] = spool.get('type', 'NONE')
+        response['spool_id'] = 0
+        response['color'] = f"#{spool.get('color', 'FFFFFFFF')[:6]}" # RGB only, ignore alpha
+        response['weight'] = 1000
         response['runout_lane'] = state.get('runout_lane', '?')
         response['filament_status'] = 'unknown'
         response['filament_status_led'] = 'gray'

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -5,6 +5,7 @@ import copy
 from . import filament_protocol
 
 SPOOLMAN_PROXY_ENDPOINT_BASE = "klippy/spoolman_proxy"
+FILAMENT_INFO_DIR = "/oem/printer_data/config/extended/rfid"
 
 class AFCLaneState:
     EMPTY = "empty"
@@ -30,11 +31,15 @@ class AFCLane:
         self.print_task_config = None
         self.toolhead_sensor = None
         self.filament_feed = None
+        self.filament_detect = None
 
         self.pending_refresh = False
         self.pending_spool_id = None
 
         self.cached_spool_weight = 1000
+
+        self.last_rfid_uid = None
+        self.last_state = {}
 
         self.printer.register_event_handler("klippy:connect", self._handle_connect)
 
@@ -56,6 +61,11 @@ class AFCLane:
     def _handle_connect(self):
         try:
             self.print_task_config = self.printer.lookup_object("print_task_config")
+        except:
+            pass
+
+        try:
+            self.filament_detect = self.printer.lookup_object("filament_detect")
         except:
             pass
 
@@ -105,6 +115,60 @@ class AFCLane:
         except Exception as e:
             logging.error(f"Failed to clear spool data: {e}")
             return False
+
+    def _rfid_uid(self, state):
+        try:
+            if not state.get('loaded', True):
+                return None
+            card_uid = state.get('detect', {}).get('CARD_UID', None)
+            if not card_uid:
+                return None
+            filename = ''.join(f"{byte:02X}" for byte in card_uid)
+            return filename
+        except:
+            return None
+
+    def _load_rfid_state(self, filename):
+        try:
+            if not filename:
+                return None
+            filepath = f"{FILAMENT_INFO_DIR}/{filename}.json"
+            if os.path.exists(filepath):
+                with open(filepath, 'r') as f:
+                    return json.load(f)
+        except:
+            pass
+        return None
+
+    def _save_rfid_state(self, filename, spool):
+        try:
+            if not filename:
+                return False
+
+            filepath = f"{FILAMENT_INFO_DIR}/{filename}.json"
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+            with open(filepath, 'w') as f:
+                json.dump(spool, f, indent=2)
+
+            self.gcode.respond_info(f"Persisted RFID state for lane {self.name}, card UID {filename}")
+            return True
+        except Exception as e:
+            logging.error(f"Failed to persist RFID state for lane {self.name}, card UID {filename}: {e}")
+            return False
+
+    def _apply_rfid_state(self, filename, spool):
+        spool_id = spool.get('spool_id', 0)
+
+        self._set_filament_config(
+            vendor=spool.get('vendor', 'NONE'),
+            type=spool.get('type', 'NONE'),
+            sub_type=spool.get('subtype', 'NONE'),
+            color=spool.get('color', 'FFFFFFFF'),
+            spool_id=spool_id
+        )
+
+        self.gcode.respond_info(f"Restored RFID state for lane {self.name}, card UID {filename}, spool ID {spool_id}")
+        self._refresh_spool(spool_id)
 
     cmd_SET_SPOOL_ID_help = "Set spool ID and fetch filament data from Spoolman"
     def cmd_SET_SPOOL_ID(self, gcmd):
@@ -248,6 +312,12 @@ class AFCLane:
             pass
 
         try:
+            detect_status = self.filament_detect.get_status()
+            state['detect'] = dict(enumerate(detect_status.get('info', []))).get(self.lane_index, False)
+        except:
+            state['detect'] = {}
+
+        try:
             status = self.toolhead_sensor.get_status(eventtime)
             state['tool_loaded'] = status.get('filament_detected', True)
         except:
@@ -255,10 +325,34 @@ class AFCLane:
 
         return state
 
+    def _get_and_update_state(self, eventtime=None):
+        state = self._get_state(eventtime)
+        rfid_uid = self._rfid_uid(state)
+
+        # Ignore all RFID codepaths if not RFID is detected
+        if not rfid_uid:
+            self.last_state = {}
+            self.last_rfid_uid = None
+            return state
+
+        if rfid_uid != self.last_rfid_uid:
+            spool = self._load_rfid_state(rfid_uid)
+            if spool:
+                self._apply_rfid_state(rfid_uid, spool)
+                state = self._get_state(eventtime)
+        else:
+            spool = state.get('spool', {})
+            if spool != self.last_state.get('spool', {}):
+                self._save_rfid_state(rfid_uid, spool)
+
+        self.last_rfid_uid = rfid_uid
+        self.last_state = state
+        return state
+
     def get_status(self, eventtime=None):
         response = {}
 
-        state = self._get_state(eventtime)
+        state = self._get_and_update_state(eventtime)
         spool = state.get('spool', {})
 
         response['name'] = self.name

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -1,6 +1,10 @@
 import json
 import logging
 import os
+import copy
+from . import filament_protocol
+
+SPOOLMAN_PROXY_ENDPOINT_BASE = "klippy/spoolman_proxy"
 
 class AFCLaneState:
     EMPTY = "empty"
@@ -14,6 +18,7 @@ class AFCLane:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
+        self.webhooks = self.printer.lookup_object('webhooks')
         self.name = config.get_name().replace("AFC_lane ", "", 1)
 
         self.unit_name = config.get("unit", "")
@@ -26,7 +31,27 @@ class AFCLane:
         self.toolhead_sensor = None
         self.filament_feed = None
 
+        self.pending_refresh = False
+        self.pending_spool_id = None
+
+        self.cached_spool_weight = 1000
+
         self.printer.register_event_handler("klippy:connect", self._handle_connect)
+
+        self.gcode.register_mux_command(
+            "SET_SPOOL_ID", "LANE", self.name,
+            self.cmd_SET_SPOOL_ID,
+            desc=self.cmd_SET_SPOOL_ID_help)
+
+        self.gcode.register_mux_command(
+            "REFRESH_SPOOL", "LANE", self.name,
+            self.cmd_REFRESH_SPOOL,
+            desc=self.cmd_REFRESH_SPOOL_help)
+
+        self.find_by_spool_id_callback = f"{SPOOLMAN_PROXY_ENDPOINT_BASE}/find_by_spool_id/{config.get_name()}"
+        self.webhooks.register_endpoint(
+            self.find_by_spool_id_callback,
+            self._handle_find_by_spool_id_callback)
 
     def _handle_connect(self):
         try:
@@ -46,6 +71,141 @@ class AFCLane:
             except:
                 pass
 
+    def _set_filament_config(self, vendor='NONE', type='NONE', sub_type='NONE', color='FFFFFFFF', official=False, spool_id=0, weight=1000):
+        try:
+            info = copy.deepcopy(filament_protocol.FILAMENT_INFO_STRUCT)
+            if vendor:
+                info['VENDOR'] = vendor
+            if type:
+                info['MAIN_TYPE'] = type
+            if sub_type:
+                info['SUB_TYPE'] = sub_type
+            if color:
+                info['COLOR_NUMS'] = 1
+                info['RGB_1'] = int(color[:6], 16)
+                info['ALPHA'] = int(color[6:8] or 'FF', 16)
+                info['ARGB_COLOR'] = info['ALPHA'] << 24 | info['RGB_1']
+            info['SPOOL_ID'] = spool_id
+            info['OFFICIAL'] = spool_id not in (None, 0) or official
+            logging.info(f"Setting filament config for lane {self.name}: {info}")
+            self.print_task_config._rfid_filament_info_update_cb(self.lane_index, info, is_clear=True)
+            self.cached_spool_weight = weight
+            return True
+        except Exception as e:
+            logging.error(f"Failed to set filament config: {e}")
+            return False
+
+    def _clear_filament_config(self):
+        try:
+            info = copy.deepcopy(filament_protocol.FILAMENT_INFO_STRUCT)
+            logging.info(f"Clearing filament config for lane {self.name}")
+            self.print_task_config._rfid_filament_info_update_cb(self.lane_index, info, is_clear=True)
+            self.cached_spool_weight = -1
+            return True
+        except Exception as e:
+            logging.error(f"Failed to clear spool data: {e}")
+            return False
+
+    cmd_SET_SPOOL_ID_help = "Set spool ID and fetch filament data from Spoolman"
+    def cmd_SET_SPOOL_ID(self, gcmd):
+        """Set spool ID and fetch filament info from spoolman"""
+        spool_id = gcmd.get_int('SPOOL_ID', 0)
+
+        if not spool_id:
+            gcmd.respond_info(f"Clearing spool data for lane {self.name}")
+            reactor = self.printer.get_reactor()
+            reactor.register_callback(lambda et: self._clear_filament_config())
+            return
+
+        self.pending_refresh = False
+        self.pending_spool_id = spool_id
+
+        gcmd.respond_info(f"Fetching spool {spool_id} data for lane {self.name}...")
+
+        try:
+            self.webhooks.call_remote_method(
+                "spoolman_proxy",
+                cb_endpoint=self.find_by_spool_id_callback,
+                request_method="GET",
+                path=f"/v1/spool/{spool_id}"
+            )
+        except Exception as e:
+            logging.error(f"Failed to query spoolman: {e}")
+
+    def _refresh_spool(self, spool_id):
+        if not spool_id:
+            return
+        if not self.webhooks.has_remote_method('spoolman_proxy'):
+            return
+
+        try:
+            self.pending_refresh = True
+            self.pending_spool_id = spool_id
+            self.webhooks.call_remote_method(
+                "spoolman_proxy",
+                cb_endpoint=self.find_by_spool_id_callback,
+                request_method="GET",
+                path=f"/v1/spool/{spool_id}"
+            )
+        except Exception as e:
+            logging.error(f"Failed to query spoolman: {e}")
+
+    cmd_REFRESH_SPOOL_help = "Refresh current spool data from Spoolman"
+    def cmd_REFRESH_SPOOL(self, gcmd):
+        state = self._get_state()
+        spool_id = state.get('spool', {}).get('spool_id', 0)
+        if not spool_id:
+            gcmd.respond_info(f"No spool configured for lane {self.name}")
+            return
+
+        self._refresh_spool(spool_id)
+
+    def _handle_find_by_spool_id_callback(self, web_request):
+        try:
+            payload = web_request.get_dict('payload', {})
+            error = web_request.get('error', None)
+
+            if error:
+                logging.error(f"Spoolman error: {error}")
+                return
+
+            self._apply_spool_data_from_webhook(payload)
+        except Exception as e:
+            raise web_request.error(f"Failed to process spoolman response: {e}")
+
+    def _apply_spool_data_from_webhook(self, response):
+        """Apply spool data from spoolman response via webhook"""
+        if not response:
+            self.gcode.respond_info("Empty response from spoolman")
+            return
+
+        spool_id = response.get('id', 0)
+        filament = response.get('filament', {})
+        material = filament.get('material', 'PLA')
+        vendor = filament.get('vendor', {}).get('name', 'Generic')
+        color_hex = filament.get('color_hex', 'FFFFFFFF')
+        sub_type = filament.get('extra', {}).get('sub_type', 'Basic')
+        weight = response.get('remaining_weight', -1)
+
+        if self.pending_spool_id != spool_id:
+            self.gcode.respond_info(f"Spool ID mismatch for lane {self.name}: expected {self.pending_spool_id}, got {spool_id}")
+            return
+
+        if self.pending_refresh:
+            self.pending_refresh = False
+            self.cached_spool_weight = weight
+            return
+
+        self._set_filament_config(
+            vendor=vendor,
+            type=material,
+            sub_type=sub_type,
+            color=color_hex,
+            spool_id=spool_id,
+            weight=weight,
+            official=True
+        )
+
     def _get_state(self, eventtime=None):
         """Get filament info from print_task_config based on lane index"""
         if not self.print_task_config:
@@ -58,7 +218,8 @@ class AFCLane:
                 'vendor': 'NONE',
                 'type': 'NONE',
                 'subtype': 'NONE',
-                'color': 'FFFFFFFF'
+                'color': 'FFFFFFFF',
+                'spool_id': 0,
             },
             'map': f"T{self.lane_index}",
             'runout_lane': 'NONE',
@@ -75,6 +236,7 @@ class AFCLane:
             spool['type'] = dict(enumerate(status.get('filament_type', []))).get(self.lane_index, 'NONE')
             spool['subtype'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.lane_index, 'NONE')
             spool['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.lane_index, 'FFFFFFFF')
+            spool['spool_id'] = dict(enumerate(status.get('filament_spool_id', []))).get(self.lane_index, 0)
 
             tool_to_extruder = dict(enumerate(status.get('extruder_map_table', [])))
             for tool_idx, extruder_idx in tool_to_extruder.items():
@@ -109,9 +271,9 @@ class AFCLane:
         response['tool_loaded'] = state.get('tool_loaded', response['load'])
         response['loaded_to_hub'] = False
         response['material'] = spool.get('type', 'NONE')
-        response['spool_id'] = 0
+        response['spool_id'] = spool.get('spool_id', 0) or 0
         response['color'] = f"#{spool.get('color', 'FFFFFFFF')[:6]}" # RGB only, ignore alpha
-        response['weight'] = 1000
+        response['weight'] = self.cached_spool_weight if response['spool_id'] > 0 else 1000
         response['runout_lane'] = state.get('runout_lane', '?')
         response['filament_status'] = 'unknown'
         response['filament_status_led'] = 'gray'

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -105,3 +105,27 @@ gcode:
     M118 Unloading {lane} (lane {index})...
     AUTO_FEEDING EXTRUDER={index} UNLOAD=1
     M118 Unload {lane} complete
+
+[gcode_macro _AFC_SPOOLMAN_UPDATE]
+variable_last_spool_id: -1
+gcode:
+    {% set current_lane = printer.AFC.current_lane %}
+    {% set spool_id = 0 %}
+    {% if current_lane %}
+        {% set lane = printer['AFC_lane ' ~ current_lane] %}
+        {% set spool_id = lane.spool_id|default(0) %}
+    {% endif %}
+
+    {% if not printer.AFC.spoolman %}
+        SET_GCODE_VARIABLE MACRO=_AFC_SPOOLMAN_UPDATE VARIABLE=last_spool_id VALUE=-1
+    {% elif spool_id != last_spool_id %}
+        # TODO: Track whether the `spoolman_set_active_spool` was run
+        {action_call_remote_method("spoolman_set_active_spool", spool_id=spool_id)}
+        SET_GCODE_VARIABLE MACRO=_AFC_SPOOLMAN_UPDATE VARIABLE=last_spool_id VALUE={spool_id}
+    {% endif %}
+
+[delayed_gcode _AFC_SPOOLMAN_MONITOR]
+initial_duration: 1.0
+gcode:
+    _AFC_SPOOLMAN_UPDATE
+    UPDATE_DELAYED_GCODE ID=_AFC_SPOOLMAN_MONITOR DURATION=1.0

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -71,10 +71,6 @@ gcode:
     SET_PRINT_EXTRUDER_MAP CONFIG_EXTRUDER='{new_logical}' MAP_EXTRUDER='{index}'
     SET_PRINT_EXTRUDER_MAP CONFIG_EXTRUDER='{current_logical}' MAP_EXTRUDER='{old_channel}'
 
-[gcode_macro SET_SPOOL_ID]
-gcode:
-    { action_raise_error("SET_SPOOL_ID is not supported.") }
-
 [gcode_macro SET_WEIGHT]
 gcode:
     { action_raise_error("SET_WEIGHT is not supported.") }
@@ -129,3 +125,14 @@ initial_duration: 1.0
 gcode:
     _AFC_SPOOLMAN_UPDATE
     UPDATE_DELAYED_GCODE ID=_AFC_SPOOLMAN_MONITOR DURATION=1.0
+
+[delayed_gcode _AFC_REFRESH_ALL_SPOOLS]
+initial_duration: 15.0
+gcode:
+    {% for lane_name in ['E0', 'E1', 'E2', 'E3'] %}
+        {% set lane = printer['AFC_lane ' ~ lane_name] %}
+        {% if lane.spool_id %}
+            REFRESH_SPOOL LANE={lane_name}
+        {% endif %}
+    {% endfor %}
+    UPDATE_DELAYED_GCODE ID=_AFC_REFRESH_ALL_SPOOLS DURATION=15.0

--- a/overlays/firmware-extended/23-klipper-afc-lite/test/spoolman.sh
+++ b/overlays/firmware-extended/23-klipper-afc-lite/test/spoolman.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <url> <method> <path> [key=value ...]"
+    echo ""
+    echo "Arguments:"
+    echo "  url     Spoolman base URL (e.g., http://localhost:7912)"
+    echo "  method  HTTP method: GET, POST, PATCH"
+    echo "  path    API path (e.g., spool/1)"
+    echo "  args    Key=value pairs (query params for GET, JSON for POST/PATCH)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 http://localhost:7912 GET spool/1"
+    echo "  $0 http://localhost:7912 POST spool filament_id=1 remaining_weight=800"
+    echo "  $0 http://localhost:7912 PATCH spool/1 remaining_weight=750"
+    exit 1
+}
+
+build_query() {
+    local query=""
+    for arg in "$@"; do
+        key="${arg%%=*}"
+        value="${arg#*=}"
+        value=$(printf '%s' "$value" | jq -sRr @uri)
+        if [[ -z "$query" ]]; then
+            query="?${key}=${value}"
+        else
+            query="${query}&${key}=${value}"
+        fi
+    done
+    echo "$query"
+}
+
+build_json() {
+    local json="{}"
+    for arg in "$@"; do
+        key="${arg%%=*}"
+        value="${arg#*=}"
+        if [[ "$value" =~ ^[0-9]+$ ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" == "true" || "$value" == "false" ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" == "null" ]]; then
+            json=$(echo "$json" | jq --arg k "$key" '. + {($k): null}')
+        else
+            json=$(echo "$json" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}')
+        fi
+    done
+    echo "$json"
+}
+
+if [[ $# -lt 3 ]]; then
+    usage
+fi
+
+url="$1"
+method="$2"
+path="$3"
+shift 3
+
+endpoint="${url}/api/v1/${path}"
+
+case "${method^^}" in
+    GET)
+        query=$(build_query "$@")
+        echo ">> GET ${endpoint}${query}"
+        curl -s -X GET "${endpoint}${query}" | jq
+        ;;
+    POST|PATCH)
+        json=$(build_json "$@")
+        echo ">> ${method^^} $endpoint"
+        curl -s -X "${method^^}" -H "Content-Type: application/json" -d "$json" "$endpoint" | jq
+        ;;
+    *)
+        echo "Error: Unsupported method '$method'. Use GET, POST, or PATCH."
+        exit 1
+        ;;
+esac

--- a/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/extended/moonraker/spoolman.cfg
+++ b/overlays/firmware-extended/23-klipper-afc-module/root/usr/local/share/firmware-config/extended/moonraker/spoolman.cfg
@@ -1,0 +1,7 @@
+# Spoolman Integration
+# Uncomment and configure the following section to enable Spoolman support.
+# See: https://moonraker.readthedocs.io/en/latest/configuration/#spoolman
+
+#[spoolman]
+#server: http://localhost:7912
+#sync_rate: 5


### PR DESCRIPTION
Enables persistent filament configuration for any generic NFC/RFID tag. User-provided data (`vendor`, `type`, `color`, `spool_id`) automatically saved to JSON files keyed by tag UID and restored on next detection.

**Workflow Change**: Users no longer program tags via external applications. Instead, configure the printer - it remembers settings and retains assigned `spool_id` for each tag.

**No Tag Writing**: Tags are not written. Printer persists the association in `extended/rfid` directory as JSON files.

## Comparison to `afc-spool_id-spoolman`

| Feature | This PR (auto-spool-mapping) | afc-spool_id-spoolman |
|---------|------------------------------|------------------------|
| **Primary Purpose** | Generic RFID tag persistence | Spoolman integration |
| **RFID Persistence** | ✅ ANY generic tag stores/restores state | ❌ No persistence |
| **Generic Tag Support** | ✅ Blank tags, hotel cards, any NFC tag | ❌ Requires specific format |

**Key Difference**: This PR's focus is making generic tags useful for persistent filament tracking. Works completely independently of Spoolman.

## Configuration

No configuration required. Generic RFID tag persistence works out of the box.

### Optional: Spoolman Integration

If you want to use Spoolman to populate filament data, add to `moonraker.conf`:
```ini
[spoolman]
server: http://spoolman:7912
```

Then use `SET_SPOOL_ID LANE=<lane> SPOOL_ID=<id>` to fetch data from Spoolman.
