### PR TITLE
Add per-toolhead faulty thermistor bypass controls

### DIFF
--- a/docs/faulty_toolhead.md
+++ b/docs/faulty_toolhead.md
@@ -1,0 +1,78 @@
+---
+title: Faulty Toolhead Bypass
+---
+
+# Faulty Toolhead Bypass
+
+This firmware adds a Firmware Config recovery option for Snapmaker U1 printers
+that hit error `0003-0523-0000-0002` because one toolhead thermistor is faulty.
+
+It is based on Snapmaker's official guide:
+
+- https://wiki.snapmaker.com/en/snapmaker_u1/troubleshooting/bypass_a_faulty_toolhead
+
+## Warning
+
+This bypass is only intended to let the printer boot and keep using the
+remaining toolheads until the damaged part is replaced.
+
+- Do not heat or print with the faulty toolhead while the bypass is enabled.
+- Disable the bypass again after the repair is complete.
+
+## Configure
+
+1. Enable Advanced Mode on the printer screen.
+2. Open `http://<printer-ip>/firmware-config/`.
+3. Go to **Settings -> Troubleshooting**.
+4. Use the row for each affected toolhead:
+   `Faulty Toolhead 1`, `Faulty Toolhead 2`, `Faulty Toolhead 3`, or
+   `Faulty Toolhead 4`.
+5. Change that row from **Normal** to **Bypass Thermistor**.
+5. Firmware Config will restart Klipper automatically.
+
+To undo it after replacing the faulty part, set each affected toolhead row back
+to **Normal**.
+
+## What It Changes
+
+For the selected toolhead, the override:
+
+- remaps the extruder temperature `sensor_pin` to `PC5`
+- raises the extruder `max_temp` to `999`
+- sets the extruder `max_power` to `0.000001` because Klipper rejects `0`
+- sets the matching nozzle cooling fan `heater_temp` to `999`
+- sets the matching nozzle cooling fan `fan_speed` to `0`
+- changes the last `stepped_temp_table` entry from `260, 0.9` to `260, 0`
+
+Toolhead mapping:
+
+- Toolhead 1 -> `[extruder]` and `[heater_fan e0_nozzle_fan]`
+- Toolhead 2 -> `[extruder1]` and `[heater_fan e1_nozzle_fan]`
+- Toolhead 3 -> `[extruder2]` and `[heater_fan e2_nozzle_fan]`
+- Toolhead 4 -> `[extruder3]` and `[heater_fan e3_nozzle_fan]`
+
+## Implementation Note
+
+Inference from the official guide and the stock U1 `printer.cfg`:
+
+- The official guide says to change the temperature sensor pin suffix to `PC5`.
+- Stock U1 configs use per-toolhead MCU pin names (`e0:PA2`, `e1:PA2`,
+  `e2:PA2`, `e3:PA2`).
+- This firmware therefore implements the remap as `e0:PC5`, `e1:PC5`,
+  `e2:PC5`, or `e3:PC5` for the selected toolhead.
+
+The active override is installed into:
+
+```text
+/oem/printer_data/config/extended/klipper/
+```
+
+Filename pattern:
+
+- `faulty_toolhead1.cfg`
+- `faulty_toolhead2.cfg`
+- `faulty_toolhead3.cfg`
+- `faulty_toolhead4.cfg`
+
+Multiple faulty-toolhead overrides can be enabled at the same time if more than
+one toolhead is affected.

--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -50,6 +50,7 @@ Toggle settings directly from the web interface:
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
 | Cloud | None, OctoEverywhere | Enable Cloud-based remote access (Experimental) |
 | Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
+| Troubleshooting | Faulty Toolhead Bypass | Temporary toolhead thermistor bypass so the remaining toolheads can still be used ([faulty_toolhead](faulty_toolhead.md)) |
 | RFID Detection System | External, Snapmaker, OpenRFID, OpenRFID (force generic vendor) | Set how filament is detected ([rfid_support](rfid_support.md)) |
 
 Changes are applied immediately and relevant services are restarted.
@@ -94,6 +95,10 @@ For advanced configuration, edit the configuration file directly.
 ### Editing the Configuration File
 
 The `extended2.cfg` file is automatically created by the firmware.
