### PR TITLE
Fix NTAG UID for multi-cascade anti-collision

### DIFF
--- a/overlays/firmware-extended/31-openrfid/patches/usr/local/share/openrfid/02-fix-ntag-uid.patch
+++ b/overlays/firmware-extended/31-openrfid/patches/usr/local/share/openrfid/02-fix-ntag-uid.patch
@@ -1,0 +1,16 @@
+diff --git a/reader/fm175xx/rfid.py b/reader/fm175xx/rfid.py
+index 8e0e877..c860a26 100644
+--- a/reader/fm175xx/rfid.py
++++ b/reader/fm175xx/rfid.py
+@@ -479,7 +479,10 @@ class Fm175xx(MifareClassicReader, MifareUltralightReader):
+                 ret = Constants.FM175XX_CARD_COLL_ERR
+                 break
+
+-            UID += UID_part
++            if level < cascade_level - 1:
++                UID += UID_part[1:]
++            else:
++                UID += UID_part
+             BCC.append(BCC_part)
+
+             (ret, SAK_part) = self.__reader_a_select(level, UID_part, BCC_part)


### PR DESCRIPTION
In ISO 14443-3 anti-collision, multi-byte UIDs (7 or 10 bytes) span multiple cascade levels. Intermediate levels prefix UID parts with a cascade tag byte (0x88) that must be excluded from the final UID.

The FM175xx driver was appending the full `UID_part` at every level, including the cascade tag of intermediate levels, yielding a corrupt UID.

Strip the first byte from `UID_part` for all levels except the last so the assembled UID contains only the actual tag bytes.