### PR TITLE
Improve `firmware-config` to include fields description

### DIFF
--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/bin/firmware-config.py
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/bin/firmware-config.py
@@ -305,6 +305,8 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
                     settings_list.append({
                         "id": setting_id,
                         "label": config["label"],
+                        "description": config.get("description"),
+                        "help_url": config.get("help_url"),
                         "current": current_value,
                         "options": options_data
                     })
@@ -389,6 +391,8 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
                     actions_list.append({
                         "id": action_id,
                         "label": cfg.get("label", action_id),
+                        "description": cfg.get("description"),
+                        "help_url": cfg.get("help_url"),
                         "confirm": cfg.get("confirm", False),
                         "background": cfg.get("background", False),
                         "download_file": cfg.get("download_file")

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
@@ -1,0 +1,11 @@
+settings:
+  web:
+    label: Web
+  camera:
+    label: Camera
+  remote_access:
+    label: Remote Access
+  tweaks:
+    label: Tweaks
+  monitoring_debugging:
+    label: Monitoring & Debugging

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
@@ -1,0 +1,9 @@
+actions:
+  troubleshooting:
+    label: Troubleshooting
+  recovery:
+    label: Recovery
+  services:
+    label: Services
+  system:
+    label: System

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/12_settings_firmware_config.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/12_settings_firmware_config.yaml
@@ -1,9 +1,9 @@
 settings:
   web:
-    label: Web
     items:
       firmware-config:
         label: Firmware Config
+        description: Enable or disable this web configuration interface.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
@@ -1,9 +1,9 @@
 settings:
   remote_access:
-    label: Remote Access
     items:
       authorization:
         label: Web Authentication (Experimental)
+        description: Password-protect access to Fluidd and Firmware Config via Moonraker authentication.
         get_cmd:
           - bash
           - -c

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
@@ -1,9 +1,9 @@
 actions:
   troubleshooting:
-    label: Troubleshooting
     items:
       show-status:
         label: Show MCUs Version
+        description: Display firmware version of all connected MCUs.
         cmd:
           - /home/lava/bin/systemUpgrade.sh
           - show-status
@@ -12,7 +12,8 @@ actions:
 
       collect-logs:
         label: Collect System Logs
-        confirm: "Collecting system logs might take a few minutes. Do not close the window until done. Continue?"
+        description: Bundle and download a system log archive for troubleshooting.
+        confirm: "Collecting system logs might take a few minutes. These logs contain sensitive information like the serial number and Wi-Fi SSID, and should not be shared publicly. Continue?"
         cmd:
           - /home/lava/bin/sysinfoCollection.sh
           - "no"
@@ -21,10 +22,10 @@ actions:
         download_file: /userdata/logs.tar.gz
 
   recovery:
-    label: Recovery
     items:
       reset-extended-to-defaults:
         label: Reset Extended to Defaults
+        description: Clear all extended settings and reboot to a clean state.
         confirm: "Reset all extended settings to defaults and reboot?"
         background: true
         cmd:
@@ -38,6 +39,7 @@ actions:
 
       reset-to-backup-firmware:
         label: Reset Extended to Backup Firmware
+        description: Clear all extended settings, switch to the backup firmware slot, and reboot.
         confirm: "Reset all extended settings to defaults, switch to backup firmware and reboot?"
         background: true
         cmd:
@@ -51,6 +53,7 @@ actions:
 
       switch-to-backup-firmware:
         label: Switch to Backup Firmware
+        description: Boot from the backup firmware slot on next reboot.
         confirm: "Switch to backup firmware and reboot?"
         background: true
         cmd:

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/21_actions_services.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/21_actions_services.yaml
@@ -1,9 +1,9 @@
 actions:
   services:
-    label: Services
     items:
       restart-klipper:
         label: Restart Klipper
+        description: Restart the Klipper firmware service.
         confirm: true
         cmd:
           - /etc/init.d/S60klipper
@@ -12,6 +12,7 @@ actions:
 
       restart-moonraker:
         label: Restart Moonraker
+        description: Restart the Moonraker API server.
         confirm: true
         cmd:
           - /etc/init.d/S61moonraker

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/22_actions_system.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/22_actions_system.yaml
@@ -1,9 +1,9 @@
 actions:
   system:
-    label: System
     items:
       reboot-system:
         label: Reboot System
+        description: Reboot the printer system.
         confirm: true
         cmd:
           - /sbin/reboot

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -35,8 +35,12 @@
         .info-value { font-family: monospace; font-size: 14px; word-break: break-all; }
         .row { display: flex; justify-content: space-between; align-items: center; padding: 12px; background: var(--item); border-radius: 6px; margin-bottom: 8px; cursor: pointer; transition: background 0.2s; }
         .row:hover { background: var(--hover); }
-        .row-label { color: #fff; font-size: 14px; font-weight: 500; flex: 1; }
-        .row select { background: var(--card); border: 1px solid #555; border-radius: 6px; padding: 8px 12px; color: var(--text); font-size: 13px; cursor: pointer; min-width: 150px; }
+        .row-label-wrap { flex: 1; }
+        .row-label { color: #fff; font-size: 14px; font-weight: 500; }
+        .row-desc { display: block; font-size: 12px; color: var(--muted); margin-top: 2px; }
+        .row-help { font-size: 12px; color: var(--accent); margin-left: 6px; vertical-align: middle; }
+        .row-help:hover { text-decoration: none; opacity: 0.8; }
+        .row select { align-self: flex-start; background: var(--card); border: 1px solid #555; border-radius: 6px; padding: 8px 12px; color: var(--text); font-size: 13px; cursor: pointer; min-width: 150px; }
         .row select:focus { outline: none; border-color: var(--accent); }
         .links-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
         .link-item { background: var(--item); padding: 12px 16px; border-radius: 6px; text-decoration: none; display: flex; align-items: center; gap: 10px; transition: background 0.2s; }
@@ -274,7 +278,10 @@
                         <div class="group-title">${group.label}</div>
                         ${group.items.map(action =>
                             `<div class="row" onclick="runAction('${action.id}')">
-                                <span class="row-label">${action.label}</span>
+                                <div class="row-label-wrap">
+                                    <span class="row-label">${action.label}${action.help_url ? `<a class="row-help" href="${action.help_url}" target="_blank" onclick="event.stopPropagation()">↗</a>` : ''}</span>
+                                    ${action.description ? `<span class="row-desc">${action.description}</span>` : ''}
+                                </div>
                                 <button class="btn btn-primary" style="pointer-events:none">Run</button>
                             </div>`
                         ).join('')}
@@ -305,8 +312,11 @@
                             const options = Object.entries(setting.options).map(([optKey, optVal]) => {
                                 return `<option value="${optKey}" data-label="${encodeURIComponent(optVal.label)}" data-confirm="${encodeURIComponent(optVal.confirm || '')}"${optKey === setting.current ? ' selected' : ''}>${optVal.label}</option>`;
                             }).join('');
-                            return `<div class="row">
-                                <span class="row-label">${setting.label}</span>
+                            return `<div class="row"${setting.help_url ? ` onclick="if(!event.target.closest('select'))window.open('${setting.help_url}','_blank')"` : ''}>
+                                <div class="row-label-wrap">
+                                    <span class="row-label">${setting.label}${setting.help_url ? `<a class="row-help" href="${setting.help_url}" target="_blank" onclick="event.stopPropagation()">↗</a>` : ''}</span>
+                                    ${setting.description ? `<span class="row-desc">${setting.description}</span>` : ''}
+                                </div>
                                 <select data-prev-value="${setting.current}" onchange="updateSetting('${setting.id}', this)">${options}</select>
                             </div>`;
                         }).join('')}

--- a/overlays/firmware-extended/12-camera-v4l2-mpp/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
+++ b/overlays/firmware-extended/12-camera-v4l2-mpp/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
@@ -17,10 +17,10 @@ links:
 
 settings:
   camera:
-    label: Camera
     items:
       camera-internal:
         label: Internal Camera
+        description: Select the driver for the built-in MIPI camera.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get
@@ -60,6 +60,7 @@ settings:
 
       camera-usb:
         label: USB Camera
+        description: Enable streaming from an attached USB camera.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get
@@ -93,6 +94,7 @@ settings:
 
       camera-rtsp:
         label: RTSP Stream (paxx12 only)
+        description: Enable RTSP stream output for the internal camera (paxx12 driver only).
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get

--- a/overlays/firmware-extended/14-ssh/root/usr/local/share/firmware-config/functions/14_settings_ssh.yaml
+++ b/overlays/firmware-extended/14-ssh/root/usr/local/share/firmware-config/functions/14_settings_ssh.yaml
@@ -1,9 +1,9 @@
 settings:
   remote_access:
-    label: Remote Access
     items:
       ssh:
         label: SSH Access
+        description: Enable remote shell access to the printer over SSH.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_object_processing.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_object_processing.yaml
@@ -1,9 +1,10 @@
 settings:
   tweaks:
-    label: Tweaks
     items:
       object_processing:
-        label: 'Object Processing for Adaptive Mesh (<a href="http://snapmakeru1-extended-firmware.pages.dev/tweaks#object-processing-for-adaptive-mesh" target="_blank">link</a>)'
+        label: Object Processing for Adaptive Mesh
+        description: Enables Moonraker object processing for adaptive mesh. Prefer enabling exclude object in your slicer instead.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#object-processing-for-adaptive-mesh
         get_cmd:
           - bash
           - -c

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
@@ -1,9 +1,10 @@
 settings:
   tweaks:
-    label: Tweaks
     items:
       tmc_autotune:
-        label: 'TMC AutoTune (<a href="http://snapmakeru1-extended-firmware.pages.dev/tweaks#tmc-autotune" target="_blank">link</a>)'
+        label: TMC AutoTune
+        description: Optimizes TMC2240 driver settings for quieter operation and better performance.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#tmc-autotune
         get_cmd:
           - bash
           - -c
@@ -11,7 +12,7 @@ settings:
         options:
           enabled:
             label: Enabled
-            confirm: "Enable TMC AutoTune? This optimizes TMC2240 driver settings for quieter operation and better performance. Warning: May cause motors to overheat if cooling is insufficient. Monitor temperatures during first use."
+            confirm: "Enable TMC AutoTune? This optimizes TMC2240 driver settings for quieter operation and better performance. Monitor motor temperatures, print quality, and skipped steps during first use."
             cmd:
               - bash
               - -xc

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
@@ -1,9 +1,10 @@
 settings:
   tweaks:
-    label: Tweaks
     items:
       tmc_reduce_current:
-        label: 'TMC Reduced Current (<a href="http://snapmakeru1-extended-firmware.pages.dev/tweaks#tmc-reduced-current" target="_blank">link</a>)'
+        label: TMC Reduced Current
+        description: Lowers X/Y motor current from 1.2A to 1.0A for quieter operation and less heat.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#tmc-reduced-current
         get_cmd:
           - bash
           - -c
@@ -11,7 +12,7 @@ settings:
         options:
           enabled:
             label: Enabled
-            confirm: "Enable TMC Reduced Current? This lowers X/Y motor current from 1.2A to 1.0A for quieter operation and less heat. Warning: May cause skipped steps or layer shifts under heavy load. Monitor print quality after enabling."
+            confirm: "Enable TMC Reduced Current? This lowers X/Y motor current from 1.2A to 1.0A for quieter operation and less heat. Monitor motor temperatures and print quality after enabling."
             cmd:
               - bash
               - -xc

--- a/overlays/firmware-extended/22-vpn/root/usr/local/share/firmware-config/functions/16_settings_vpn.yaml
+++ b/overlays/firmware-extended/22-vpn/root/usr/local/share/firmware-config/functions/16_settings_vpn.yaml
@@ -12,10 +12,10 @@ status:
 
 settings:
   remote_access:
-    label: Remote Access
     items:
       vpn:
         label: VPN Provider (Experimental)
+        description: Connect the printer to a VPN for secure remote access from anywhere.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get

--- a/overlays/firmware-extended/22-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
+++ b/overlays/firmware-extended/22-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
@@ -1,8 +1,8 @@
 actions:
   troubleshooting:
-    label: Troubleshooting
     items:
       tailscale-status:
         label: Tailscale Status
+        description: Show current Tailscale connection status and IP address.
         cmd: [/usr/local/bin/tailscale, status]
         message: "Checking Tailscale status..."

--- a/overlays/firmware-extended/23-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
+++ b/overlays/firmware-extended/23-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
@@ -1,9 +1,9 @@
 settings:
   remote_access:
-    label: Remote Access
     items:
       cloud:
         label: Cloud Access (Experimental)
+        description: Enable alternative cloud access from outside your network.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get

--- a/overlays/firmware-extended/23-klipper-afc-lite/root/usr/local/share/firmware-config/functions/23_settings_tweaks_afc.yaml
+++ b/overlays/firmware-extended/23-klipper-afc-lite/root/usr/local/share/firmware-config/functions/23_settings_tweaks_afc.yaml
@@ -1,9 +1,10 @@
 settings:
   tweaks:
-    label: Tweaks
     items:
       afc:
-        label: 'AFC Lite via Fluidd/Mainsail (<a href="http://snapmakeru1-extended-firmware.pages.dev/afc-lite" target="_blank">link</a>)'
+        label: AFC Lite via Fluidd/Mainsail
+        description: Multi-lane filament management with CHANGE_TOOL and LANE_UNLOAD macros.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/afc-lite
         get_cmd:
           - bash
           - -c
@@ -11,7 +12,7 @@ settings:
         options:
           enabled:
             label: Enabled
-            confirm: 'Enable AFC Lite component? This adds support for multi-lane filament management with CHANGE_TOOL and LANE_UNLOAD macros. See <a href="http://snapmakeru1-extended-firmware.pages.dev/afc-lite" target="_blank">documentation</a> for details.'
+            confirm: "Enable AFC Lite component? This adds support for multi-lane filament management with CHANGE_TOOL and LANE_UNLOAD macros. See documentation for details."
             cmd:
               - bash
               - -xc

--- a/overlays/firmware-extended/90-web-frontend/root/usr/local/share/firmware-config/functions/11_settings_web_frontend.yaml
+++ b/overlays/firmware-extended/90-web-frontend/root/usr/local/share/firmware-config/functions/11_settings_web_frontend.yaml
@@ -7,10 +7,10 @@ links:
 
 settings:
   web:
-    label: Web
     items:
       web-frontend:
         label: Frontend
+        description: Choose between Fluidd and Mainsail as the web interface.
         get_cmd: [/usr/local/bin/extended-config.py, get, /home/lava/printer_data/config/extended/extended2.cfg, web, frontend, fluidd]
         options:
           mainsail:

--- a/overlays/firmware-extended/99-monitoring/root/usr/local/share/firmware-config/functions/61_settings_monitoring.yaml
+++ b/overlays/firmware-extended/99-monitoring/root/usr/local/share/firmware-config/functions/61_settings_monitoring.yaml
@@ -1,9 +1,9 @@
 settings:
   monitoring_debugging:
-    label: Monitoring & Debugging
     items:
       klipper-metrics:
         label: Klipper Metrics Exporter
+        description: Export Klipper metrics for scraping by Prometheus.
         get_cmd:
           - bash
           - -c

--- a/overlays/firmware-extended/99-remote-screen/root/usr/local/share/firmware-config/functions/12_settings_remote_screen.yaml
+++ b/overlays/firmware-extended/99-remote-screen/root/usr/local/share/firmware-config/functions/12_settings_remote_screen.yaml
@@ -9,10 +9,10 @@ links:
 
 settings:
   web:
-    label: Web
     items:
       remote-screen:
         label: Remote Screen
+        description: Stream the printer touchscreen to the browser.
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get


### PR DESCRIPTION
- Display descriptions as subtitle text below setting/action labels in the web interface
- Improve confirm dialog wording for TMC autotune, TMC reduced current, and AFC Lite to remove HTML and clarify warnings

## Screenshot

<img width="762" height="429" alt="Screenshot 2026-02-20 at 17 11 32" src="https://github.com/user-attachments/assets/bee99256-4b67-4205-9d34-50f8836e2213" />
