### PR TITLE
Integrate Spoolman with the NFC filament detection

### DIFF
--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -101,6 +101,26 @@ Using the non-standard OpenSpool `subtype` field it is possible to specify a mat
 - `additional_color_hexes` - Additional colors for multicolor spools (up to 4)
 - `weight` - Spool weight in grams
 - `diameter` - Filament diameter in mm (e.g., 1.75)
+- `spool_id` - Integer ID for automatic Spoolman synchronization
+
+### Spoolman Integration
+
+The extended firmware optionally integrates with [Spoolman](https://github.com/Donkie/Spoolman) via Moonraker.
+
+When an OpenSpool NFC tag containing a `spool_id` integer is inserted into any tool slot, the firmware can automatically synchronize your upstream Spoolman database. 
+
+By default, Spoolman NFC Sync is **disabled** to avoid interfering with users who manage Spoolman manually. You can enable it via the Firmware Configuration under **Settings -> Spoolman**.
+
+When **Spoolman NFC Sync** is enabled:
+- **Active Extruder**: If a spool is loaded into the currently active extruder, it is automatically marked as "active" in your Spoolman database so filament usage is tracked accurately.
+- **Parked Extruders**: If a spool is loaded into an idle extruder, the printer's display and web interface (Mainsail/Fluidd) are immediately updated to show the newly loaded spool, ready for the next toolchange. This requires the Spoolman Multi-Tool Configuration to be enabled.
+
+**Spoolman Multi-Tool Configuration:**
+Spoolman requires specific Klipper macros to function properly in a multi-tool setup. The firmware bundles a pre-configured `spoolman_multi_tool.cfg` file.
+The **Spoolman Multi-Tool Configuration** option allows you to manage these macros:
+- **Follow NFC Sync** (Default): The built-in macros are automatically enabled or disabled to match your Spoolman NFC Sync toggle.
+- **Enabled**: Forces the built-in macros to be active, regardless of sync status.
+- **Disabled**: Renames the built-in macros to `.disabled`, allowing you to provide your own custom macro implementation in `/home/lava/printer_data/config/extended/klipper/` without conflicts.
 
 ### Snapmaker Orca Naming Convention
 

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
@@ -7,6 +7,8 @@ settings:
     label: Remote Access
   snapmaker_components:
     label: Snapmaker Components
+  spoolman:
+    label: Spoolman
   tweaks:
     label: Tweaks
   troubleshooting:

--- a/overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -224,6 +224,11 @@ def openspool_parse_payload(payload, card_uid=[]):
         info['OFFICIAL'] = True
         info['CARD_UID'] = card_uid
 
+        try:
+            info['SPOOL_ID'] = int(data.get('spool_id', 0))
+        except (ValueError, TypeError):
+            info['SPOOL_ID'] = 0
+
         return filament_protocol.FILAMENT_PROTO_OK, info
 
     except json.JSONDecodeError as e:

--- a/overlays/firmware-extended/65-spoolman-nfc/patches/01-filament-detect.patch
+++ b/overlays/firmware-extended/65-spoolman-nfc/patches/01-filament-detect.patch
@@ -1,0 +1,11 @@
+--- a/home/lava/klipper/klippy/extras/filament_detect.py
++++ b/home/lava/klipper/klippy/extras/filament_detect.py
+@@ -226,6 +226,8 @@
+                 filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]
+             if 'SKU' in params:
+                 filament_info['SKU'] = int(params.pop('SKU'))
++            if 'SPOOL_ID' in params:
++                filament_info['SPOOL_ID'] = int(params.pop('SPOOL_ID'))
+ 
+             if params:
+                 raise web_request.error("unsupported fields: %s" % (', '.join(sorted(params.keys()))))

--- a/overlays/firmware-extended/65-spoolman-nfc/patches/01-filament-protocol.patch
+++ b/overlays/firmware-extended/65-spoolman-nfc/patches/01-filament-protocol.patch
@@ -1,0 +1,10 @@
+--- a/home/lava/klipper/klippy/extras/filament_protocol.py
++++ b/home/lava/klipper/klippy/extras/filament_protocol.py
+@@ -34,6 +34,7 @@
+     'RSA_KEY_VERSION': 0,
+     'OFFICIAL': False,
+     'CARD_UID': 0,
++    'SPOOL_ID': 0,
+ }
+ 
+ # Filament main type

