### PR TITLE
Add OpenRFID rotating logs and update support docs

### DIFF
--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -190,7 +190,7 @@ Enable them by removing the `#` prefix from the tag processor.
 - Ensure you place on tag on the side next to the U1 housing, which will depend on which side of the printer you load the spool
 - If a vendor tag is present, for example Bambu Lab filament tags, this will usually interfere with reading a user-provided tag (you can cover up the vendor tag with foil tape)
 - Manually read tag: `FILAMENT_DT_UPDATE CHANNEL=<n>` then `FILAMENT_DT_QUERY CHANNEL=<n>`
-- Check `klippy.log` for detection messages
+- For OpenRFID issues, open Fluidd **Logs** and fetch `openrfid.log`
 
 **OpenPrintTag tags don't work:**
 - Expected - OpenPrintTag uses ISO15693 which is not supported by U1 hardware

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/bin/openrfid.py
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/bin/openrfid.py
@@ -7,14 +7,35 @@ import os
 import runpy
 import sys
 
+
+LOG_FILE = "/oem/printer_data/logs/openrfid.log"
+MAX_ROTATIONS = 7
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <target.cfg> [source.cfg ...]")
         sys.exit(1)
 
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
     syslogHandler = logging.handlers.SysLogHandler(address="/dev/log")
     stderrHandler = logging.StreamHandler(sys.stderr)
-    logging.root.handlers = [syslogHandler, stderrHandler]
+    fileHandler = logging.handlers.TimedRotatingFileHandler(
+        LOG_FILE,
+        when="midnight",
+        interval=1,
+        backupCount=MAX_ROTATIONS,
+    )
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    for handler in (syslogHandler, stderrHandler, fileHandler):
+        handler.setFormatter(formatter)
+
+    logging.root.handlers = [syslogHandler, stderrHandler, fileHandler]
     logging.root.setLevel(logging.DEBUG)
 
     target = sys.argv[1]


### PR DESCRIPTION
Logs are stored and accessible via Fluidd and Mainsail.