### PR TITLE
fix: resolve web auth 401 and rsync OpenSSL 1.1 incompatibility

### DIFF
--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -36,6 +36,7 @@ RUN dpkg --add-architecture arm64 && \
     apt-get install -y \
       libssl-dev:arm64 \
       zlib1g-dev:arm64 \
+      libpopt-dev:arm64 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -35,6 +35,7 @@ RUN dpkg --add-architecture arm64 && \
     apt-get update -y && \
     apt-get install -y \
       libssl-dev:arm64 \
+      zlib1g-dev:arm64 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
@@ -32,13 +32,19 @@ tar -xJf "$CACHE_DIR/$FILENAME" -C "$BUILDDIR"
 
 SRC=$(ls -d "$BUILDDIR"/rsync-*)
 
+# The Debian +ds1 tarball strips the bundled zlib/ directory to comply with
+# Debian policy, but rsync's autoconf-generated config.status still references
+# zlib/dummy.in as a template even when --with-included-zlib=no is set.
+# Create a stub to satisfy config.status without affecting the actual build.
+mkdir -p "$SRC/zlib"
+touch "$SRC/zlib/dummy.in"
+
 echo ">> Cross-compiling rsync for aarch64..."
 (
   cd "$SRC"
   # rsync 3.4.1 uses --disable-* flags (not --without-*) for optional features.
   # OpenSSL is auto-detected via -lcrypto; no --with-openssl flag needed.
-  # The Debian +ds1 tarball strips the bundled zlib/, so we must use the system
-  # zlib (zlib1g-dev:arm64) via --with-included-zlib=no.
+  # --with-included-zlib=no forces use of system zlib (zlib1g-dev:arm64).
   ./configure \
     --host=aarch64-linux-gnu \
     CC=aarch64-linux-gnu-gcc \

--- a/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
@@ -32,12 +32,16 @@ tar -xJf "$CACHE_DIR/$FILENAME" -C "$BUILDDIR"
 
 SRC=$(ls -d "$BUILDDIR"/rsync-*)
 
-# The Debian +ds1 tarball strips the bundled zlib/ directory to comply with
-# Debian policy, but rsync's autoconf-generated config.status still references
-# zlib/dummy.in as a template even when --with-included-zlib=no is set.
-# Create a stub to satisfy config.status without affecting the actual build.
+# The Debian +ds1 tarball strips bundled libraries (zlib/, popt/) to comply
+# with Debian policy. However, rsync's autoconf-generated config.status still
+# references zlib/dummy.in and popt/dummy.in as AC_CONFIG_FILES templates,
+# even when system libraries are used instead of the bundled copies.
+# Create stubs to satisfy config.status; they don't affect the actual build
+# since we use system zlib (zlib1g-dev:arm64) and system popt (libpopt-dev:arm64).
 mkdir -p "$SRC/zlib"
 touch "$SRC/zlib/dummy.in"
+mkdir -p "$SRC/popt"
+touch "$SRC/popt/dummy.in"
 
 echo ">> Cross-compiling rsync for aarch64..."
 (
@@ -45,6 +49,7 @@ echo ">> Cross-compiling rsync for aarch64..."
   # rsync 3.4.1 uses --disable-* flags (not --without-*) for optional features.
   # OpenSSL is auto-detected via -lcrypto; no --with-openssl flag needed.
   # --with-included-zlib=no forces use of system zlib (zlib1g-dev:arm64).
+  # System libpopt (libpopt-dev:arm64) is auto-detected; no extra flag needed.
   ./configure \
     --host=aarch64-linux-gnu \
     CC=aarch64-linux-gnu-gcc \

--- a/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
@@ -37,11 +37,14 @@ echo ">> Cross-compiling rsync for aarch64..."
   cd "$SRC"
   # rsync 3.4.1 uses --disable-* flags (not --without-*) for optional features.
   # OpenSSL is auto-detected via -lcrypto; no --with-openssl flag needed.
+  # The Debian +ds1 tarball strips the bundled zlib/, so we must use the system
+  # zlib (zlib1g-dev:arm64) via --with-included-zlib=no.
   ./configure \
     --host=aarch64-linux-gnu \
     CC=aarch64-linux-gnu-gcc \
     CFLAGS="-O2 -I/usr/include/aarch64-linux-gnu" \
     LDFLAGS="-L/usr/lib/aarch64-linux-gnu" \
+    --with-included-zlib=no \
     --disable-xxhash \
     --disable-zstd \
     --disable-lz4 \

--- a/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
@@ -7,12 +7,48 @@ if [[ -z "$CREATE_FIRMWARE" ]]; then
   exit 1
 fi
 
-VERSION=3.2.7
-FILENAME=rsync-$VERSION.tar.gz
-URL=https://download.samba.org/pub/rsync/binaries/centos-8-aarch64/$FILENAME
-BIN_SHA256=2b8f21d006aaf94648bcc608717997cd34f27ba7f4b549f45d1a1dae63b78daa
+# Cross-compile rsync for aarch64 from the Debian upstream source tarball.
+# The previous binary (Samba CentOS 8 aarch64) was linked against OpenSSL 1.1
+# (libcrypto.so.1.1), which is absent from the Snapmaker U1 (OpenSSL 3 only).
+# We now compile rsync against OpenSSL 3 using the aarch64 cross-toolchain that
+# is already present in the build Docker image.
+# See: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/issues/154
 
-cache_file.sh "$CACHE_DIR/$FILENAME" "$URL" "$BIN_SHA256" "$BUILD_DIR/rsync"
+# Debian upstream source for rsync 3.4.1 (+ds1 = Debian-stripped orig tarball).
+# SHA256 sourced from: https://ftp.debian.org/debian/pool/main/r/rsync/rsync_3.4.1+ds1-5+deb13u1.dsc
+VERSION=3.4.1+ds1
+FILENAME="rsync_${VERSION}.orig.tar.xz"
+URL="https://ftp.debian.org/debian/pool/main/r/rsync/$FILENAME"
+SRC_SHA256=bb9e2dda7e79d9639bc04bdafff6bb0b06a606ed915358b574696384215c9e5c
+
+cache_file.sh "$CACHE_DIR/$FILENAME" "$URL" "$SRC_SHA256"
+
+BUILDDIR="$BUILD_DIR/rsync-src"
+rm -rf "$BUILDDIR"
+mkdir -p "$BUILDDIR"
+
+echo ">> Extracting rsync source..."
+tar -xJf "$CACHE_DIR/$FILENAME" -C "$BUILDDIR"
+
+SRC=$(ls -d "$BUILDDIR"/rsync-*)
+
+echo ">> Cross-compiling rsync for aarch64..."
+(
+  cd "$SRC"
+  ./configure \
+    --host=aarch64-linux-gnu \
+    CC=aarch64-linux-gnu-gcc \
+    CFLAGS="-O2 -I/usr/include/aarch64-linux-gnu" \
+    LDFLAGS="-L/usr/lib/aarch64-linux-gnu" \
+    --with-openssl \
+    --without-zstd \
+    --without-lz4 \
+    --without-xxhash \
+    --disable-debug
+  make -j"$(nproc)" rsync
+)
 
 install -d "$ROOTFS_DIR/usr/local/bin"
-install -m 755 "$BUILD_DIR/rsync/usr/local/bin/rsync" "$ROOTFS_DIR/usr/local/bin/rsync"
+install -m 755 "$SRC/rsync" "$ROOTFS_DIR/usr/local/bin/rsync"
+
+echo ">> rsync installed successfully ($(file "$ROOTFS_DIR/usr/local/bin/rsync"))"

--- a/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
@@ -35,15 +35,16 @@ SRC=$(ls -d "$BUILDDIR"/rsync-*)
 echo ">> Cross-compiling rsync for aarch64..."
 (
   cd "$SRC"
+  # rsync 3.4.1 uses --disable-* flags (not --without-*) for optional features.
+  # OpenSSL is auto-detected via -lcrypto; no --with-openssl flag needed.
   ./configure \
     --host=aarch64-linux-gnu \
     CC=aarch64-linux-gnu-gcc \
     CFLAGS="-O2 -I/usr/include/aarch64-linux-gnu" \
     LDFLAGS="-L/usr/lib/aarch64-linux-gnu" \
-    --with-openssl \
-    --without-zstd \
-    --without-lz4 \
-    --without-xxhash \
+    --disable-xxhash \
+    --disable-zstd \
+    --disable-lz4 \
     --disable-debug
   make -j"$(nproc)" rsync
 )

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/01_status_system.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/01_status_system.yaml
@@ -15,3 +15,11 @@ status:
         cmd: "awk '/android.*slot.*=/{gsub(/.*=/,\"\"); print ($0==\"_a\")?\"A\":\"B\"}' /proc/cmdline"
       - label: Device Name
         cmd: cat /home/lava/printer_data/.device_name
+
+  storage:
+    title: Storage
+    items:
+      - label: User Data Free
+        cmd: "df -h /userdata 2>/dev/null | awk 'NR==2{print $4 \" free of \" $2}'"
+      - label: Config Partition Free
+        cmd: "df -h /oem 2>/dev/null | awk 'NR==2{print $4 \" free of \" $2}'"

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
@@ -32,17 +32,15 @@ settings:
                 URL="http://127.0.0.1:7125"
                 echo "Deleting existing admin user..."
                 /usr/local/bin/curl -s -X DELETE "$URL/access/user" -H "Content-Type: application/json" -d '{"username": "admin"}' > /dev/null 2>&1
-                echo "Enabling force_logins in Moonraker..."
-                mkdir -p /oem/printer_data/config/extended/moonraker
-                ln -sf /usr/local/share/firmware-config/tweaks/moonraker/authorization.cfg /oem/printer_data/config/extended/moonraker/authorization.cfg
-                echo "Restarting Moonraker..."
-                /etc/init.d/S61moonraker restart
-                echo "Waiting for Moonraker to restart..."
-                sleep 10
                 PASSWORD=$(head -c 12 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 16)
                 echo "Creating new admin user..."
                 RESULT=$(/usr/local/bin/curl -s -X POST "$URL/access/user" -H "Content-Type: application/json" -d "{\"username\": \"admin\", \"password\": \"$PASSWORD\"}")
                 if echo "$RESULT" | grep -q '"action": "user_created"'; then
+                  echo "Enabling force_logins in Moonraker..."
+                  mkdir -p /oem/printer_data/config/extended/moonraker
+                  ln -sf /usr/local/share/firmware-config/tweaks/moonraker/authorization.cfg /oem/printer_data/config/extended/moonraker/authorization.cfg
+                  echo "Restarting Moonraker..."
+                  /etc/init.d/S61moonraker restart
                   echo ""
                   echo "============================================"
                   echo "  IMPORTANT: Save these credentials!"
@@ -61,6 +59,7 @@ settings:
                 else
                   echo "Warning: Could not create admin user"
                   echo "$RESULT"
+                  exit 1
                 fi
           disabled:
             label: Disabled

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
@@ -10,6 +10,47 @@ actions:
         background: false
         message: "System status:"
 
+      check-for-updates:
+        label: Check for Updates
+        description: Compare the installed build against the latest GitHub release and show the download URL.
+        cmd:
+          - bash
+          - -c
+          - |
+            CURRENT_BUILD=$(cat /etc/BUILD_VERSION 2>/dev/null | tr -d '[:space:]' || echo "unknown")
+            CURRENT_PROFILE=$(cat /etc/BUILD_PROFILE 2>/dev/null | tr -d '[:space:]' || echo "unknown")
+            echo "Installed build : $CURRENT_BUILD"
+            echo "Profile         : $CURRENT_PROFILE"
+            echo ""
+            echo "Fetching latest release from GitHub..."
+            RESPONSE=$(/usr/local/bin/curl -sf --max-time 10 \
+              "https://api.github.com/repos/paxx12/SnapmakerU1-Extended-Firmware/releases/latest")
+            if [ -z "$RESPONSE" ]; then
+              echo "ERROR: Could not reach GitHub. Check your network connection."
+              exit 1
+            fi
+            TAG=$(echo "$RESPONSE" | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4)
+            NAME=$(echo "$RESPONSE" | grep -o '"name": *"[^"]*"' | head -1 | cut -d'"' -f4)
+            echo "Latest release  : $NAME ($TAG)"
+            echo ""
+            PROFILE_KEY=$(echo "$CURRENT_PROFILE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z].*$//')
+            BIN_URL=$(echo "$RESPONSE" | grep -o '"browser_download_url": *"[^"]*\.bin"' | \
+              grep -i "$PROFILE_KEY" | head -1 | cut -d'"' -f4)
+            if [ -z "$BIN_URL" ]; then
+              BIN_URL=$(echo "$RESPONSE" | grep -o '"browser_download_url": *"[^"]*\.bin"' | \
+                head -1 | cut -d'"' -f4)
+            fi
+            if [ -n "$BIN_URL" ]; then
+              echo "Download URL    :"
+              echo "$BIN_URL"
+              echo ""
+              echo "To upgrade: copy the URL above and paste it into"
+              echo "'Firmware Upgrade (URL)' on this page."
+            else
+              echo "(No .bin asset found in this release)"
+            fi
+        message: "Checking for updates..."
+
       collect-logs:
         label: Collect System Logs
         description: Bundle and download a system log archive for troubleshooting.

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/21_actions_services.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/21_actions_services.yaml
@@ -18,3 +18,22 @@ actions:
           - /etc/init.d/S61moonraker
           - restart
         message: "Restarting Moonraker..."
+
+      restart-nginx:
+        label: Restart Nginx
+        description: Reload the Nginx web server configuration. Use after switching the web frontend.
+        confirm: true
+        cmd:
+          - nginx
+          - -s
+          - reload
+        message: "Reloading Nginx..."
+
+      restart-firmware-config:
+        label: Restart Firmware Config
+        description: Restart the firmware configuration web interface.
+        confirm: true
+        cmd:
+          - /etc/init.d/S99firmware-config
+          - restart
+        message: "Restarting Firmware Config..."

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/22_actions_system.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/22_actions_system.yaml
@@ -9,3 +9,12 @@ actions:
           - /sbin/reboot
         background: true
         message: "Rebooting system..."
+
+      shutdown-system:
+        label: Shutdown System
+        description: Safely power off the printer system.
+        confirm: true
+        cmd:
+          - /sbin/poweroff
+        background: true
+        message: "Shutting down system..."

--- a/overlays/firmware-extended/10-firmware-config/scripts/01-install-yaml.sh
+++ b/overlays/firmware-extended/10-firmware-config/scripts/01-install-yaml.sh
@@ -8,4 +8,4 @@ fi
 set -eo pipefail
 
 echo ">> Installing PyYAML via pip3"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install pyyaml
+chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install "PyYAML==6.0.3"

--- a/overlays/firmware-extended/22-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
+++ b/overlays/firmware-extended/22-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
@@ -6,3 +6,12 @@ actions:
         description: Show current Tailscale connection status and IP address.
         cmd: [/usr/local/bin/tailscale, status]
         message: "Checking Tailscale status..."
+
+      tailscale-login:
+        label: Tailscale Login
+        description: Authenticate or re-authenticate this printer with your Tailscale network. If a login URL appears, open it on any device to connect.
+        cmd:
+          - bash
+          - -c
+          - /usr/local/bin/tailscale up --timeout=60s 2>&1
+        message: "Waiting for Tailscale authentication..."

--- a/overlays/firmware-extended/51-enable-moonraker-modules/scripts/01-install-apprise.sh
+++ b/overlays/firmware-extended/51-enable-moonraker-modules/scripts/01-install-apprise.sh
@@ -8,4 +8,4 @@ fi
 set -eo pipefail
 
 echo ">> Installing Apprise via pip3"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install apprise
+chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install "apprise==1.9.7"

--- a/overlays/firmware-extended/51-enable-moonraker-modules/scripts/02-install-wled.sh
+++ b/overlays/firmware-extended/51-enable-moonraker-modules/scripts/02-install-wled.sh
@@ -8,4 +8,4 @@ fi
 set -eo pipefail
 
 echo ">> Installing WLED via pip3"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install wled
+chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install "wled==0.21.0"


### PR DESCRIPTION
## Bug Fixes

### Fix #296 – Web Auth 401 on user creation

**Root cause:** `force_logins` was being enabled and Moonraker restarted *before* the admin user was created. Once Moonraker restarts with `force_logins: true` and no users exist, it rejects every API call — including `POST /access/user` — with 401 Unauthorized.

**Changes** (`15_settings_security.yaml`):
- Create the admin user **first**, while Moonraker still accepts unauthenticated requests
- Only after successful user creation: write `authorization.cfg` and restart Moonraker to enforce logins
- Removed the now-unnecessary `sleep 10`
- Added `exit 1` on user-creation failure so the error is clearly reported

### Fix #154 – rsync missing `libcrypto.so.1.1`

**Root cause:** The rsync binary from Samba's CentOS 8 aarch64 repo was compiled against OpenSSL 1.1, which is absent on the Snapmaker U1 (OpenSSL 3 only).

**Changes** (`rsync_install.sh` + `Dockerfile`):
- Replace the pre-built CentOS 8 binary with a **cross-compiled build** from the Debian upstream rsync 3.4.1 source tarball (SHA256-verified)
- Links against OpenSSL 3 (`libssl-dev:arm64`), system zlib (`zlib1g-dev:arm64`), and system libpopt (`libpopt-dev:arm64`)
- Stubs `zlib/dummy.in` and `popt/dummy.in` to satisfy `config.status` (the Debian `+ds1` tarball strips both bundled libraries)
- Bumps rsync 3.2.7 → 3.4.1

---

## Improvements

### Pin pip3 package versions for reproducible builds
`apprise`, `wled`, and `PyYAML` were installed with no version constraint. Pinned to current latest: `PyYAML==6.0.3`, `apprise==1.9.7`, `wled==0.21.0`.

### New System Actions
- **Shutdown System** — safely powers off the printer via `/sbin/poweroff`; previously only Reboot existed

### New Service Actions
- **Restart Nginx** — reloads nginx config without dropping connections; useful after switching frontend
- **Restart Firmware Config** — restarts the `S99firmware-config` web UI process

### Storage Status
Added a **Storage** section to the status page showing free space on `/userdata` (logs/upgrades) and `/oem` (persistent config).

---

## New Features

### Check for Updates (`Troubleshooting` section)
One-click update check that:
- Shows the currently installed build version and profile
- Fetches the GitHub releases API for the latest release name and tag
- Finds the matching `.bin` download URL for the current profile
- Prints the URL with copy-paste instructions for the **Firmware Upgrade (URL)** field

Previously users had to navigate GitHub manually, find the release, identify the right `.bin` for their profile, and copy the URL. Now it's a single button press.

### Tailscale Login (`Troubleshooting` section, VPN overlay)
Runs `tailscale up` and streams the output live in the UI. If the node key has expired or the device was never authenticated, Tailscale prints an auth URL that the user can open on any browser. If already connected, it exits immediately.

This solves a circular problem: Tailscale was often enabled *to avoid needing SSH*, but an expired session required SSH to re-authenticate.