### PR TITLE
Fixes #209:  Add user-controlled toggle to suppress mqtt_agent DNS polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,18 @@ tools/rk2918_tools/img_maker
 tools/rk2918_tools/img_unpack
 tools/rk2918_tools/mkkrnlimg
 _site/
+
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Claude.ai files and stuff
+.claude
+plan.md
+research.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ _site/
 
 # Claude.ai files and stuff
 .claude
-plan.md
-research.md

--- a/overlays/common/05-disable-cloud-polling/patches/01-guard-mqtt-agent.patch
+++ b/overlays/common/05-disable-cloud-polling/patches/01-guard-mqtt-agent.patch
@@ -1,0 +1,12 @@
+--- a/etc/init.d/S59mqtt_agent
++++ b/etc/init.d/S59mqtt_agent
+@@ -6,6 +6,9 @@
+ PROG=mqtt_agent
+ PIDFILE=/var/run/mqtt_agent.pid
+ ARGS="-v true"
++
++# Skip cloud agent if disabled by custom firmware
++[ -f /oem/.cloud_agent_disabled ] && exit 0
+
+ log()
+ {

--- a/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/17_settings_cloud_agent.yaml
+++ b/overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/17_settings_cloud_agent.yaml
@@ -1,0 +1,32 @@
+settings:
+  remote_access:
+    items:
+      cloud-agent:
+        label: Snapmaker Cloud Agent
+        description: >
+          Controls the mqtt_agent cloud connectivity service. When disabled, the printer
+          stops making repeated DNS requests to id.snapmaker.com every 5 seconds. Disable
+          this if you do not use the Snapmaker mobile app or cloud remote control features.
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/.cloud_agent_disabled && echo "disabled" || echo "enabled"
+        options:
+          enabled:
+            label: Enabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/.cloud_agent_disabled &&
+                /etc/init.d/S59mqtt_agent start
+          disabled:
+            label: Disabled (stops DNS queries to id.snapmaker.com)
+            confirm: "Disabling stops the Snapmaker cloud connectivity service. The Snapmaker mobile app and cloud remote control will not work. Continue?"
+            cmd:
+              - bash
+              - -xc
+              - |
+                touch /oem/.cloud_agent_disabled &&
+                /etc/init.d/S59mqtt_agent stop
+        default: enabled


### PR DESCRIPTION
## Summary

Fixes #290 — the printer emits two DNS queries (A + AAAA) for `id.snapmaker.com` every ~5 seconds due to `mqtt_agent` cycling through its reconnect state machine when cloud auth fails.

- Adds a flag-file guard to `S59mqtt_agent` via a new common overlay (`05-disable-cloud-polling`), so the service can be suppressed without patching the closed-source binary. Applies to both `basic` and `extended` profiles.
- Adds a **Snapmaker Cloud Agent** toggle in the firmware-config UI under **Remote Access** (extended profile only), so users can enable/disable the service without SSH.
- Defaults to **enabled** — no breaking change for users who use the Snapmaker mobile app or cloud remote control.

## Root cause

`mqtt_agent` enters a `NETWORK_DETECTION` → `CONNECTING_BROKER` → failure → retry loop every ~5 seconds when the device is not enrolled in the Snapmaker cloud (or auth has expired). Each retry cycle calls `getaddrinfo("id.snapmaker.com")`, producing the A + AAAA query pattern. The binary accepts no flag to disable cloud connectivity.

## Changes

- **`overlays/common/05-disable-cloud-polling/patches/01-guard-mqtt-agent.patch`** — patches `S59mqtt_agent` to exit early if `/oem/.cloud_agent_disabled` exists. `/oem/` is persistent storage, so the setting survives reboots and firmware updates.
- **`overlays/firmware-extended/10-firmware-config/root/usr/local/share/firmware-config/functions/17_settings_cloud_agent.yaml`** — adds the UI toggle. Selecting **Disabled** writes the flag file and stops the running service live; **Enabled** removes the flag and starts it. No reboot required.

## Test plan

- [x] Flashed firmware to test printer, navigated to **Remote Access** in firmware-config — **Snapmaker Cloud Agent** toggle present, defaulting to **Enabled**
- [x] Confirmed baseline DNS queries to `id.snapmaker.com` (A + AAAA) visible every ~5 seconds while enabled
- [x] Selected **Disabled**, confirmed dialog — `mqtt_agent` stopped, `/oem/.cloud_agent_disabled` created, DNS queries ceased
- [x] Selected **Enabled** — service restarted, DNS queries resumed within ~10 seconds
- [x] Rebooted with flag present — `mqtt_agent` did not start on boot, flag persisted in `/oem/`
- [x] Basic profile SSH test: `touch /oem/.cloud_agent_disabled && /etc/init.d/S59mqtt_agent stop` — process stopped cleanly
