### PR TITLE
feat(tweaks): add Cancel Individual Objects toggle

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -50,7 +50,7 @@ Toggle settings directly from the web interface:
 | Klipper Metrics Exporter | Enabled, Disabled | Enable Prometheus metrics |
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
 | Cloud | None, OctoEverywhere | Enable Cloud-based remote access (Experimental) |
-| Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
+| Tweaks | Cancel Individual Objects, TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
 | RFID Detection System | External, Snapmaker | Set how filament is detected ([rfid_support](rfid_support.md)) |
 
 Changes are applied immediately and relevant services are restarted.

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Heavily expanded firmware with extensive features and customization. Includes al
 **Klipper Customization:**
 
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
-- [Klipper Tweaks](tweaks.md) - Experimental [TMC driver optimizations](tweaks.md#tmc-autotune), [reduced current](tweaks.md#tmc-reduced-current), and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh)
+- [Klipper Tweaks](tweaks.md) - [Cancel Individual Objects](tweaks.md#cancel-individual-objects), experimental [TMC driver optimizations](tweaks.md#tmc-autotune), [reduced current](tweaks.md#tmc-reduced-current), and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh)
 - [AFC-Lite Stub](afc-lite.md) - Experimental AFC UI compatibility layer for Fluidd/Mainsail
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
 

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -4,9 +4,37 @@ title: Klipper Tweaks
 
 # Klipper Tweaks
 
-Advanced experimental tweaks for Klipper stepper motor driver configuration. These settings can **only** be configured via the [Firmware Configuration](firmware_config.md) web interface under **Settings → Tweaks**.
+Advanced experimental tweaks for Klipper configuration. These settings can **only** be configured via the [Firmware Configuration](firmware_config.md) web interface under **Settings → Tweaks**.
 
-> **Warning**: These are experimental features that modify low-level stepper driver parameters. Use with caution and monitor your printer carefully after enabling.
+> **Warning**: These are experimental features. Use with caution and monitor your printer carefully after enabling.
+
+## Cancel Individual Objects
+
+Enables the Klipper `[exclude_object]` module so you can cancel individual objects during a multi-object print directly from the Fluidd or Mainsail web interface — without cancelling the entire print.
+
+**What it does:**
+- Activates Klipper's built-in exclude_object module
+- Adds a per-object cancel button to the Fluidd/Mainsail print status panel
+- Requires no Moonraker-side processing (no file upload delay)
+
+**Slicer setup required:**
+Your slicer must be configured to label objects in the gcode output. Enable the relevant option before slicing:
+
+| Slicer | Setting location | Option name |
+|---|---|---|
+| OrcaSlicer | Print Settings → Others | **Label objects** |
+| Bambu Studio | Print Settings → Others | **Label objects** |
+| PrusaSlicer | Print Settings → Output options | **Label objects** |
+| Cura | Marketplace plugin | **Exclude Objects** plugin |
+
+Prints sliced without object labels will still print normally — the cancel buttons simply won't appear.
+
+**Recommendation:**
+- **Use this instead of** the "Object Processing for Adaptive Mesh" tweak unless you also need adaptive mesh — this approach has zero upload-time overhead
+- Safe to enable permanently; no downside for prints that don't use it
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
 
 ## TMC AutoTune
 
@@ -100,6 +128,7 @@ Changes take effect immediately after Klipper restarts (no reboot required).
 ## Technical Details
 
 These tweaks work by adding or removing configuration files from `/oem/printer_data/config/extended/`:
+- `klipper/exclude_object.cfg` - Cancel Individual Objects (`[exclude_object]`)
 - `klipper/tmc_autotune.cfg` - TMC AutoTune parameters
 - `klipper/tmc_current.cfg` - Reduced current settings
 - `moonraker/object_processing.cfg` - Moonraker object processing settings

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_exclude_object.yaml
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_exclude_object.yaml
@@ -1,0 +1,32 @@
+settings:
+  tweaks:
+    items:
+      exclude_object:
+        label: Cancel Individual Objects
+        description: Enables cancelling individual objects mid-print from the web interface. Requires your slicer to label objects.
+        help_url: https://snapmakeru1-extended-firmware.pages.dev/tweaks#cancel-individual-objects
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/exclude_object.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable Cancel Individual Objects? Your slicer must have 'Label Objects' (OrcaSlicer/Bambu Studio) or 'Exclude Object' (PrusaSlicer/Cura) enabled to generate the required markers. Prints sliced without these markers will work normally."
+            cmd:
+              - bash
+              - -xc
+              - |
+                cp /usr/local/share/firmware-config/tweaks/klipper/exclude_object.cfg /oem/printer_data/config/extended/klipper/exclude_object.cfg &&
+                echo "Cancel Individual Objects enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/exclude_object.cfg &&
+                echo "Cancel Individual Objects disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/exclude_object.cfg
+++ b/overlays/firmware-extended/21-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/exclude_object.cfg
@@ -1,0 +1,18 @@
+# Cancel Individual Objects
+#
+# Enables the Klipper [exclude_object] module, which allows cancelling
+# individual objects mid-print from the Fluidd or Mainsail web interface.
+#
+# Requirements:
+#   Your slicer must have "Label Objects" or "Exclude Object" enabled so that
+#   it emits EXCLUDE_OBJECT_DEFINE markers in the generated gcode.
+#
+#   Supported slicers (enable in print/output settings):
+#     - OrcaSlicer / Bambu Studio : "Label objects" checkbox
+#     - PrusaSlicer / SuperSlicer : Print Settings → Output → Label objects
+#     - Cura                      : "Exclude objects" plugin (Marketplace)
+#
+# Note: Moonraker's "Object Processing" tweak is NOT required when using this
+# setting. Slicer-generated markers are preferred over server-side processing.
+
+[exclude_object]


### PR DESCRIPTION
## Summary

Adds a **Cancel Individual Objects** toggle to the Tweaks section of the firmware-config web interface. When enabled, Klipper's built-in `[exclude_object]` module is activated, allowing users to cancel individual objects mid-print from Fluidd or Mainsail without cancelling the entire print job.

- Follows the exact same pattern as the existing TMC tweaks (enable/disable writes/removes a cfg file and restarts Klipper)
- Zero overhead: no Moonraker-side object processing, no file upload delay
- Prints sliced without object labels work normally — the cancel UI simply doesn't appear
- Full docs added to `tweaks.md` including a slicer compatibility table

## How it works

Toggling to **Enabled** copies `exclude_object.cfg` (containing just `[exclude_object]`) into `/oem/printer_data/config/extended/klipper/` and restarts Klipper. Toggling to **Disabled** removes it.

## Slicer setup (user responsibility)

| Slicer | Where | Option |
|---|---|---|
| OrcaSlicer / Bambu Studio | Print Settings → Others | **Label objects** |
| PrusaSlicer | Print Settings → Output options | **Label objects** |
| Cura | Marketplace | **Exclude Objects** plugin |

## Test plan

- [ ] Enable the tweak; confirm `[exclude_object]` appears in `GET /printer/objects/list` response
- [ ] Slice a multi-object plate with "Label objects" enabled; confirm cancel buttons appear in Fluidd/Mainsail during print
- [ ] Slice without "Label objects"; confirm print works normally with no errors
- [ ] Disable the tweak; confirm `exclude_object.cfg` is removed and Klipper restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)