### PR TITLE
Integrate Spoolman with the NFC filament detection

### DIFF
--- a/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -224,6 +224,11 @@ def openspool_parse_payload(payload, card_uid=[]):
         info['OFFICIAL'] = True
         info['CARD_UID'] = card_uid
 
+        try:
+            info['SPOOL_ID'] = int(data.get('spool_id', 0))
+        except (ValueError, TypeError):
+            info['SPOOL_ID'] = 0
+
         return filament_protocol.FILAMENT_PROTO_OK, info
 
     except json.JSONDecodeError as e:

--- a/overlays/firmware-extended/14-spoolman-nfc/patches/01-filament-protocol.patch
+++ b/overlays/firmware-extended/14-spoolman-nfc/patches/01-filament-protocol.patch
@@ -1,0 +1,10 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_protocol.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_protocol.py
+@@ -35,6 +35,7 @@
+     'RSA_KEY_VERSION': 0,
+     'OFFICIAL': False,
+     'CARD_UID': 0,
++    'SPOOL_ID': 0,
+ }
+ 
+ # Filament main type

--- a/overlays/firmware-extended/14-spoolman-nfc/patches/02-moonraker-spoolman.patch
+++ b/overlays/firmware-extended/14-spoolman-nfc/patches/02-moonraker-spoolman.patch
@@ -1,0 +1,45 @@
+--- rootfs.original/home/lava/moonraker/moonraker/components/spoolman.py
++++ rootfs/home/lava/moonraker/moonraker/components/spoolman.py
+@@ -238,7 +238,10 @@
+     async def _handle_klippy_ready(self) -> None:
+         result: Dict[str, Dict[str, Any]]
+         result = await self.klippy_apis.subscribe_objects(
+-            {"toolhead": ["position", "extruder"]}, self._handle_status_update, {}
++            {
++                "toolhead": ["position", "extruder"],
++                "filament_detect": None
++            }, self._handle_status_update, {}
+         )
+         toolhead = result.get("toolhead", {})
+         self._current_extruder = toolhead.get("extruder", "extruder")
+@@ -259,6 +262,30 @@
+ 
+     def _handle_status_update(self, status: Dict[str, Any], _: float) -> None:
+         toolhead: Optional[Dict[str, Any]] = status.get("toolhead")
++        
++        # Check if filament_detect status has changed
++        filament_detect: Optional[Dict[str, Any]] = status.get("filament_detect")
++        if filament_detect is not None:
++            info_list = filament_detect.get("info", [])
++            
++            # Determine which index is the current active extruder
++            active_idx = 0
++            if self._current_extruder != "extruder":
++                try:
++                    active_idx = int(self._current_extruder.replace("extruder", ""))
++                except ValueError:
++                    pass
++            
++            # If the info array has an entry for the active extruder, get its SPOOL_ID
++            if active_idx < len(info_list):
++                info = info_list[active_idx]
++                # Fallback to checking the dict in case info isn't guaranteed to be fully populated
++                if isinstance(info, dict):
++                    spool_id = info.get("SPOOL_ID", 0)
++                    if spool_id is not None and spool_id > 0 and spool_id != self.spool_id:
++                        logging.info(f"NFC detect triggered Spoolman switch to Spool ID {spool_id} on {self._current_extruder}")
++                        self.set_active_spool(spool_id)
++
+         if toolhead is None:
+             return
+         epos: float = toolhead.get("position", [0, 0, 0, self._highest_epos])[3]

--- a/overlays/firmware-extended/14-spoolman-nfc/pre-scripts/01_dos2unix.sh
+++ b/overlays/firmware-extended/14-spoolman-nfc/pre-scripts/01_dos2unix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+dos2unix "$1/home/lava/klipper/klippy/extras/filament_protocol.py" \
+  "$1/home/lava/moonraker/moonraker/components/spoolman.py"

--- a/overlays/firmware-extended/14-spoolman-nfc/test/deploy-run.sh
+++ b/overlays/firmware-extended/14-spoolman-nfc/test/deploy-run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <printer-ip-or-host>"
+  echo "Example: $0 192.168.1.100"
+  exit 1
+fi
+
+SSH_HOST="$1"
+DIR="$(dirname "$0")"
+ROOT_DIR="$(realpath "$DIR/../../../..")"
+
+set -xeo pipefail
+
+echo "Deploying modified files to $SSH_HOST..."
+
+# Copy modified Klipper file
+scp "$ROOT_DIR/tmp/firmware/rootfs/home/lava/klipper/klippy/extras/filament_protocol.py" "root@$SSH_HOST:/home/lava/klipper/klippy/extras/"
+
+# Copy modified Moonraker component
+scp "$ROOT_DIR/tmp/firmware/rootfs/home/lava/moonraker/moonraker/components/spoolman.py" "root@$SSH_HOST:/home/lava/moonraker/moonraker/components/"
+
+# Restart Klipper and Moonraker services on the printer
+echo "Restarting Klipper and Moonraker services..."
+ssh -t "root@$SSH_HOST" "/etc/init.d/S60klipper restart && /etc/init.d/S61moonraker restart"
+
+echo "Deployed successfully!"

