### PR TITLE
Moonraker filament type parsing fix

### DIFF
--- a/overlays/firmware-extended/24-moonraker-patches/patches/02-fix-moonraker-filament-type-parsing.patch
+++ b/overlays/firmware-extended/24-moonraker-patches/patches/02-fix-moonraker-filament-type-parsing.patch
@@ -1,5 +1,5 @@
---- a/home/lava/moonraker/moonraker/components/file_manager/metadata.py
-+++ b/home/lava/moonraker/moonraker/components/file_manager/metadata.py
+--- rootfs.original/home/lava/moonraker/moonraker/components/file_manager/metadata.py	2026-03-25 15:20:49.474585752 +0100
++++ rootfs/home/lava/moonraker/moonraker/components/file_manager/metadata.py	2026-03-25 15:24:23.677931165 +0100
 @@ -93,7 +93,7 @@
      pattern = pattern.replace(r"(%S)", r"(.*)")
      match = re.search(pattern, data)
@@ -7,5 +7,5 @@
 -        return match.group(1).strip('"')
 +        return match.group(1).replace('"', '')
      return None
-
+ 
  def regex_find_min_float(pattern: str, data: str) -> Optional[float]:

--- a/overlays/firmware-extended/24-moonraker-patches/patches/02-fix-moonraker-filament-type-parsing.patch
+++ b/overlays/firmware-extended/24-moonraker-patches/patches/02-fix-moonraker-filament-type-parsing.patch
@@ -1,0 +1,11 @@
+--- a/home/lava/moonraker/moonraker/components/file_manager/metadata.py
++++ b/home/lava/moonraker/moonraker/components/file_manager/metadata.py
+@@ -93,7 +93,7 @@
+     pattern = pattern.replace(r"(%S)", r"(.*)")
+     match = re.search(pattern, data)
+     if match:
+-        return match.group(1).strip('"')
++        return match.group(1).replace('"', '')
+     return None
+
+ def regex_find_min_float(pattern: str, data: str) -> Optional[float]:


### PR DESCRIPTION
Not sure if this is something that deserves a firmware patch, but it fixes a bug that results in filament type mismatches when there is a space in the filament type provided by the slicer, which in turn blocks filament selection from the Snapmaker U1 print UI.

More details here: https://github.com/Arksine/moonraker/pull/1066

Ideally, Snapmaker could fix it by updating Moonraker once (and if) my fix is merged there, but who knows if that will ever happen.