### PR TITLE
Improve RFID tag discovery reliability

### DIFF
--- a/overlays/firmware-extended/13-rfid-support/patches/01-add-ntag215-support.patch
+++ b/overlays/firmware-extended/13-rfid-support/patches/01-add-ntag215-support.patch
@@ -1,6 +1,5 @@
-diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
---- rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py	2025-11-06 05:01:19.000000000 +0100
-+++ rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py	2025-12-01 23:11:18.401585041 +0100
+--- a/home/lava/klipper/klippy/extras/fm175xx_reader.py	2026-02-16 10:12:21.219599981 +0100
++++ b/home/lava/klipper/klippy/extras/fm175xx_reader.py	2026-02-16 10:18:59.102343533 +0100
 @@ -121,6 +121,14 @@
  # RFID card type
  FM175XX_MIFARE_CARD_TYPE_UNKNOWN        = 0xFF  # unknown type
@@ -16,7 +15,16 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
  
  # About M1 Card
  # EEPROM
-@@ -584,8 +592,22 @@
+@@ -579,7 +587,7 @@
+         cmd.bits_to_send = 7
+         cmd.bits_to_recv = 0
+         cmd.bytes_to_recv = 2
+-        cmd.timeout = 10
++        cmd.timeout = 50
+         cmd.cmd = FM175XX_CMD_TRANSCEIVE
+         result = self.__command_exe(cmd)
+         ret = result.err_code
+@@ -588,8 +596,22 @@
              if (result.out_param.bytes_recved == 2):
                  self.__picc_a.ATQA[0] = result.out_param.recv_buff[0]
                  self.__picc_a.ATQA[1] = result.out_param.recv_buff[1]
@@ -26,7 +34,7 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
 +        else:
 +            logging.info("Wakeup failed with error %d, trying REQA instead", ret)
 +            cmd.send_buff[0] = FM175XX_RF_CMD_REQA
-+            cmd.timeout = 10
++            cmd.timeout = 50
 +            result = self.__command_exe(cmd)
 +            ret = result.err_code
 +            if (result.err_code == FM175XX_OK):
@@ -39,7 +47,7 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
  
          return ret
  
-@@ -844,6 +866,60 @@
+@@ -850,6 +872,60 @@
  
          return ret
  
@@ -100,7 +108,18 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
      # Reader-A: M1, read all data
      def __reader_a_m1_read_all_data(self, uid:list, auth_mode:int, auth_key:list, retry_times = 3) -> Fm175xxReturnVal:
          ret = Fm175xxReturnVal()
-@@ -967,6 +1043,7 @@
+@@ -907,8 +983,8 @@
+                 self.__need_to_shutdown = False
+                 break
+ 
+-            retry_times_1 = 10
+-            retry_times_2 = 15
++            retry_times_1 = 5
++            retry_times_2 = 5
+             retry_times_3 = 10
+             if (self.__self_test_stage == FM175XX_SELF_TEST_STAGE_READY):
+                 self.__card_info_read_flag = (1 << self.__self_test_channel)
+@@ -975,6 +1051,7 @@
                          # M1 card
                          if (FM175XX_MIFARE_CARD_TYPE_M1 == self.__picc_a.SAK[0]):
                              card_type = FM175XX_MIFARE_CARD_TYPE_M1
@@ -108,7 +127,7 @@ diff -uNr rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py root
                              ret = self.__reader_a_m1_read_all_data(self.__picc_a.UID,
                                                                     FM175XX_M1_CARD_AUTH_MODE_A,
                                                                     self._hkdf_key_a,
-@@ -983,6 +1060,27 @@
+@@ -991,6 +1068,27 @@
                                      self.__self_test_success_cnt += 1
                                      if (self.__card_info_deal_cb != None):
                                          self.__card_info_deal_cb(ch, card_op, card_op_result, card_type, card_data)

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -54,10 +54,12 @@ class AFCLane:
         state = {
             'loaded': False,
             'tool_loaded': False,
-            'vendor': 'NONE',
-            'type': 'NONE',
-            'subtype': 'NONE',
-            'color': 'FFFFFFFF',
+            'spool': {
+                'vendor': 'NONE',
+                'type': 'NONE',
+                'subtype': 'NONE',
+                'color': 'FFFFFFFF'
+            },
             'map': f"T{self.lane_index}",
             'runout_lane': 'NONE',
         }
@@ -65,12 +67,14 @@ class AFCLane:
         try:
             status = self.print_task_config.get_status(eventtime)
             state['loaded'] = dict(enumerate(status.get('filament_exist', []))).get(self.lane_index, False)
-            state['vendor'] = dict(enumerate(status.get('filament_vendor', []))).get(self.lane_index, 'NONE')
-            state['type'] = dict(enumerate(status.get('filament_type', []))).get(self.lane_index, 'NONE')
-            state['subtype'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.lane_index, 'NONE')
-            state['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.lane_index, 'FFFFFFFF')
             if status.get('auto_replenish_filament', False):
                 state['runout_lane'] = 'AUTO'
+
+            spool = state['spool']
+            spool['vendor'] = dict(enumerate(status.get('filament_vendor', []))).get(self.lane_index, 'NONE')
+            spool['type'] = dict(enumerate(status.get('filament_type', []))).get(self.lane_index, 'NONE')
+            spool['subtype'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.lane_index, 'NONE')
+            spool['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.lane_index, 'FFFFFFFF')
 
             tool_to_extruder = dict(enumerate(status.get('extruder_map_table', [])))
             for tool_idx, extruder_idx in tool_to_extruder.items():
@@ -93,6 +97,7 @@ class AFCLane:
         response = {}
 
         state = self._get_state(eventtime)
+        spool = state.get('spool', {})
 
         response['name'] = self.name
         response['unit'] = self.unit_name
@@ -103,10 +108,10 @@ class AFCLane:
         response['prep'] = state.get('loaded', False)
         response['tool_loaded'] = state.get('tool_loaded', response['load'])
         response['loaded_to_hub'] = False
-        response['material'] = state.get('type', 'NONE')
-        response['spool_id'] = None
-        response['color'] = f"#{state.get('color', 'FFFFFFFF')[:6]}" # RGB only, ignore alpha
-        response['weight'] = 1000 # AFC doesn't track weight
+        response['material'] = spool.get('type', 'NONE')
+        response['spool_id'] = 0
+        response['color'] = f"#{spool.get('color', 'FFFFFFFF')[:6]}" # RGB only, ignore alpha
+        response['weight'] = 1000
         response['runout_lane'] = state.get('runout_lane', '?')
         response['filament_status'] = 'unknown'
         response['filament_status_led'] = 'gray'


### PR DESCRIPTION
Increase timeout from 10ms to 50ms in REQA/WUPA commands to allow more time for NTAG215 tags to respond.
Reduce retry attempts from 10/15 to 5/5 to optimize discovery speed.
