### PR TITLE
Add force bed leveling and timelapse print preference tweaks

### DIFF
--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_bed_leveling_force.yaml
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_bed_leveling_force.yaml
@@ -1,0 +1,54 @@
+settings:
+  tweaks:
+    items:
+      bed_leveling_force:
+        label: Force Bed Mesh Calibration
+        description: Forces bed mesh calibration before each print.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#force-auto-bed-leveling
+        get_cmd:
+          - bash
+          - -c
+          - |
+            if test -f /oem/printer_data/config/extended/klipper/bed_leveling_adaptive_force.cfg; then
+              echo "adaptive"
+            elif test -f /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg; then
+              echo "force"
+            else
+              echo "disabled"
+            fi
+        options:
+          force:
+            label: Force Full Mesh
+            confirm: "Force full bed mesh calibration before every print?"
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                rm -f /oem/printer_data/config/extended/klipper/bed_leveling_adaptive_force.cfg &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg &&
+                echo "Force full bed mesh enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          adaptive:
+            label: Force Adaptive Mesh
+            confirm: "Force adaptive bed mesh calibration before every print? Falls back to full mesh when exclude_object is not active."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                rm -f /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg /oem/printer_data/config/extended/klipper/bed_leveling_adaptive_force.cfg &&
+                echo "Force adaptive bed mesh enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/bed_leveling_force.cfg \
+                      /oem/printer_data/config/extended/klipper/bed_leveling_adaptive_force.cfg &&
+                echo "Force bed mesh disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_timelapse_force.yaml
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_tweaks_timelapse_force.yaml
@@ -1,0 +1,33 @@
+settings:
+  tweaks:
+    items:
+      timelapse_force:
+        label: Force Timelapse
+        description: Allows TIMELAPSE_START to work even when timelapse is not enabled in the Snapmaker app. Your slicer must call TIMELAPSE_START, TIMELAPSE_TAKE_FRAME, and TIMELAPSE_STOP.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#force-timelapse
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/timelapse_force.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Allow TIMELAPSE_START to bypass the Snapmaker timelapse preference? Your slicer must call TIMELAPSE_START, TIMELAPSE_TAKE_FRAME, and TIMELAPSE_STOP."
+            cmd:
+              - bash
+              - -xc
+              - |
+                mkdir -p /oem/printer_data/config/extended/klipper &&
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg /oem/printer_data/config/extended/klipper/timelapse_force.cfg &&
+                echo "Force timelapse enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -f /oem/printer_data/config/extended/klipper/timelapse_force.cfg &&
+                echo "Force timelapse disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg
@@ -1,0 +1,17 @@
+[gcode_macro BED_MESH_CALIBRATE]
+rename_existing: _BED_MESH_CALIBRATE_BASE
+description: Force adaptive bed mesh calibration (falls back to full mesh when exclude_object is not active)
+gcode:
+    {% set prev_state = printer["machine_state_manager"].main_state %}
+    SET_MAIN_STATE MAIN_STATE=IDLE
+    SET_PRINT_PREFERENCES BED_LEVEL=1
+    SET_MAIN_STATE MAIN_STATE={prev_state}
+    _BED_LEVELING_FORCE_VALIDATE
+    _BED_MESH_CALIBRATE_BASE {rawparams} ADAPTIVE=1
+
+[gcode_macro _BED_LEVELING_FORCE_VALIDATE]
+gcode:
+    {% set ptc = printer["print_task_config"] %}
+    {% if ptc is not defined or not ptc.auto_bed_leveling %}
+        { action_raise_error("bed_leveling_force: AUTO_BED_LEVELING was not set — SET_MAIN_STATE workaround did not take effect") }
+    {% endif %}

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
@@ -1,0 +1,17 @@
+[gcode_macro BED_MESH_CALIBRATE]
+rename_existing: _BED_MESH_CALIBRATE_BASE
+description: Force full bed mesh calibration
+gcode:
+    {% set prev_state = printer["machine_state_manager"].main_state %}
+    SET_MAIN_STATE MAIN_STATE=IDLE
+    SET_PRINT_PREFERENCES BED_LEVEL=1
+    SET_MAIN_STATE MAIN_STATE={prev_state}
+    _BED_LEVELING_FORCE_VALIDATE
+    _BED_MESH_CALIBRATE_BASE {rawparams}
+
+[gcode_macro _BED_LEVELING_FORCE_VALIDATE]
+gcode:
+    {% set ptc = printer["print_task_config"] %}
+    {% if ptc is not defined or not ptc.auto_bed_leveling %}
+        { action_raise_error("bed_leveling_force: AUTO_BED_LEVELING was not set — SET_MAIN_STATE workaround did not take effect") }
+    {% endif %}

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
@@ -1,0 +1,17 @@
+[gcode_macro TIMELAPSE_START]
+rename_existing: _TIMELAPSE_START_BASE
+description: Force timelapse start regardless of print preferences
+gcode:
+    {% set prev_state = printer["machine_state_manager"].main_state %}
+    SET_MAIN_STATE MAIN_STATE=IDLE
+    SET_PRINT_PREFERENCES TIME_LAPSE_CAMERA=1
+    SET_MAIN_STATE MAIN_STATE={prev_state}
+    _TIMELAPSE_FORCE_VALIDATE
+    _TIMELAPSE_START_BASE {rawparams}
+
+[gcode_macro _TIMELAPSE_FORCE_VALIDATE]
+gcode:
+    {% set ptc = printer["print_task_config"] %}
+    {% if ptc is not defined or not ptc.time_lapse_camera %}
+        { action_raise_error("timelapse_force: TIME_LAPSE_CAMERA was not set — SET_MAIN_STATE workaround did not take effect") }
+    {% endif %}


### PR DESCRIPTION
Adds `FORCE=1` parameter to `TIMELAPSE_START` and `BED_MESH_CALIBRATE` via klipper patches, allowing macros to bypass the `print_task_config` guards that block these commands when the Snapmaker app has not enabled them.

Each tweak overrides the relevant klipper command to inject `FORCE=1`:

- `timelapse_force.cfg`: overrides `TIMELAPSE_START` with `FORCE=1`
- `bed_leveling_force.cfg`: overrides `BED_MESH_CALIBRATE` with `FORCE=1 ADAPTIVE=1`

Adaptive mesh falls back to full mesh when `exclude_object` is not active.