--- a/overlays/firmware-extended/65-spoolman-nfc/patches/02-moonraker-spoolman.patch
+++ b/overlays/firmware-extended/65-spoolman-nfc/patches/02-moonraker-spoolman.patch
@@ -1,0 +1,117 @@
+--- a/home/lava/moonraker/moonraker/components/spoolman.py	2026-05-05 18:44:11.311205517 +0200
++++ b/home/lava/moonraker/moonraker/components/spoolman.py	2026-05-05 18:44:11.315278693 +0200
+@@ -9,6 +9,7 @@
+ import logging
+ import re
+ import contextlib
++import subprocess
+ import tornado.websocket as tornado_ws
+ from ..common import RequestType, HistoryFieldData
+ from ..utils import json_wrapper as jsonw
+@@ -53,6 +54,18 @@
+         self._error_logged: bool = False
+         self._highest_epos: float = 0
+         self._current_extruder: str = "extruder"
++        self._nfc_spool_ids: List[int] = [0] * 8
++        try:
++            res = subprocess.check_output([
++                "/usr/local/bin/extended-config.py", "get",
++                "/oem/printer_data/config/extended/extended2.cfg",
++                "components", "spoolman_sync", "disabled"
++            ])
++            self._nfc_sync_enabled = (res.decode().strip().lower() == "enabled")
++        except Exception as e:
++            logging.warning(f"Failed to read extended-config for spoolman_sync: {e}")
++            self._nfc_sync_enabled = False
++        
+         self.spool_history = HistoryFieldData(
+             "spool_ids", "spoolman", "Spool IDs used", "collect",
+             reset_callback=self._on_history_reset
+@@ -238,7 +251,10 @@
+     async def _handle_klippy_ready(self) -> None:
+         result: Dict[str, Dict[str, Any]]
+         result = await self.klippy_apis.subscribe_objects(
+-            {"toolhead": ["position", "extruder"]}, self._handle_status_update, {}
++            {
++                "toolhead": ["position", "extruder"],
++                "filament_detect": None
++            }, self._handle_status_update, {}
+         )
+         toolhead = result.get("toolhead", {})
+         self._current_extruder = toolhead.get("extruder", "extruder")
+@@ -259,6 +275,75 @@
+ 
+     def _handle_status_update(self, status: Dict[str, Any], _: float) -> None:
+         toolhead: Optional[Dict[str, Any]] = status.get("toolhead")
++
++        # Check if filament_detect status has changed
++        filament_detect: Optional[Dict[str, Any]] = status.get("filament_detect")
++        if filament_detect is not None:
++            info_list = filament_detect.get("info", [])
++
++            # Determine which index is the current active extruder
++            active_idx = 0
++            if self._current_extruder != "extruder":
++                try:
++                    active_idx = int(self._current_extruder.replace("extruder", ""))
++                except ValueError:
++                    pass
++
++            for idx, info in enumerate(info_list):
++                if isinstance(info, dict):
++                    try:
++                        spool_id = int(info.get("SPOOL_ID", 0))
++                    except (ValueError, TypeError):
++                        spool_id = 0
++
++                    if spool_id is None:
++                        spool_id = 0
++
++                    # Ensure our tracking list is long enough
++                    while len(self._nfc_spool_ids) <= idx:
++                        self._nfc_spool_ids.append(0)
++
++                    if spool_id != self._nfc_spool_ids[idx]:
++                        if not self._nfc_sync_enabled:
++                            logging.info(f"NFC tag updated on T{idx} to {spool_id}, but NFC sync is disabled. Ignoring.")
++                            self._nfc_spool_ids[idx] = spool_id
++                            continue
++
++                        if spool_id > 0:
++                            logging.info(f"NFC tag detected on T{idx}, loaded SPOOL_ID: {spool_id}")
++                        else:
++                            logging.info(f"NFC tag removed from T{idx}, SPOOL_ID cleared")
++
++                        self._nfc_spool_ids[idx] = spool_id
++
++                        async def sync_spool_macro(sid=spool_id, tool_idx=idx) -> None:
++                            try:
++                                # The UI strictly depends on `T0`, `T1`, `T2` macro variables to stay in sync for parked tools!
++                                val = str(sid) if sid > 0 else "'\"\"'"
++                                await self.klippy_apis.run_gcode(f"SET_GCODE_VARIABLE MACRO=T{tool_idx} VARIABLE=spool_id VALUE={val}")
++                            except Exception as e:
++                                pass
++
++                        self.eventloop.create_task(sync_spool_macro())
++
++                        # Only force a Moonraker active spool override if the tag was inserted
++                        # into the CURRENTLY ACTIVE printing tool!
++                        if idx == active_idx and spool_id != self.spool_id:
++                            if spool_id > 0:
++                                async def sync_active_spool(sid=spool_id) -> None:
++                                    try:
++                                        await self.klippy_apis.run_gcode(f"SET_ACTIVE_SPOOL ID={sid}")
++                                    except Exception as e:
++                                        self.set_active_spool(sid)
++                                self.eventloop.create_task(sync_active_spool())
++                            else:
++                                async def clear_active_spool() -> None:
++                                    try:
++                                        await self.klippy_apis.run_gcode("CLEAR_ACTIVE_SPOOL")
++                                    except Exception as e:
++                                        self.set_active_spool(None)
++                                self.eventloop.create_task(clear_active_spool())
++
+         if toolhead is None:
+             return
+         epos: float = toolhead.get("position", [0, 0, 0, self._highest_epos])[3]

--- a/overlays/firmware-extended/65-spoolman-nfc/pre-scripts/01_dos2unix.sh
+++ b/overlays/firmware-extended/65-spoolman-nfc/pre-scripts/01_dos2unix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+dos2unix "$1/home/lava/klipper/klippy/extras/filament_protocol.py" \
+  "$1/home/lava/moonraker/moonraker/components/spoolman.py"

--- a/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/bin/spoolman-macros-apply.sh
+++ b/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/bin/spoolman-macros-apply.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+CFG="/oem/printer_data/config/extended/extended2.cfg"
+MACRO_DIR="/home/lava/printer_data/config/extended/klipper"
+MACRO_FILE="$MACRO_DIR/spoolman_multi_tool.cfg"
+
+SYNC_ENABLED=$(/usr/local/bin/extended-config.py get "$CFG" components spoolman_sync disabled)
+MACRO_MODE=$(/usr/local/bin/extended-config.py get "$CFG" components spoolman_macros auto)
+
+SHOULD_ENABLE=false
+if [ "$MACRO_MODE" = "enabled" ]; then
+    SHOULD_ENABLE=true
+elif [ "$MACRO_MODE" = "auto" ] && [ "$SYNC_ENABLED" = "enabled" ]; then
+    SHOULD_ENABLE=true
+fi
+
+# Ensure macro directory exists
+mkdir -p "$MACRO_DIR"
+
+KLIPPER_NEEDS_RESTART=false
+
+if [ "$SHOULD_ENABLE" = "true" ]; then
+    if [ -f "$MACRO_FILE.disabled" ]; then
+        mv "$MACRO_FILE.disabled" "$MACRO_FILE"
+        KLIPPER_NEEDS_RESTART=true
+    fi
+else
+    if [ -f "$MACRO_FILE" ]; then
+        mv "$MACRO_FILE" "$MACRO_FILE.disabled"
+        KLIPPER_NEEDS_RESTART=true
+    fi
+fi
+
+if [ "$KLIPPER_NEEDS_RESTART" = "true" ]; then
+    /etc/init.d/S60klipper restart
+fi
+
+# Always restart moonraker to pick up sync changes
+/etc/init.d/S61moonraker restart

--- a/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/extended/klipper/spoolman_multi_tool.cfg.disabled
+++ b/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/extended/klipper/spoolman_multi_tool.cfg.disabled
@@ -1,0 +1,131 @@
+# Originated from: https://github.com/unlucio/U1-klipper-configs/blob/main/spoolman/spoolman_multi_tool.cfg
+# Author: unlucio
+
+# Remember the selected spools across printer reboots
+[save_variables]
+filename: ~/printer_data/config/variables.cfg
+
+[gcode_macro _SPOOLMAN_CFG]
+variable_tools: "T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24,T25,T26,T27,T28,T29,T30,T31"
+gcode:
+  # no g-code, this is just a conveniet "array" because I don't like to repeat my sef.
+  RESPOND PREFIX="🧶" MSG="Nothing to see here"
+
+# main Spool selection macro
+[gcode_macro SET_ACTIVE_SPOOL]
+gcode:
+  {% if params.ID is defined %}
+    {% set id = params.ID|int %}
+    {action_call_remote_method("spoolman_set_active_spool", spool_id=id)}
+    UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
+  {% else %}
+    {action_respond_info("Parameter 'ID' is required")}
+  {% endif %}
+
+[gcode_macro CLEAR_ACTIVE_SPOOL]
+gcode:
+  RESPOND PREFIX="🧶" MSG="Active spool cleared"
+  {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
+  UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
+
+# Only touch tools that exist AND actually expose .spool_id
+[gcode_macro CLEAR_ALL_SPOOLS]
+gcode:
+  {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
+
+  RESPOND PREFIX="🧶" MSG="Clearing all spools"
+
+  {% set tools = printer["gcode_macro _SPOOLMAN_CFG"].tools.split(",") %}
+  {% for tool in tools %}
+    {% set macro = "gcode_macro " ~ tool %}
+    {% if macro in printer and printer[macro].spool_id is defined %}
+      SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE=\"\"
+    {% endif %}
+  {% endfor %}
+
+  UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=1
+
+[delayed_gcode SAVE_SELECTED_SPOOLS]
+gcode:
+  {% set tools = printer["gcode_macro _SPOOLMAN_CFG"].tools.split(",") %}
+
+  {% for tool in tools %}
+    {% set macro = "gcode_macro " ~ tool %}
+    {% set vname = tool|lower ~ "__spool_id" %}
+
+    {% if macro in printer and printer[macro].spool_id is defined %}
+      {% set sid = printer[macro].spool_id|string %}
+    {% else %}
+      {% set sid = "" %}
+    {% endif %}
+
+    {% if sid != "" %}
+      #RESPOND PREFIX="🧶" MSG="Saving spool for { vname }: { sid }"
+      SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
+    {% else %}
+      #RESPOND PREFIX="🧶" MSG="Clearing spool for { vname }"
+      SAVE_VARIABLE VARIABLE={vname} VALUE=\"\"
+    {% endif %}
+  {% endfor %}
+
+[gcode_macro SAVE_CURRENT_SPOOLS]
+gcode:
+  RESPOND PREFIX="🧶" MSG="Current spools saved"
+  UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
+
+# Apply selected spool during print
+[delayed_gcode RESTORE_SELECTED_SPOOLS]
+initial_duration: 0.1
+gcode:
+  {% set svv = printer.save_variables.variables %}
+  {% for object in printer %}
+    {% if object.startswith('gcode_macro ') and printer[object].spool_id is defined %}
+      {% set macro = object.replace('gcode_macro ', '') %}
+      {% set var = (macro + '__SPOOL_ID')|lower %}
+      {% if svv[var] is defined %}
+        SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE={svv[var]}
+        RESPOND PREFIX="🧶" MSG="TRestring spools selection"
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+# Per tool spool config
+[gcode_macro T0]
+rename_existing: T0.10001
+variable_spool_id: ""
+gcode:
+  {% set sid = printer["gcode_macro T0"].spool_id %}
+  {% if sid %}
+    SET_ACTIVE_SPOOL ID={sid}
+  {% endif %}
+  T0.10001 {rawparams}
+
+[gcode_macro T1]
+rename_existing: T1.10001
+variable_spool_id: ""
+gcode:
+  {% set sid = printer["gcode_macro T1"].spool_id %}
+  {% if sid %}
+    SET_ACTIVE_SPOOL ID={sid}
+  {% endif %}
+  T1.10001 {rawparams}
+
+[gcode_macro T2]
+rename_existing: T2.10001
+variable_spool_id: ""
+gcode:
+  {% set sid = printer["gcode_macro T2"].spool_id %}
+  {% if sid %}
+    SET_ACTIVE_SPOOL ID={sid}
+  {% endif %}
+  T2.10001 {rawparams}
+
+[gcode_macro T3]
+rename_existing: T3.10001
+variable_spool_id: ""
+gcode:
+  {% set sid = printer["gcode_macro T3"].spool_id %}
+  {% if sid %}
+    SET_ACTIVE_SPOOL ID={sid}
+  {% endif %}
+  T3.10001 {rawparams}

--- a/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/functions/20_settings_spoolman_sync.yaml
+++ b/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/functions/20_settings_spoolman_sync.yaml
@@ -1,0 +1,69 @@
+settings:
+  spoolman:
+    items:
+      spoolman_sync:
+        label: Spoolman NFC Sync
+        description: Automatically sync the active spool in Moonraker when an NFC tag is detected.
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /oem/printer_data/config/extended/extended2.cfg
+          - components
+          - spoolman_sync
+          - disabled
+        options:
+          enabled:
+            label: Enabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components spoolman_sync enabled
+                /usr/local/bin/spoolman-macros-apply.sh
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components spoolman_sync disabled
+                /usr/local/bin/spoolman-macros-apply.sh
+        default: disabled
+
+      spoolman_macros:
+        label: Spoolman Multi-Tool Configuration
+        help_url: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/blob/develop/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/extended/klipper/spoolman_multi_tool.cfg
+        description: Manage the built-in spoolman_multi_tool.cfg macros for Klipper.
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /oem/printer_data/config/extended/extended2.cfg
+          - components
+          - spoolman_macros
+          - auto
+        options:
+          auto:
+            label: Follow NFC Sync
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components spoolman_macros auto
+                /usr/local/bin/spoolman-macros-apply.sh
+          enabled:
+            label: Enabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components spoolman_macros enabled
+                /usr/local/bin/spoolman-macros-apply.sh
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg components spoolman_macros disabled
+                /usr/local/bin/spoolman-macros-apply.sh
+        default: auto

--- a/overlays/firmware-extended/65-spoolman-nfc/test/deploy-run.sh
+++ b/overlays/firmware-extended/65-spoolman-nfc/test/deploy-run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <printer-ip-or-host>"
+  echo "Example: $0 192.168.1.100"
+  exit 1
+fi
+
+SSH_HOST="$1"
+DIR="$(dirname "$0")"
+ROOT_DIR="$(realpath "$DIR/../../../..")"
+
+set -xeo pipefail
+
+# sed '/^'"$SSH_HOST"' /d' -i ~/.ssh/known_hosts
+ssh-copy-id -o "StrictHostKeyChecking=no" "root@$SSH_HOST"
+ssh-add -l >/dev/null 2>&1 || ssh-add
+
+echo "Deploying modified files to $SSH_HOST..."
+
+# Copy modified Klipper file
+scp "$ROOT_DIR/tmp/firmware/rootfs/home/lava/klipper/klippy/extras/filament_protocol.py" "root@$SSH_HOST:/home/lava/klipper/klippy/extras/"
+scp "$ROOT_DIR/tmp/firmware/rootfs/home/lava/klipper/klippy/extras/filament_protocol_ndef.py" "root@$SSH_HOST:/home/lava/klipper/klippy/extras/"
+scp "$ROOT_DIR/tmp/firmware/rootfs/home/lava/klipper/klippy/extras/filament_detect.py" "root@$SSH_HOST:/home/lava/klipper/klippy/extras/"
+
+# Copy modified Moonraker component
+scp "$ROOT_DIR/tmp/firmware/rootfs/home/lava/moonraker/moonraker/components/spoolman.py" "root@$SSH_HOST:/home/lava/moonraker/moonraker/components/"
+
+# Copy Spoolman multi-tool macros
+echo "Deploying Spoolman multi-tool macros..."
+ssh "root@$SSH_HOST" "mkdir -p /usr/local/share/firmware-config/extended/klipper/ /usr/local/share/firmware-config/functions/ /usr/local/bin/"
+scp "$ROOT_DIR/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/extended/klipper/spoolman_multi_tool.cfg.disabled" "root@$SSH_HOST:/usr/local/share/firmware-config/extended/klipper/"
+scp "$ROOT_DIR/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml" "root@$SSH_HOST:/usr/local/share/firmware-config/functions/"
+scp "$ROOT_DIR/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/share/firmware-config/functions/20_settings_spoolman_sync.yaml" "root@$SSH_HOST:/usr/local/share/firmware-config/functions/"
+scp "$ROOT_DIR/overlays/firmware-extended/65-spoolman-nfc/root/usr/local/bin/spoolman-macros-apply.sh" "root@$SSH_HOST:/usr/local/bin/"
+ssh "root@$SSH_HOST" "chmod +x /usr/local/bin/spoolman-macros-apply.sh"
+
+# Copy modified OpenRFID files
+echo "Deploying OpenRFID modified files..."
+scp "$ROOT_DIR/tmp/firmware/rootfs/usr/local/share/openrfid/filament/generic.py" "root@$SSH_HOST:/usr/local/share/openrfid/filament/"
+scp "$ROOT_DIR/tmp/firmware/rootfs/usr/local/share/openrfid/tag/openspool/processor.py" "root@$SSH_HOST:/usr/local/share/openrfid/tag/openspool/"
+scp "$ROOT_DIR/tmp/firmware/rootfs/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg" "root@$SSH_HOST:/usr/local/share/openrfid/extended/"
+scp "$ROOT_DIR/tmp/firmware/rootfs/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg" "root@$SSH_HOST:/usr/local/share/openrfid/extended/"
+
+# Restart Klipper, Moonraker, and OpenRFID services on the printer
+echo "Restarting services..."
+ssh -t "root@$SSH_HOST" "/etc/init.d/S49extended-config restart && /etc/init.d/S60klipper restart && /etc/init.d/S61moonraker restart && /etc/init.d/S99openrfid restart && /etc/init.d/S99firmware-config restart"
+
+echo "Deployed successfully!"

--- a/overlays/firmware-extended/65-spoolman-nfc/test/test_moonraker_spoolman.py
+++ b/overlays/firmware-extended/65-spoolman-nfc/test/test_moonraker_spoolman.py
@@ -1,0 +1,129 @@
+import os
+import sys
+import logging
+from unittest.mock import MagicMock
+
+logging.basicConfig(level=logging.INFO)
+
+# Set path so python finds the moonraker package
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, os.path.join(ROOT_DIR, "tmp/firmware/rootfs/home/lava/moonraker"))
+
+# Mock missing Moonraker dependencies from pip (tornado)
+sys.modules['tornado'] = MagicMock()
+sys.modules['tornado.websocket'] = MagicMock()
+
+import moonraker.components.spoolman as spoolman_comp
+
+class MockServer:
+    def __init__(self):
+        self.config = MockConfig()
+    
+    def get_event_loop(self):
+        loop = MagicMock()
+        loop.get_loop_time.return_value = 0.0
+        def run_sync(coro):
+            import asyncio
+            asyncio.run(coro)
+        loop.create_task.side_effect = run_sync
+        return loop
+
+    def get_host_info(self):
+        return {"machine_id": "test_id"}
+
+    def register_endpoint(self, *args, **kwargs): pass
+    def register_event_handler(self, *args, **kwargs): pass
+    def register_notification(self, *args, **kwargs): pass
+    def register_remote_method(self, *args, **kwargs): pass
+    def lookup_component(self, name): return MagicMock()
+    def send_event(self, event, payload): pass
+
+class MockConfig:
+    def __init__(self):
+        self._name = "spoolman"
+    
+    def get(self, key, default=None):
+        if key == "server":
+            return "http://localhost:7912"
+        if key == "sync_rate":
+            return 5
+        return default
+    
+    def getint(self, key, default=None, minval=None):
+        return default
+
+    def get_server(self):
+        return MockServer()
+    
+    def get_name(self):
+        return self._name
+
+    def error(self, msg):
+        return Exception(msg)
+
+# Instantiate the mocked Spoolman component
+mock_spoolman = spoolman_comp.SpoolManager(MockConfig())
+
+# Reset properties for testing that might be overwritten during init
+mock_spoolman.server = MockServer()
+mock_spoolman.klippy_apis = MagicMock()
+mock_spoolman.database = MagicMock()
+mock_spoolman.spool_history.tracker.history = MagicMock()
+mock_spoolman.spool_history.tracker.history.tracking_enabled.return_value = True
+
+# Now simulate an update
+mock_status_payload = {
+    "filament_detect": {
+        "info": [
+            {
+                "SPOOL_ID": 1337,
+                "VENDOR": "OpenSpool",
+                "MAIN_TYPE": 1
+            }
+        ]
+    }
+}
+
+print("--- Testing Moonraker Spoolman Component ---")
+print(f"Simulating Klipper Payload: {mock_status_payload}")
+
+# Overwrite _active_spool_id so we can assert on it later
+# Note: set_active_spool uses self.spool_id 
+print(f"Initial Spool ID: {mock_spoolman.spool_id}")
+
+mock_spoolman._handle_status_update(mock_status_payload, 0.0)
+
+print(f"Final Spool ID: {mock_spoolman.spool_id}")
+
+if mock_spoolman.spool_id == 1337:
+    print("SUCCESS: Moonraker correctly received the payload and updated the active spool!")
+else:
+    print("FAILED: Moonraker did not set the active spool id.")
+    sys.exit(1)
+
+print(r"\--- Testing Inactive Tool Insertion ---")
+mock_status_payload_2 = {
+    "filament_detect": {
+        "info": [
+            {
+                "SPOOL_ID": 1337,
+                "VENDOR": "OpenSpool",
+                "MAIN_TYPE": 1
+            },
+            {
+                "SPOOL_ID": 9,
+                "VENDOR": "OpenSpool",
+                "MAIN_TYPE": 1
+            }
+        ]
+    }
+}
+
+mock_spoolman._handle_status_update(mock_status_payload_2, 0.0)
+print(f"Final Spool ID after inserting ID 9 into Tool 1: {mock_spoolman.spool_id}")
+
+if mock_spoolman.spool_id == 1337:
+    print("SUCCESS: Inactive tool spool insertion successfully ignored by active spool handler!")
+else:
+    print("FAILED: Active spool ID was overridden by inactive tool insertion.")
+    sys.exit(1)

--- a/overlays/firmware-extended/65-spoolman-nfc/test/test_ndef_parser.py
+++ b/overlays/firmware-extended/65-spoolman-nfc/test/test_ndef_parser.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import json
+
+# Add klippy extras to path so we can import the modules
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.append(os.path.join(ROOT_DIR, "tmp/firmware/rootfs/home/lava/klipper"))
+
+import klippy.extras.filament_protocol as filament_protocol
+import klippy.extras.filament_protocol_ndef as filament_protocol_ndef
+
+# Create a mock NDEF byte array containing an OpenSpool JSON payload
+# that includes a spool_id.
+mock_json_payload = json.dumps({
+    "protocol": "openspool",
+    "spool_id": 420,
+    "material": "PETG",
+    "color": "Blue"
+})
+
+class MockRecord:
+    def __init__(self, data):
+        self.data_msg = data
+
+# m1_proto_data_parse_ndef expects a list of NDEF records and the card UID
+records = [MockRecord(mock_json_payload)]
+card_uid = b'\\x01\\x02\\x03\\x04'
+
+print("--- Testing OpenSpool NDEF parsing ---")
+print(f"Input JSON Payload: {mock_json_payload}")
+
+# Call the function
+status, info = filament_protocol_ndef.openspool_parse_payload(mock_json_payload.encode('utf-8'), card_uid)
+
+print(f"Status returned: {status} (Expected: 0 / FILAMENT_PROTO_OK)")
+print(f"Extracted SPOOL_ID: {info.get('SPOOL_ID')}")
+
+if status == filament_protocol.FILAMENT_PROTO_OK and info.get('SPOOL_ID') == 420:
+    print("SUCCESS: The parser successfully extracted the SPOOL_ID from the NDEF payload!")
+else:
+    print("FAILED: The parser did not extract the SPOOL_ID correctly.")
+    sys.exit(1)


### PR DESCRIPTION
# [Feature] Spoolman NFC Integration

## Description
Integrates the U1's filament detection with Moonraker/Spoolman to automatically sync active spools via OpenSpool NFC tags.
Successfully tested on my own machine.

## What's Changed
* Added Web UI toggles under "Spoolman" to independently control NFC sync and built-in macros.
* Extended Klipper's filament protocol and NDEF parser to support `SPOOL_ID`.
* Updated `/printer/filament_detect/set` to handle spool identification from internal and external scanners.
* Added `spoolman_multi_tool.cfg` for seamless multi-tool spool management.