+
+Some Firmware Config options, such as tweaks and troubleshooting helpers,
+install files into `extended/klipper/` or `extended/moonraker/` instead of
+writing to `extended2.cfg`.
 
 #### Via Fluidd/Mainsail
 
@@ -244,7 +249,8 @@ The `.default` files are updated on each boot to reflect the current firmware de
 - Lines starting with `#` are comments and ignored
 - Only one camera service can be active at a time for internal camera
 - Only one web interface can be active at a time
-- Changes made via the Firmware Config web interface are written to `extended2.cfg`
+- Many Firmware Config settings update `extended2.cfg`, but some options also
+  manage files in `extended/klipper/` or `extended/moonraker/`
 
 ## Recovery & Reset
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ Heavily expanded firmware with extensive features and customization:
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
 - [Klipper Tweaks](tweaks.md) - Experimental [TMC driver optimizations](tweaks.md#tmc-autotune), [reduced current](tweaks.md#tmc-reduced-current), and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh)
 - [AFC-Lite Stub](afc-lite.md) - Experimental AFC UI compatibility layer for Fluidd/Mainsail
+- [Faulty Toolhead Bypass](faulty_toolhead.md) - Temporary bypass for one failed toolhead thermistor so the other toolheads can still be used
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
 - [Alternative Filament Detection](rfid_support.md#alternative-detection-systems) - Alternative detection implementations with extended spool/tag support from Bambu, Creality, Anycubic, and others
 

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
@@ -9,5 +9,7 @@ settings:
     label: Snapmaker Components
   tweaks:
     label: Tweaks
+  troubleshooting:
+    label: Troubleshooting
   monitoring_debugging:
     label: Monitoring & Debugging

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/README.md
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/README.md
@@ -1,0 +1,37 @@
+# Faulty Toolhead Bypass
+
+This overlay adds a Firmware Config setting that applies Snapmaker's temporary
+workaround for error `0003-0523-0000-0002` when one toolhead thermistor is
+damaged and prevents the printer from booting normally.
+
+Each toolhead setting installs its own Klipper override independently.
+Each override:
+
+- remaps the affected extruder temperature sensor pin to `PC5`
+- raises the affected extruder `max_temp` to `999`
+- sets the affected extruder `max_power` to `0.000001`
+- sets the matching nozzle cooling fan `heater_temp` to `999`
+- sets the matching nozzle cooling fan `fan_speed` to `0`
+- changes the last `stepped_temp_table` entry to `260, 0`
+
+Toolhead mapping:
+
+- Toolhead 1 -> `[extruder]` and `[heater_fan e0_nozzle_fan]`
+- Toolhead 2 -> `[extruder1]` and `[heater_fan e1_nozzle_fan]`
+- Toolhead 3 -> `[extruder2]` and `[heater_fan e2_nozzle_fan]`
+- Toolhead 4 -> `[extruder3]` and `[heater_fan e3_nozzle_fan]`
+
+Source:
+
+- Snapmaker Wiki: https://wiki.snapmaker.com/en/snapmaker_u1/troubleshooting/bypass_a_faulty_toolhead
+
+Inference from the stock U1 `printer.cfg`:
+
+- The official guide says to change the sensor pin suffix to `PC5`.
+- Stock U1 config uses per-toolhead MCU prefixes (`e0:PA2`, `e1:PA2`,
+  `e2:PA2`, `e3:PA2`), so this overlay implements that as `e0:PC5`,
+  `e1:PC5`, `e2:PC5`, and `e3:PC5`.
+
+This is a temporary recovery aid so the remaining toolheads can be used until
+the faulty part is replaced. Enable it only for the affected toolheads and
+disable it again after repair.

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/24_settings_troubleshooting_faulty_toolhead1.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/24_settings_troubleshooting_faulty_toolhead1.yaml
@@ -1,0 +1,33 @@
+settings:
+  troubleshooting:
+    items:
+      toolhead1:
+        label: Toolhead 1
+        description: Temporary thermistor and heating bypass for Toolhead 1.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/faulty_toolhead
+        get_cmd:
+          - bash
+          - -c
+          - test -e /oem/printer_data/config/extended/klipper/faulty_toolhead1.cfg && echo "bypass_thermistor" || echo "enabled"
+        options:
+          enabled:
+            label: Normal
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/faulty_toolhead1.cfg &&
+                echo "Toolhead 1 thermistor bypass disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          bypass_thermistor:
+            label: Bypass Thermistor
+            confirm: "Apply the faulty toolhead bypass to Toolhead 1? This disables normal temperature fault handling for Toolhead 1 so the printer can keep using the other toolheads. Do not heat or print with the faulty toolhead while this bypass is enabled."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead1.cfg /oem/printer_data/config/extended/klipper/faulty_toolhead1.cfg &&
+                echo "Toolhead 1 faulty toolhead bypass enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: enabled

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/25_settings_troubleshooting_faulty_toolhead2.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/25_settings_troubleshooting_faulty_toolhead2.yaml
@@ -1,0 +1,33 @@
+settings:
+  troubleshooting:
+    items:
+      toolhead2:
+        label: Toolhead 2
+        description: Temporary thermistor and heating bypass for Toolhead 2.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/faulty_toolhead
+        get_cmd:
+          - bash
+          - -c
+          - test -e /oem/printer_data/config/extended/klipper/faulty_toolhead2.cfg && echo "bypass_thermistor" || echo "enabled"
+        options:
+          enabled:
+            label: Normal
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/faulty_toolhead2.cfg &&
+                echo "Toolhead 2 thermistor bypass disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          bypass_thermistor:
+            label: Bypass Thermistor
+            confirm: "Apply the faulty toolhead bypass to Toolhead 2? This disables normal temperature fault handling for Toolhead 2 so the printer can keep using the other toolheads. Do not heat or print with the faulty toolhead while this bypass is enabled."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead2.cfg /oem/printer_data/config/extended/klipper/faulty_toolhead2.cfg &&
+                echo "Toolhead 2 faulty toolhead bypass enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: enabled

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/26_settings_troubleshooting_faulty_toolhead3.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/26_settings_troubleshooting_faulty_toolhead3.yaml
@@ -1,0 +1,33 @@
+settings:
+  troubleshooting:
+    items:
+      toolhead3:
+        label: Toolhead 3
+        description: Temporary thermistor and heating bypass for Toolhead 3.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/faulty_toolhead
+        get_cmd:
+          - bash
+          - -c
+          - test -e /oem/printer_data/config/extended/klipper/faulty_toolhead3.cfg && echo "bypass_thermistor" || echo "enabled"
+        options:
+          enabled:
+            label: Normal
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/faulty_toolhead3.cfg &&
+                echo "Toolhead 3 thermistor bypass disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          bypass_thermistor:
+            label: Bypass Thermistor
+            confirm: "Apply the faulty toolhead bypass to Toolhead 3? This disables normal temperature fault handling for Toolhead 3 so the printer can keep using the other toolheads. Do not heat or print with the faulty toolhead while this bypass is enabled."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead3.cfg /oem/printer_data/config/extended/klipper/faulty_toolhead3.cfg &&
+                echo "Toolhead 3 faulty toolhead bypass enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: enabled

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/27_settings_troubleshooting_faulty_toolhead4.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/27_settings_troubleshooting_faulty_toolhead4.yaml
@@ -1,0 +1,33 @@
+settings:
+  troubleshooting:
+    items:
+      toolhead4:
+        label: Toolhead 4
+        description: Temporary thermistor and heating bypass for Toolhead 4.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/faulty_toolhead
+        get_cmd:
+          - bash
+          - -c
+          - test -e /oem/printer_data/config/extended/klipper/faulty_toolhead4.cfg && echo "bypass_thermistor" || echo "enabled"
+        options:
+          enabled:
+            label: Normal
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/faulty_toolhead4.cfg &&
+                echo "Toolhead 4 thermistor bypass disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          bypass_thermistor:
+            label: Bypass Thermistor
+            confirm: "Apply the faulty toolhead bypass to Toolhead 4? This disables normal temperature fault handling for Toolhead 4 so the printer can keep using the other toolheads. Do not heat or print with the faulty toolhead while this bypass is enabled."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead4.cfg /oem/printer_data/config/extended/klipper/faulty_toolhead4.cfg &&
+                echo "Toolhead 4 faulty toolhead bypass enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: enabled

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead1.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead1.cfg
@@ -1,0 +1,26 @@
+# faulty_toolhead_bypass: toolhead1
+# Temporary bypass for Snapmaker U1 Toolhead 1 thermistor failure.
+# Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.
+# Do not heat or print with the faulty toolhead while this override is enabled.
+
+[extruder]
+sensor_pin: e0:PC5
+max_temp: 999
+max_power: 0.000001
+
+[heater_fan e0_nozzle_fan]
+heater_temp: 999
+fan_speed: 0
+stepped_temp_table:
+  45, 0.3
+  60, 0.35
+  70, 0.4
+  100, 0.45
+  140, 0.5
+  160, 0.6
+  180, 0.65
+  200, 0.7
+  220, 0.75
+  230, 0.8
+  240, 0.85
+  260, 0

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead2.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead2.cfg
@@ -1,0 +1,26 @@
+# faulty_toolhead_bypass: toolhead2
+# Temporary bypass for Snapmaker U1 Toolhead 2 thermistor failure.
+# Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.
+# Do not heat or print with the faulty toolhead while this override is enabled.
+
+[extruder1]
+sensor_pin: e1:PC5
+max_temp: 999
+max_power: 0.000001
+
+[heater_fan e1_nozzle_fan]
+heater_temp: 999
+fan_speed: 0
+stepped_temp_table:
+  45, 0.3
+  60, 0.35
+  70, 0.4
+  100, 0.45
+  140, 0.5
+  160, 0.6
+  180, 0.65
+  200, 0.7
+  220, 0.75
+  230, 0.8
+  240, 0.85
+  260, 0

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead3.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead3.cfg
@@ -1,0 +1,26 @@
+# faulty_toolhead_bypass: toolhead3
+# Temporary bypass for Snapmaker U1 Toolhead 3 thermistor failure.
+# Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.
+# Do not heat or print with the faulty toolhead while this override is enabled.
+
+[extruder2]
+sensor_pin: e2:PC5
+max_temp: 999
+max_power: 0.000001
+
+[heater_fan e2_nozzle_fan]
+heater_temp: 999
+fan_speed: 0
+stepped_temp_table:
+  45, 0.3
+  60, 0.35
+  70, 0.4
+  100, 0.45
+  140, 0.5
+  160, 0.6
+  180, 0.65
+  200, 0.7
+  220, 0.75
+  230, 0.8
+  240, 0.85
+  260, 0

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead4.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead4.cfg
@@ -1,0 +1,26 @@
+# faulty_toolhead_bypass: toolhead4
+# Temporary bypass for Snapmaker U1 Toolhead 4 thermistor failure.
+# Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.
+# Do not heat or print with the faulty toolhead while this override is enabled.
+
+[extruder3]
+sensor_pin: e3:PC5
+max_temp: 999
+max_power: 0.000001
+
+[heater_fan e3_nozzle_fan]
+heater_temp: 999
+fan_speed: 0
+stepped_temp_table:
+  45, 0.3
+  60, 0.35
+  70, 0.4
+  100, 0.45
+  140, 0.5
+  160, 0.6
+  180, 0.65
+  200, 0.7
+  220, 0.75
+  230, 0.8
+  240, 0.85
+  260, 0


### PR DESCRIPTION
Add Firmware Config troubleshooting controls for Snapmaker U1 toolheads to bypass faulty thermistors individually, based on the Snapmaker wiki guide: https://wiki.snapmaker.com/en/snapmaker_u1/troubleshooting/bypass_a_faulty_toolhead . Each toolhead can be switched independently between normal mode and thermistor bypass, with the override also locking out heating and adjusting the nozzle fan behavior so affected toolheads do not block printer startup.

## Screenshots

<img width="988" height="543" alt="Screenshot 2026-04-03 at 17 36 43" src="https://github.com/user-attachments/assets/4437c8a7-e3ed-4c0f-94d8-8d13dc563e62" />
