### PR TITLE
Draft: Implement naive heated chamber via bed heating

### DIFF
--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -86,6 +86,23 @@ Enables object processing in Moonraker's file manager to support adaptive mesh f
 **Configuration:**
 This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
 
+## Naive Heated Chamber
+
+Allow to heat chamber using bed heater.
+
+**What it does:**
+- Implements support for **M191** command
+- Sets heated bed temp to 100C
+- Waits actively for **Cavity sensor** reach target temp
+
+**Risks:**
+- Heated bed should be empty to not start melting any print left on plate
+
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
+
 ## How to Configure
 
 1. Open the printer's web interface (Fluidd or Mainsail)

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_naive_heated_chamber.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_naive_heated_chamber.yaml
@@ -1,0 +1,32 @@
+settings:
+  tweaks:
+    items:
+      naive_heated_chamber:
+        label: Naive Heated Chamber
+        description: Enables naive heated chamber support.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#naive-heated-chamber
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/naive_heated_chamber.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable Naive Heated Chamber? This enables naive heated chamber support. Chamber is heated using bed heater (set to 100C)."
+            cmd:
+              - bash
+              - -xc
+              - |
+                cp -v /usr/local/share/firmware-config/tweaks/klipper/naive_heated_chamber.cfg /oem/printer_data/config/extended/klipper/naive_heated_chamber.cfg &&
+                echo "Naive Heated Chamber enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -vf /oem/printer_data/config/extended/klipper/naive_heated_chamber.cfg &&
+                echo "Naive Heated Chamber disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/naive_heated_chamber.cfg
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/naive_heated_chamber.cfg
@@ -1,0 +1,9 @@
+[gcode_macro M191]
+description: Set Chamber Temperature and Wait
+gcode:
+    {% set TEMP = params.S|default(0)|float %}
+    M118 Chamber temperature set to {TEMP}
+    M190 S100
+    TEMPERATURE_WAIT SENSOR="temperature_sensor cavity" MINIMUM={TEMP}
+    M190 S0
+    M118 Chamber temperature {TEMP} reached


### PR DESCRIPTION
As in the title. Using bed heater to heat chamber. I'm thinking of adding also:
- [ ] hard limit to 70C? 80C?
- [ ] timeout to prevent infinite heating
- [ ] update docs how to enable it in slicer
- [ ] handle cancelling print from UI or screen
- [ ] *OPTIONALLY* allow to change `temperature_sensor` to something other than `cavity`