### PR TITLE
Prefer cached pip installs with network fallback

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -15,4 +15,4 @@ TTY_FLAG=""
 
 ENV_FLAGS="-e GIT_VERSION -e CI -e PASSWORD"
 
-exec docker run --rm $TTY_FLAG $ENV_FLAGS --cap-add=SYS_ADMIN -w "$PWD" -v "$PWD:$PWD" "$IMAGE_NAME" "$@"
+exec docker run --rm $DOCKER_OPTS $TTY_FLAG $ENV_FLAGS --cap-add=SYS_ADMIN -w "$PWD" -v "$PWD:$PWD" "$IMAGE_NAME" "$@"

--- a/overlays/firmware-extended/02-firmware-config/scripts/01-install-yaml.sh
+++ b/overlays/firmware-extended/02-firmware-config/scripts/01-install-yaml.sh
@@ -8,4 +8,4 @@ fi
 set -eo pipefail
 
 echo ">> Installing PyYAML via pip3"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install pyyaml
+cache_pip.sh "$ROOTFS_DIR" pyyaml

--- a/overlays/firmware-extended/12-patch-moonraker/scripts/01-install-apprise.sh
+++ b/overlays/firmware-extended/12-patch-moonraker/scripts/01-install-apprise.sh
@@ -8,4 +8,4 @@ fi
 set -eo pipefail
 
 echo ">> Installing Apprise via pip3"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install apprise
+cache_pip.sh "$ROOTFS_DIR" apprise

--- a/overlays/firmware-extended/12-patch-moonraker/scripts/02-install-wled.sh
+++ b/overlays/firmware-extended/12-patch-moonraker/scripts/02-install-wled.sh
@@ -8,4 +8,4 @@ fi
 set -eo pipefail
 
 echo ">> Installing WLED via pip3"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install wled
+cache_pip.sh "$ROOTFS_DIR" wled

--- a/overlays/firmware-extended/61-app-remote-screen/pre-scripts/01-install-screen-apps.sh
+++ b/overlays/firmware-extended/61-app-remote-screen/pre-scripts/01-install-screen-apps.sh
@@ -11,4 +11,4 @@ echo ">> Installing screen-apps"
 make -C "$ROOT_DIR/deps/screen-apps" install DESTDIR="$ROOTFS_DIR"
 
 echo ">> Installing Python dependencies for fb-http"
-chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 install $(cat "$ROOT_DIR/deps/screen-apps/apps/fb-http/requirements.txt")
+cache_pip.sh "$ROOTFS_DIR" $(cat "$ROOT_DIR/deps/screen-apps/apps/fb-http/requirements.txt")

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -27,6 +27,7 @@ export ROOTFS_IMG="$BUILD_DIR/rk-unpacked/rootfs.img"
 # Cache dirs for build tools
 export GOPATH="$ROOT_DIR/tmp/cache-go"
 export CCACHE_DIR="$ROOT_DIR/tmp/ccache"
+export CHROOT_CACHE="$ROOT_DIR/tmp/cache-chroot"
 
 rm -rf "$BUILD_DIR"
 

--- a/scripts/helpers/cache_pip.sh
+++ b/scripts/helpers/cache_pip.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <rootfs-dir> [pip params]"
+  exit 1
+fi
+
+ROOTFS_DIR="$1"
+shift
+
+pip3_cmd() {
+  chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/pip3 "$@"
+}
+
+if [[ -n "$CI" ]]; then
+  # In CI always prefer network dependencies
+  pip3_cmd install "$@"
+elif ! pip3_cmd install --no-index --find-links=/root/pip "$@"; then
+  # Unless CI prefer cached dependencies
+  pip3_cmd download -d /root/pip "$@"
+  pip3_cmd install --no-index --find-links=/root/pip "$@"
+fi

--- a/scripts/helpers/chroot_firmware.sh
+++ b/scripts/helpers/chroot_firmware.sh
@@ -5,16 +5,35 @@ if [[ $# -lt 2 ]]; then
   exit 1
 fi
 
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
 ROOTFS="$(realpath "$1")"
 shift
 
 cd "$ROOTFS"
 
+cleanup() {
+  mountpoint "$ROOTFS/root" && umount "$ROOTFS/root"
+  rm -rf "$ROOTFS/root"
+  mkdir -p "$ROOTFS/root"
+
+  [[ -e ./etc/resolv.conf.bak ]] && mv ./etc/resolv.conf.bak ./etc/resolv.conf
+  rm -f ./etc/resolv.conf
+}
+
 if [[ -e ./etc/resolv.conf ]]; then
   mv ./etc/resolv.conf ./etc/resolv.conf.bak
-  trap 'mv ./etc/resolv.conf.bak ./etc/resolv.conf' EXIT
-else
-  trap 'rm -f ./etc/resolv.conf' EXIT
+fi
+
+trap 'cleanup' EXIT
+
+if [[ -z "$CI" ]]; then
+  # Cache /root
+  mkdir -p "$CHROOT_CACHE/root"
+  mount --bind "$CHROOT_CACHE/root" "$ROOTFS/root"
 fi
 
 set -euo pipefail


### PR DESCRIPTION
Install Python deps from the local pip cache first and only hit the network on cache miss, while wiring a shared chroot cache path for repeated builds.

Optimise build size to remove extra `/root/.cache`