### PR TITLE
Persist last assigned DHCP IP address to reduce chance of IP address rotation

### DIFF
--- a/overlays/common/05-persist-dhcp/root/etc/init.d/S10persist-dhcp
+++ b/overlays/common/05-persist-dhcp/root/etc/init.d/S10persist-dhcp
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+export PATH
+
+case "$1" in
+  start)
+    mkdir -p /oem/dhcpcd
+    if [ ! -L /var/db/dhcpcd ]; then
+      rm -rf /var/db/dhcpcd
+      ln -s /oem/dhcpcd /var/db/dhcpcd
+    fi
+    ;;
+  stop|restart|status)
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This makes printer to persist latest lease used, and try to re-use the lease after restart instead of depending on the router.