### PR TITLE
fix(openrfid): fix review issues from PR #306 (PIDFILE, stray echo, help_url, error handling)

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -51,7 +51,7 @@ Toggle settings directly from the web interface:
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
 | Cloud | None, OctoEverywhere | Enable Cloud-based remote access (Experimental) |
 | Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
-| RFID Detection System | External, Snapmaker | Set how filament is detected ([rfid_support](rfid_support.md)) |
+| RFID Detection System | External, Snapmaker, OpenRFID, OpenRFID (force generic vendor) | Set how filament is detected ([rfid_support](rfid_support.md)) |
 
 Changes are applied immediately and relevant services are restarted.
 
@@ -156,6 +156,10 @@ Note: Remote screen requires additional Moonraker configuration. See [Remote Scr
 **rfid** - Filament tag detection system
 - `snapmaker` (default) - Snapmaker's built-in RFID reader
 - `external` - Disable built-in readers (useful for external readers)
+- `openrfid` - Alternative detection with extended spool/tag support
+- `openrfid-generic` - Same as openrfid, labels all spool vendors as generic
+
+See [Alternative Filament Detection](rfid_support.md#alternative-detection-systems) for setup instructions.
 
 #### [remote_access]
 
@@ -204,7 +208,7 @@ usb: none
 rtsp: false
 
 [components]
-# Filament tag detection system: external, snapmaker
+# Filament tag detection system: external, snapmaker, openrfid, openrfid-generic
 rfid: snapmaker
 
 [remote_access]

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ Heavily expanded firmware with extensive features and customization. Includes al
 - [Klipper Tweaks](tweaks.md) - Experimental [TMC driver optimizations](tweaks.md#tmc-autotune), [reduced current](tweaks.md#tmc-reduced-current), and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh)
 - [AFC-Lite Stub](afc-lite.md) - Experimental AFC UI compatibility layer for Fluidd/Mainsail
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
+- [Alternative Filament Detection](rfid_support.md#alternative-detection-systems) - Alternative detection implementations with extended spool/tag support from Bambu, Creality, Anycubic, and others
 
 **Monitoring & Notifications:**
 

--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -120,6 +120,53 @@ Use the **NFC Tools** app (iOS/Android) to inspect tags:
 **Compatible tag types:** NTAG213/215/216, Mifare Classic 1K
 **Note:** ISO15693 tags (OpenPrintTag) are not supported
 
+## Alternative Detection Systems
+
+**Available in: Extended firmware only**
+
+The OpenRFID detection system is an alternative to Snapmaker's built-in filament tag detection, based on the [OpenRFID](https://github.com/suchmememanyskill/OpenRFID) project. It adds support for tagged spools from multiple manufacturers.
+
+To enable it, navigate to the [firmware-config](firmware_config.md) web interface, go to **Snapmaker Components > RFID Detection System**, and select **OpenRFID** or **OpenRFID (force generic vendor)**.
+
+- **OpenRFID** - Filament is identified by brand and type. Spools unrecognized by Snapmaker Orca are hidden in Snapmaker Orca.
+- **OpenRFID (force generic vendor)** - Same as OpenRFID, but spools are labeled as Generic so they always appear in Snapmaker Orca.
+- **External** - Disables the built-in readers entirely, useful for external readers such as [wasikuss/snapmaker-u1-remote-rfid-reader](https://github.com/wasikuss/snapmaker-u1-remote-rfid-reader).
+
+### Supported Tags
+
+| System | Enabled by default | Remarks |
+|--------|-------------------|---------|
+| Bambu | No | Requires additional configuration (see below) |
+| Creality | No | Requires additional configuration (see below) |
+| Anycubic | Yes | - |
+| Snapmaker | Yes | - |
+| Elegoo | No | Elegoo spools tagged with RFID work unreliably |
+| [OpenSpool](https://openspool.io/) | Yes | - |
+| TigerTag | Yes | Fully offline implementation |
+
+### Bambu / Creality Spool Configuration
+
+Bambu and Creality tagged spools require authentication keys. Edit the user configuration file to enable them:
+
+```
+/oem/printer_data/config/extended/openrfid_user.cfg
+```
+
+For **Bambu** spools:
+```ini
+[bambu_lab_tag_processor]
+key = <your 32 hex character key>
+```
+
+For **Creality** spools:
+```ini
+[creality_tag_processor]
+key = <your 32 hex character key>
+encryption_key = <your 32 hex character key>
+```
+
+After editing, restart the printer.
+
 ## Troubleshooting
 
 **Tag not detected:**

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -17,7 +17,7 @@ usb: none
 rtsp: false
 
 [components]
-rfid: external, snapmaker
+rfid: external, snapmaker, openrfid, openrfid-generic
 
 [remote_access]
 # Enable SSH access: true, false

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -40,7 +40,7 @@
         .row-desc { display: block; font-size: 12px; color: var(--muted); margin-top: 2px; }
         .row-help { font-size: 12px; color: var(--accent); margin-left: 6px; vertical-align: middle; }
         .row-help:hover { text-decoration: none; opacity: 0.8; }
-        .row select { align-self: flex-start; background: var(--card); border: 1px solid #555; border-radius: 6px; padding: 8px 12px; color: var(--text); font-size: 13px; cursor: pointer; min-width: 150px; }
+        .row select { align-self: flex-start; background: var(--card); border: 1px solid #555; border-radius: 6px; padding: 8px 12px; color: var(--text); font-size: 13px; cursor: pointer; min-width: 150px; max-width: 150px; }
         .row select:focus { outline: none; border-color: var(--accent); }
         .links-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
         .link-item { background: var(--item); padding: 12px 16px; border-radius: 6px; text-decoration: none; display: flex; align-items: center; gap: 10px; transition: background 0.2s; }

--- a/overlays/firmware-extended/30-rfid-support/root/usr/local/share/firmware-config/functions/13_settings_rfid_reader.yaml
+++ b/overlays/firmware-extended/30-rfid-support/root/usr/local/share/firmware-config/functions/13_settings_rfid_reader.yaml
@@ -21,6 +21,7 @@ settings:
               - -xc
               - |
                 /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components rfid external
+                /etc/init.d/S99openrfid stop
                 /etc/init.d/S59rfid-support restart
                 /etc/init.d/S60klipper restart
           snapmaker:
@@ -30,6 +31,7 @@ settings:
               - -xc
               - |
                 /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components rfid snapmaker
+                /etc/init.d/S99openrfid stop
                 /etc/init.d/S59rfid-support restart
                 /etc/init.d/S60klipper restart
         default: snapmaker

--- a/overlays/firmware-extended/30-rfid-support/root/usr/local/share/firmware-config/functions/13_settings_rfid_reader.yaml
+++ b/overlays/firmware-extended/30-rfid-support/root/usr/local/share/firmware-config/functions/13_settings_rfid_reader.yaml
@@ -4,7 +4,7 @@ settings:
     items:
       rfid:
         label: Filament Detection
-        help_url: https://snapmakeru1-extended-firmware.pages.dev/rfid_support#alternative-detection-system
+        help_url: https://snapmakeru1-extended-firmware.pages.dev/rfid_support#alternative-detection-systems
         description: Set how filament is detected.
         get_cmd:
           - /usr/local/bin/extended-config.py

--- a/overlays/firmware-extended/31-openrfid/root/etc/init.d/S99openrfid
+++ b/overlays/firmware-extended/31-openrfid/root/etc/init.d/S99openrfid
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PIDFILE="/var/run/filament-detect.pid"
+PIDFILE="/var/run/openrfid.pid"
 EXTENDED2_CFG="/oem/printer_data/config/extended/extended2.cfg"
 
 start() {

--- a/overlays/firmware-extended/31-openrfid/root/etc/init.d/S99openrfid
+++ b/overlays/firmware-extended/31-openrfid/root/etc/init.d/S99openrfid
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+PIDFILE="/var/run/filament-detect.pid"
+EXTENDED2_CFG="/oem/printer_data/config/extended/extended2.cfg"
+
+start() {
+    RFID=$(/usr/local/bin/extended-config.py get "$EXTENDED2_CFG" components rfid snapmaker 2>/dev/null)
+    DETECT_CONFIG=""
+    case "$RFID" in
+        openrfid)
+            DETECT_CONFIG=/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
+            ;;
+
+        openrfid-generic)
+            DETECT_CONFIG=/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
+            ;;
+
+        *)
+            echo "Filament tag detection not set to openrfid or openrfid-generic, not starting."
+            return
+            ;;
+    esac
+
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        echo "OpenRFID already running"
+        return 0
+    fi
+
+    ADDITIONAL_CONFIG=/oem/printer_data/config/extended/openrfid_user.cfg
+    if ! test -f "$ADDITIONAL_CONFIG"; then
+        ADDITIONAL_CONFIG=""
+    fi
+
+    printf "Starting OpenRFID: "
+    start-stop-daemon -S -b -m \
+        -p "$PIDFILE" \
+        -x /usr/bin/python3 -- /usr/local/bin/openrfid.py \
+        /tmp/openrfid.cfg \
+        /usr/local/share/openrfid/extended/openrfid_u1_base.cfg \
+        $DETECT_CONFIG \
+        $ADDITIONAL_CONFIG
+    echo "OK"
+}
+
+stop() {
+    printf "Stopping OpenRFID: "
+    if [ -f "$PIDFILE" ]; then
+        start-stop-daemon -K -p "$PIDFILE" -s TERM
+        rm -f "$PIDFILE"
+        echo "OK"
+    else
+        echo "not running"
+    fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|reload)
+        stop
+        sleep 1
+        start
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+        ;;
+esac
+
+exit $?

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/bin/openrfid.py
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/bin/openrfid.py
@@ -13,8 +13,20 @@ _FM175XX_READER = "/home/lava/klipper/klippy/extras/fm175xx_reader.py"
 
 
 def _snapmaker_key():
-    with open(_FM175XX_READER, "r") as f:
-        m = re.search(r'FM175XX_M1_CARD_HKDF_SALT_KEY_B\s*=\s*b"([^"]+)"', f.read())
+    try:
+        with open(_FM175XX_READER, "r") as f:
+            content = f.read()
+    except OSError as e:
+        print(f"Error: cannot read Klipper RFID driver at {_FM175XX_READER}: {e}", file=sys.stderr)
+        sys.exit(1)
+    m = re.search(r'FM175XX_M1_CARD_HKDF_SALT_KEY_B\s*=\s*b"([^"]+)"', content)
+    if m is None:
+        print(
+            f"Error: Snapmaker HKDF key not found in {_FM175XX_READER}. "
+            "The firmware driver may have changed.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     return m.group(1).encode().hex()
 
 

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/bin/openrfid.py
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/bin/openrfid.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import configparser
+import logging
+import logging.handlers
+import os
+import re
+import runpy
+import sys
+
+
+_FM175XX_READER = "/home/lava/klipper/klippy/extras/fm175xx_reader.py"
+
+
+def _snapmaker_key():
+    with open(_FM175XX_READER, "r") as f:
+        m = re.search(r'FM175XX_M1_CARD_HKDF_SALT_KEY_B\s*=\s*b"([^"]+)"', f.read())
+    return m.group(1).encode().hex()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <target.cfg> [source.cfg ...]")
+        sys.exit(1)
+
+    target = sys.argv[1]
+    sources = sys.argv[2:]
+
+    config = configparser.RawConfigParser()
+    config.optionxform = str
+    config.read(sources)
+
+    if not config.has_section("snapmaker_tag_processor"):
+        config.add_section("snapmaker_tag_processor")
+    config.set("snapmaker_tag_processor", "key", _snapmaker_key())
+
+    with open(target, "w") as f:
+        config.write(f)
+
+    handler = logging.handlers.SysLogHandler(address="/dev/log")
+    logging.root.handlers = [handler]
+    logging.root.setLevel(logging.DEBUG)
+
+    sys.argv = [sys.argv[0], target]
+    sys.path.insert(0, "/usr/local/share/openrfid")
+    os.chdir("/usr/local/share/openrfid")
+    runpy.run_path("main.py", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/share/firmware-config/functions/15_settings_openrfid.yaml
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/share/firmware-config/functions/15_settings_openrfid.yaml
@@ -1,0 +1,30 @@
+settings:
+  snapmaker_components:
+    items:
+      rfid:
+        options:
+          openrfid:
+            label: OpenRFID
+            confirm: Please read the relevant documentation for this feature. Bambu Lab and Creality spools are not enabled by default.
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components rfid openrfid
+                cp -an /usr/local/share/openrfid/extended/openrfid_user.cfg /oem/printer_data/config/extended/openrfid_user.cfg
+                /etc/init.d/S59rfid-support restart
+                /etc/init.d/S99openrfid start
+                /etc/init.d/S60klipper restart
+          openrfid-generic:
+            label: OpenRFID (force generic vendor)
+            confirm: Please read the relevant documentation for this feature. Bambu Lab and Creality spools are not enabled by default.
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components rfid openrfid-generic
+                cp -an /usr/local/share/openrfid/extended/openrfid_user.cfg /oem/printer_data/config/extended/openrfid_user.cfg
+                /etc/init.d/S59rfid-support restart
+                /etc/init.d/S99openrfid start
+                /etc/init.d/S60klipper restart
+                echo Please read the relevant documentation for this feature. Bambu Lab and Creality spools are not enabled by default.

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/share/firmware-config/functions/15_settings_openrfid.yaml
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/share/firmware-config/functions/15_settings_openrfid.yaml
@@ -27,4 +27,3 @@ settings:
                 /etc/init.d/S59rfid-support restart
                 /etc/init.d/S99openrfid start
                 /etc/init.d/S60klipper restart
-                echo Please read the relevant documentation for this feature. Bambu Lab and Creality spools are not enabled by default.

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
@@ -1,0 +1,85 @@
+[output_pin upper_rfid_coils_enable_pin]
+gpio_device = 1
+line = 27
+
+[output_pin lower_rfid_coils_enable_pin]
+gpio_device = 1
+line = 24
+
+[output_pin rfid_reader_right_side_reset_pin]
+gpio_device = 1
+line = 25
+
+[output_pin rfid_reader_left_side_reset_pin]
+gpio_device = 1
+line = 28
+
+[software_spi rfid_reader_right_side_spi]
+bus = 2
+device = 0
+max_speed_hz = 500000
+mode = 0
+
+[software_spi rfid_reader_left_side_spi]
+bus = 2
+device = 1
+max_speed_hz = 500000
+mode = 0
+
+[fm175xx rfid_reader_right_side]
+enabled = false
+spi = rfid_reader_right_side_spi
+reset_pin = rfid_reader_right_side_reset_pin
+
+[fm175xx rfid_reader_left_side]
+enabled = false
+spi = rfid_reader_left_side_spi
+reset_pin = rfid_reader_left_side_reset_pin
+
+[gpio_enabled_rfid_reader slot_0_reader]
+slot = 0
+rfid_reader = rfid_reader_left_side
+gpio_pins_high = upper_rfid_coils_enable_pin
+gpio_pins_low = lower_rfid_coils_enable_pin
+
+[gpio_enabled_rfid_reader slot_1_reader]
+slot = 1
+rfid_reader = rfid_reader_left_side
+gpio_pins_high = lower_rfid_coils_enable_pin
+gpio_pins_low = upper_rfid_coils_enable_pin
+
+[gpio_enabled_rfid_reader slot_2_reader]
+slot = 2
+rfid_reader = rfid_reader_right_side
+gpio_pins_high = upper_rfid_coils_enable_pin
+gpio_pins_low = lower_rfid_coils_enable_pin
+
+[gpio_enabled_rfid_reader slot_3_reader]
+slot = 3
+rfid_reader = rfid_reader_right_side
+gpio_pins_high = lower_rfid_coils_enable_pin
+gpio_pins_low = upper_rfid_coils_enable_pin
+
+[anycubic_tag_processor]
+
+[openspool_tag_processor]
+
+[tigertag_tag_processor]
+
+[webhook_exporter error_exporter]
+method = POST
+event = tag_read_error
+url = http://localhost/printer/filament_detect/set
+body_json_template = {"channel":{{reader.slot}},"info":{}}
+
+[moonraker_on_property_change]
+moonraker_socket_path = /oem/printer_data/comms/moonraker.sock
+track_object = filament_detect
+track_field = state
+get_index_from_field = array
+act_on_value = 1
+
+[configuration]
+auto_read_mode = false
+retries = 20
+read_interval_seconds = 0.2

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
@@ -1,0 +1,18 @@
+[webhook_exporter success_exporter]
+method = POST
+event = tag_read
+url = http://localhost/printer/filament_detect/set
+body_json_template = {
+        "channel":{{ reader.slot }},
+        "info":{
+            "VENDOR": "{{ 'Snapmaker' if filament.manufacturer == 'Snapmaker' else 'Generic' }}",
+            "MAIN_TYPE": "{{ filament.type }}",
+            "SUB_TYPE": "{{ filament.modifiers | join(' ') if filament.manufacturer == 'Snapmaker' else '' }}",
+            "HOTEND_MIN_TEMP": {{ filament.hotend_min_temp_c | int }},
+            "HOTEND_MAX_TEMP": {{ filament.hotend_max_temp_c | int }},
+            "BED_TEMP": {{ filament.bed_temp_c | int }},
+            "ALPHA": {{ filament.alpha }},
+            "RGB_1": {{ filament.rgb }},
+            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}]
+        }
+    }

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
@@ -1,0 +1,18 @@
+[webhook_exporter success_exporter]
+method = POST
+event = tag_read
+url = http://localhost/printer/filament_detect/set
+body_json_template = {
+        "channel":{{ reader.slot }},
+        "info":{
+            "VENDOR": "{{filament.manufacturer}}",
+            "MAIN_TYPE": "{{ filament.type }}",
+            "SUB_TYPE": "{{ filament.modifiers | join(' ') }}",
+            "HOTEND_MIN_TEMP": {{ filament.hotend_min_temp_c | int }},
+            "HOTEND_MAX_TEMP": {{ filament.hotend_max_temp_c | int }},
+            "BED_TEMP": {{ filament.bed_temp_c | int }},
+            "ALPHA": {{ filament.alpha }},
+            "RGB_1": {{ filament.rgb }},
+            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}]
+        }
+    }

--- a/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
+++ b/overlays/firmware-extended/31-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
@@ -1,0 +1,15 @@
+# Example file on how to configure the Bambu/Creality tag processors.
+
+#[bambu_lab_tag_processor]
+# Bambu Lab tagged filament detection key (32 hex characters)
+#key =
+
+#[creality_tag_processor]
+# Creality tagged filament detection key (32 hex characters)
+#key =
+# Creality tagged filament detection encryption key (32 hex characters)
+#encryption_key =
+
+# Elegoo spools are disabled by default. They are not detected reliably on Snapmaker U1
+# due to tag placement. Uncomment to enable.
+# [elegoo_tag_processor]

--- a/overlays/firmware-extended/31-openrfid/scripts/01-install-openrfid.sh
+++ b/overlays/firmware-extended/31-openrfid/scripts/01-install-openrfid.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+GIT_URL=https://github.com/suchmememanyskill/OpenRFID.git
+GIT_SHA=a8637479fc2579575b6a0e3325534dfca5bcaa7c
+
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
+set -eo pipefail
+
+TARGET_DIR="$CACHE_DIR/OpenRFID"
+cache_git.sh "$TARGET_DIR" "$GIT_URL" "$GIT_SHA"
+
+echo ">> Installing OpenRFID..."
+cd "$TARGET_DIR"
+make install DESTDIR="$ROOTFS_DIR/usr/local/share/openrfid"
+echo ">> OpenRFID installation completed successfully."


### PR DESCRIPTION
## Summary

Bug fixes for the OpenRFID overlay introduced in #306, addressing issues found during review.

- **Wrong PIDFILE path in `S99openrfid`** — The init script used `/var/run/filament-detect.pid`, a leftover from the previous service name. This has been corrected to `/var/run/openrfid.pid`. As written, if any remnant PID file from the old `filament-detect` service existed, the already-running guard would fire incorrectly and OpenRFID would silently refuse to start.

- **Stray `echo` in `15_settings_openrfid.yaml`** — The `openrfid-generic` activation command ended with `echo Please read the relevant documentation...`. This was redundant (the `confirm` dialog already shows this message before the user proceeds) and was explicitly flagged for removal in the review thread.

- **Broken `help_url` anchor** — `13_settings_rfid_reader.yaml` pointed to `#alternative-detection-system` (singular) but the corresponding docs heading is `## Alternative Detection Systems`, which generates the anchor `#alternative-detection-systems`. The `?` button in the firmware-config UI would silently 404 on this anchor.

- **No error handling in `openrfid.py`** — `_snapmaker_key()` would crash with an unhelpful `AttributeError: 'NoneType' object has no attribute 'group'` if the Klipper RFID driver file was missing or had been updated to rename the HKDF key constant. It now prints a descriptive message to stderr and exits with code 1 in both failure cases.

## Test plan

- [x] With no prior `filament-detect` service installed: enable OpenRFID and confirm the PID file is created at `/var/run/openrfid.pid`
- [x] Confirm `S99openrfid stop` cleans up `/var/run/openrfid.pid`
- [x] Enable OpenRFID (force generic vendor): confirm only the `confirm` dialog message appears; no extra text in the action output
- [x] Click the `?` help icon on the Filament Detection setting: confirm it navigates to the correct docs anchor
- [x] Remove `fm175xx_reader.py` temporarily and run `openrfid.py`: confirm a clear error message is printed instead of an `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)