### PR TITLE
feat: make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ tools: tools/rk2918_tools tools/upfile tools/resource_tool
 tools/%: FORCE
 	make -C $@
 
+.PHONY: tools-clean
+tools-clean:
+	make -C tools/rk2918_tools clean
+	make -C tools/upfile clean
+	make -C tools/resource_tool clean
+
 # =============== Firmware ===============
 
 .PHONY: firmware
@@ -64,6 +70,10 @@ firmware/$(FIRMWARE_FILE):
 	wget -O $@.tmp "https://public.resource.snapmaker.com/firmware/U1/$(FIRMWARE_FILE)"
 	echo "$(FIRMWARE_SHA256)  $@.tmp" | sha256sum -c --quiet
 	mv $@.tmp $@
+
+.PHONY: clean-firmware
+firmware-clean:
+	rm -rf firmware/
 
 # ================= Test =================
 
@@ -79,3 +89,9 @@ changelog:
 
 .PHONY: FORCE
 FORCE:
+
+# ================= Clean =================
+
+.PHONY: clean
+clean: tools-clean firmware-clean
+	rm -rf $(BUILD_DIR)

--- a/tools/resource_tool/Makefile
+++ b/tools/resource_tool/Makefile
@@ -1,5 +1,5 @@
 resource_tool: resource_tool.c
 	gcc -o $@ $<
 
-clean: 
+clean:
 	rm -f resource_tool

--- a/tools/rk2918_tools/Makefile
+++ b/tools/rk2918_tools/Makefile
@@ -10,4 +10,4 @@ TARGETS := afptool img_unpack img_maker mkkrnlimg
 all: ${TARGETS}
 
 clean:
-	rm ${TARGETS}
+	rm -f ${TARGETS}

--- a/tools/upfile/Makefile
+++ b/tools/upfile/Makefile
@@ -8,3 +8,6 @@ test: upfile
 	./upfile pack tmp/update.bin tmp
 	md5sum $(FIRMWARE_FILE) tmp/update.bin
 	cmp $(FIRMWARE_FILE) tmp/update.bin
+
+clean:
+	rm -f upfile


### PR DESCRIPTION
Because artifact folders and files are created in a container that is 1/ owned by root 2/ through `make`, they probably should be cleaned through `make` in a manner that leaves no possible errors when running `rm -rf` as root.