### PR TITLE
feat: add dev script for amd64 hosts

### DIFF
--- a/dev.amd64.sh
+++ b/dev.amd64.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+IMAGE_NAME="snapmaker-u1-dev"
+BUILD_CONTEXT=".github/dev"
+
+# See https://docs.docker.com/build/building/multi-platform/
+if ! docker buildx build --platform linux/arm64 --cache-from "$IMAGE_NAME" -t "$IMAGE_NAME" --load "$BUILD_CONTEXT"; then
+    echo "[!] Docker build failed."
+    exit 1
+fi
+
+TTY_FLAG=""
+[[ -t 0 ]] && TTY_FLAG="-it"
+
+ENV_FLAGS="-e GIT_VERSION -e CI -e PASSWORD"
+
+exec docker run --platform linux/arm64 --rm $TTY_FLAG $ENV_FLAGS -w "$PWD" -v "$PWD:$PWD" --entrypoint /bin/bash "$IMAGE_NAME"


### PR DESCRIPTION
I ran into issues when trying to build my own firmware, and edited `./dev.sh` to fix them. I was able to build a entire firmware, from nothing up to its deployment on my U1.

I can guarantee that this isn't *enough* to run on Linux amd64; for example,  I had to install `qemu-user-static` to run the image. As my system is already set up for cross-platform Docker image builds, there's likely even more steps missing.

Opened this PR to open the discussion!