### PR TITLE
Add `14-patch-firmware-files` overlay for common USB NIC firmware

### DIFF
--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:trixie
 
+RUN sed -i 's/^Components: .*/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
+
 # The ccache is installed separately
 # as otherwise not all symlinks are created
 RUN apt-get update -y && \
@@ -24,6 +26,7 @@ RUN apt-get update -y && \
       golang-go \
       ffmpeg \
       u-boot-tools \
+      firmware-realtek \
     && apt-get -y install ccache \
     && git config --global --add safe.directory '*' \
     && rm -rf /var/lib/apt/lists/*

--- a/overlays/firmware-extended/14-patch-firmware-files/scripts/01_pull_firmware_files.sh
+++ b/overlays/firmware-extended/14-patch-firmware-files/scripts/01_pull_firmware_files.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
+set -eo pipefail
+
+FIRMWARE_FILES=(
+  # RTL8153A (USB 3.0, revision A)
+  rtl_nic/rtl8153a-4.fw
+  # RTL8153B (USB 3.0, revision B)
+  rtl_nic/rtl8153b-2.fw
+  # RTL8153C (USB 3.0, revision C)
+  rtl_nic/rtl8153c-1.fw
+  # RTL8156A (USB 3.0, 2.5G, revision A)
+  rtl_nic/rtl8156a-2.fw
+  # RTL8156B (USB 3.0, 2.5G, revision B)
+  rtl_nic/rtl8156b-2.fw
+)
+
+HOST_FIRMWARE_DIR=/usr/lib/firmware
+ROOTFS_FIRMWARE_DIR="$ROOTFS_DIR/lib/firmware"
+
+for fw_file in "${FIRMWARE_FILES[@]}"; do
+  dest="$ROOTFS_FIRMWARE_DIR/$fw_file"
+  src="$HOST_FIRMWARE_DIR/$fw_file"
+
+  if [[ -e "$dest" ]]; then
+    echo "Error: '$fw_file' already exists in firmware rootfs — refusing to overwrite."
+    exit 1
+  fi
+
+  if [[ ! -f "$src" ]]; then
+    echo "Error: '$fw_file' not found on host system at '$src'."
+    exit 1
+  fi
+
+  echo "[+] Pulling firmware: $fw_file"
+  install -D -m 644 "$src" "$dest"
+done


### PR DESCRIPTION
## Summary

- Add `14-patch-firmware-files` overlay that pulls Realtek USB NIC firmware files from the build host into the firmware rootfs

## Firmware files included

| File | Chip | Notes |
|---|---|---|
| `rtl_nic/rtl8153a-4.fw` | RTL8153A | USB 3.0 1G, rev A |
| `rtl_nic/rtl8153b-2.fw` | RTL8153B | USB 3.0 1G, rev B |
| `rtl_nic/rtl8153c-1.fw` | RTL8153C | USB 3.0 1G, rev C |
| `rtl_nic/rtl8156a-2.fw` | RTL8156A | USB 3.0 2.5G, rev A |
| `rtl_nic/rtl8156b-2.fw` | RTL8156B | USB 3.0 2.5G, rev B |
