### PR TITLE
Add force bed leveling and timelapse print preference tweaks

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -49,7 +49,7 @@ Toggle settings directly from the web interface:
 | Klipper Metrics Exporter | Enabled, Disabled | Enable Prometheus metrics |
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
 | Cloud | None, OctoEverywhere | Enable Cloud-based remote access (Experimental) |
-| Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
+| Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub, Force Auto Bed Leveling, Force Timelapse | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
 | Troubleshooting | Faulty Toolhead Bypass | Temporary toolhead thermistor bypass so the remaining toolheads can still be used ([faulty_toolhead](faulty_toolhead.md)) |
 | RFID Detection System | External, Snapmaker, OpenRFID, OpenRFID (force generic vendor) | Set how filament is detected ([rfid_support](rfid_support.md)) |
 

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -86,6 +86,29 @@ Enables object processing in Moonraker's file manager to support adaptive mesh f
 **Configuration:**
 This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
 
+## Force Auto Bed Leveling
+
+Forces auto bed leveling to be enabled at the start of every print from Fluidd/Mainsail.
+
+**What it does:**
+- Overrides the `SDCARD_PRINT_FILE` Klipper macro to inject `SET_PRINT_PREFERENCES AUTO_BED_LEVELING=1` before each print starts
+- Works for prints started from Fluidd or Mainsail (virtual SD card prints)
+- Does not affect prints started from Snapmaker's own app
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
+## Force Timelapse
+
+Forces timelapse recording to be enabled at the start of every print from Fluidd/Mainsail.
+
+**What it does:**
+- Overrides the `SDCARD_PRINT_FILE` Klipper macro to inject `SET_PRINT_PREFERENCES TIMELAPSE=1` before each print starts
+- Forces timelapse on for every print regardless of which app started it, including Snapmaker Orca (OrcaSlicer), Fluidd, and Mainsail
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
 ## How to Configure
 
 1. Open the printer's web interface (Fluidd or Mainsail)
@@ -103,5 +126,7 @@ These tweaks work by adding or removing configuration files from `/oem/printer_d
 - `klipper/tmc_autotune.cfg` - TMC AutoTune parameters
 - `klipper/tmc_current.cfg` - Reduced current settings
 - `moonraker/object_processing.cfg` - Moonraker object processing settings
+- `klipper/bed_leveling_force.cfg` - overrides `SDCARD_PRINT_FILE` and calls `SET_PRINT_PREFERENCES AUTO_BED_LEVELING=1`
+- `klipper/timelapse_force.cfg` - overrides `SDCARD_PRINT_FILE` and calls `SET_PRINT_PREFERENCES TIMELAPSE=1`
 
 These files are automatically included by the main printer configuration if present. Manual editing of these files is not recommended as they will be overwritten by the Firmware Configuration interface.

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_bed_leveling_force.yaml
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_bed_leveling_force.yaml
@@ -1,0 +1,33 @@
+settings:
+  tweaks:
+    items:
+      bed_leveling_force:
+        label: Force Auto Bed Leveling
+        description: Forces auto bed leveling before each print.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#force-auto-bed-leveling
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Force auto bed leveling? This overrides the print start macro to call SET_PRINT_PREFERENCES AUTO_BED_LEVELING=1 before each print."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg &&
+                echo "Force bed leveling enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg &&
+                echo "Force bed leveling disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_timelapse_force.yaml
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_timelapse_force.yaml
@@ -1,0 +1,33 @@
+settings:
+  tweaks:
+    items:
+      timelapse_force:
+        label: Force Timelapse
+        description: Forces timelapse recording before each print. Ensures timelapse is always enabled when printing from Fluidd/Mainsail.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#force-timelapse
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/timelapse_force.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Force timelapse for every print? This overrides the print start macro to call SET_PRINT_PREFERENCES TIMELAPSE=1 before each print."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg /oem/printer_data/config/extended/klipper/timelapse_force.cfg &&
+                echo "Force timelapse enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/timelapse_force.cfg &&
+                echo "Force timelapse disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
@@ -1,0 +1,21 @@
+# Force Auto Bed Leveling
+#
+# Overrides SDCARD_PRINT_FILE to call SET_PRINT_PREFERENCES AUTO_BED_LEVELING=1
+# before each SD card print.
+
+[gcode_macro SDCARD_PRINT_FILE]
+rename_existing: _SDCARD_PRINT_FILE_BASE
+description: Apply forced print preferences then start SD card print
+gcode:
+    {% if printer["gcode_macro _PRINT_PREF_BED_LEVELING"] %}
+        _PRINT_PREF_BED_LEVELING
+    {% endif %}
+    {% if printer["gcode_macro _PRINT_PREF_TIMELAPSE"] %}
+        _PRINT_PREF_TIMELAPSE
+    {% endif %}
+    _SDCARD_PRINT_FILE_BASE {rawparams}
+
+[gcode_macro _PRINT_PREF_BED_LEVELING]
+description: Force auto bed leveling before each print
+gcode:
+    SET_PRINT_PREFERENCES AUTO_BED_LEVELING=1

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
@@ -1,0 +1,22 @@
+# Force Timelapse
+#
+# Overrides SDCARD_PRINT_FILE to call SET_PRINT_PREFERENCES TIMELAPSE=1
+# before each SD card print. Ensures timelapse is always enabled when printing
+# from Fluidd/Mainsail regardless of what the Snapmaker app last configured.
+
+[gcode_macro SDCARD_PRINT_FILE]
+rename_existing: _SDCARD_PRINT_FILE_BASE
+description: Apply forced print preferences then start SD card print
+gcode:
+    {% if printer["gcode_macro _PRINT_PREF_BED_LEVELING"] %}
+        _PRINT_PREF_BED_LEVELING
+    {% endif %}
+    {% if printer["gcode_macro _PRINT_PREF_TIMELAPSE"] %}
+        _PRINT_PREF_TIMELAPSE
+    {% endif %}
+    _SDCARD_PRINT_FILE_BASE {rawparams}
+
+[gcode_macro _PRINT_PREF_TIMELAPSE]
+description: Force timelapse before each print
+gcode:
+    SET_PRINT_PREFERENCES TIMELAPSE=1


### PR DESCRIPTION
## Summary

- Adds overlay \`35-feature-print-preferences\` with two new independently toggleable tweaks under **Settings → Tweaks** in the firmware-config UI
- **Force Auto Bed Leveling**: overrides \`SDCARD_PRINT_FILE\` to call \`SET_PRINT_PREFERENCES AUTO_BED_LEVELING=1\` before each SD card print
- **Force Timelapse**: overrides \`SDCARD_PRINT_FILE\` to call \`SET_PRINT_PREFERENCES TIMELAPSE=1\` before each SD card print

## Design

Each cfg is self-contained — enabling a feature symlinks exactly one file. Both cfgs share an identical \`SDCARD_PRINT_FILE\` macro that guards each hook with an existence check before calling, then delegates to the original handler:

\`\`\`
{% if printer["gcode_macro _PRINT_PREF_BED_LEVELING"] %}
    _PRINT_PREF_BED_LEVELING
{% endif %}
{% if printer["gcode_macro _PRINT_PREF_TIMELAPSE"] %}
    _PRINT_PREF_TIMELAPSE
{% endif %}
_SDCARD_PRINT_FILE_BASE {rawparams}
\`\`\`

Each cfg only defines the hook it actually implements. When both are enabled, the last cfg alphabetically (\`timelapse_force.cfg\`) owns \`SDCARD_PRINT_FILE\`; both \`_PRINT_PREF_*\` macros are defined so both preferences fire correctly.