--- a/overlays/firmware-extended/14-spoolman-nfc/test/test_moonraker_spoolman.py
+++ b/overlays/firmware-extended/14-spoolman-nfc/test/test_moonraker_spoolman.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import logging
+from unittest.mock import MagicMock
+
+logging.basicConfig(level=logging.INFO)
+
+# Set path so python finds the moonraker package
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, os.path.join(ROOT_DIR, "tmp/firmware/rootfs/home/lava/moonraker"))
+
+# Mock missing Moonraker dependencies from pip (tornado)
+sys.modules['tornado'] = MagicMock()
+sys.modules['tornado.websocket'] = MagicMock()
+
+import moonraker.components.spoolman as spoolman_comp
+
+class MockServer:
+    def __init__(self):
+        self.config = MockConfig()
+    
+    def get_event_loop(self):
+        loop = MagicMock()
+        loop.get_loop_time.return_value = 0.0
+        return loop
+
+    def get_host_info(self):
+        return {"machine_id": "test_id"}
+
+    def register_endpoint(self, *args, **kwargs): pass
+    def register_event_handler(self, *args, **kwargs): pass
+    def register_notification(self, *args, **kwargs): pass
+    def register_remote_method(self, *args, **kwargs): pass
+    def lookup_component(self, name): return MagicMock()
+    def send_event(self, event, payload): pass
+
+class MockConfig:
+    def __init__(self):
+        self._name = "spoolman"
+    
+    def get(self, key, default=None):
+        if key == "server":
+            return "http://localhost:7912"
+        if key == "sync_rate":
+            return 5
+        return default
+    
+    def getint(self, key, default=None, minval=None):
+        return default
+
+    def get_server(self):
+        return MockServer()
+    
+    def get_name(self):
+        return self._name
+
+    def error(self, msg):
+        return Exception(msg)
+
+# Instantiate the mocked Spoolman component
+mock_spoolman = spoolman_comp.SpoolManager(MockConfig())
+
+# Reset properties for testing that might be overwritten during init
+mock_spoolman.server = MockServer()
+mock_spoolman.klippy_apis = MagicMock()
+mock_spoolman.database = MagicMock()
+mock_spoolman.spool_history.tracker.history = MagicMock()
+mock_spoolman.spool_history.tracker.history.tracking_enabled.return_value = True
+
+# Now simulate an update
+mock_status_payload = {
+    "filament_detect": {
+        "info": [
+            {
+                "SPOOL_ID": 1337,
+                "VENDOR": "OpenSpool",
+                "MAIN_TYPE": 1
+            }
+        ]
+    }
+}
+
+print("--- Testing Moonraker Spoolman Component ---")
+print(f"Simulating Klipper Payload: {mock_status_payload}")
+
+# Overwrite _active_spool_id so we can assert on it later
+# Note: set_active_spool uses self.spool_id 
+print(f"Initial Spool ID: {mock_spoolman.spool_id}")
+
+mock_spoolman._handle_status_update(mock_status_payload, 0.0)
+
+print(f"Final Spool ID: {mock_spoolman.spool_id}")
+
+if mock_spoolman.spool_id == 1337:
+    print("SUCCESS: Moonraker correctly received the payload and updated the active spool!")
+else:
+    print("FAILED: Moonraker did not set the active spool id.")
+    sys.exit(1)

--- a/overlays/firmware-extended/14-spoolman-nfc/test/test_ndef_parser.py
+++ b/overlays/firmware-extended/14-spoolman-nfc/test/test_ndef_parser.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import json
+
+# Add klippy extras to path so we can import the modules
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.append(os.path.join(ROOT_DIR, "tmp/firmware/rootfs/home/lava/klipper"))
+
+import klippy.extras.filament_protocol as filament_protocol
+import klippy.extras.filament_protocol_ndef as filament_protocol_ndef
+
+# Create a mock NDEF byte array containing an OpenSpool JSON payload
+# that includes a spool_id.
+mock_json_payload = json.dumps({
+    "protocol": "openspool",
+    "spool_id": 420,
+    "material": "PETG",
+    "color": "Blue"
+})
+
+class MockRecord:
+    def __init__(self, data):
+        self.data_msg = data
+
+# m1_proto_data_parse_ndef expects a list of NDEF records and the card UID
+records = [MockRecord(mock_json_payload)]
+card_uid = b'\\x01\\x02\\x03\\x04'
+
+print("--- Testing OpenSpool NDEF parsing ---")
+print(f"Input JSON Payload: {mock_json_payload}")
+
+# Call the function
+status, info = filament_protocol_ndef.openspool_parse_payload(mock_json_payload.encode('utf-8'), card_uid)
+
+print(f"Status returned: {status} (Expected: 0 / FILAMENT_PROTO_OK)")
+print(f"Extracted SPOOL_ID: {info.get('SPOOL_ID')}")
+
+if status == filament_protocol.FILAMENT_PROTO_OK and info.get('SPOOL_ID') == 420:
+    print("SUCCESS: The parser successfully extracted the SPOOL_ID from the NDEF payload!")
+else:
+    print("FAILED: The parser did not extract the SPOOL_ID correctly.")
+    sys.exit(1)


### PR DESCRIPTION
# [Feature] Spoolman NFC Integration

## Description
This PR introduces native integration between the U1's filament detection system and Moonraker's Spoolman component. When a newly loaded filament spool containing an OpenSpool NFC tag is read by the printer, Moonraker will automatically detect the embedded `spool_id` and synchronize the active spool with your upstream Spoolman server.

## What's Changed

* **NFC OpenSpool Parsing**: Added `SPOOL_ID` to Klipper's `FILAMENT_INFO_STRUCT` via `klippy/extras/filament_protocol.py`. Updated `klippy/extras/filament_protocol_ndef.py` to correctly parse the `spool_id` JSON payload from OpenSpool formatted NDEF tags.
* **Moonraker Automation**: Modified `moonraker/components/spoolman.py` in Moonraker to subscribe to Klipper's `filament_detect` object. When it detects a new tag insertion on the active extruder containing a non-zero `SPOOL_ID`, it invokes `self.set_active_spool(spool_id)`.
