### PR TITLE
Feature: Add G-code MD5 Verification

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -50,6 +50,7 @@ Toggle settings directly from the web interface:
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
 | Cloud | None, OctoEverywhere | Enable Cloud-based remote access (Experimental) |
 | Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
+| G-code MD5 Verification | Enabled, Disabled | Verify MD5 Checksums in G-code files ([gcode_md5](gcode_md5.md)) |
 | Troubleshooting | Faulty Toolhead Bypass | Temporary toolhead thermistor bypass so the remaining toolheads can still be used ([faulty_toolhead](faulty_toolhead.md)) |
 | RFID Detection System | External, Snapmaker, OpenRFID, OpenRFID (force generic vendor) | Set how filament is detected ([rfid_support](rfid_support.md)) |
 

--- a/docs/gcode_md5.md
+++ b/docs/gcode_md5.md
@@ -1,0 +1,116 @@
+---
+title: G-code MD5 Verification
+---
+
+# G-code MD5 Verification
+
+Verifies an MD5 checksum embedded in a g-code file before printing begins.
+If the file has been corrupted or truncated Klipper will detect the mismatch, 
+cancel the print, and report a clear error rather than starting a bad print.
+
+## How it works
+
+The feature uses an opt-in, file-by-file approach:
+
+1. **Slicer host**: after slicing, run one of the helper scripts provided
+   with this feature. The script computes an MD5 hash of the file and
+   prepends `; MD5:<hash>` as the very first line.
+
+2. **Printer**: when `PRINT_START` runs, `CHECK_MD5` reads that first line,
+   re-hashes the rest of the file, and compares the two values. A mismatch
+   triggers `CANCEL_PRINT` and a clear error message.
+
+Files **without** a `; MD5:` header are printed normally so existing 
+workflows and files are unaffected.
+
+## How the hook works
+
+When enabled, Firmware Config symlinks `gcode_md5.cfg` into Klipper's
+extended config directory. That file wraps `PRINT_START` using Klipper's
+`rename_existing` pattern: the original macro is preserved as
+`_PRINT_START_BASE` and called with all its original parameters after a
+successful check. When the feature is disabled, the symlink is removed and
+Klipper has no knowledge of the plugin.
+
+## Setup
+
+### Step 1 — Enable the feature
+
+Go to **Firmware Config → Tweaks → G-code MD5 Verification** and set it
+to **Enabled**. Klipper will restart automatically.
+
+### Step 2 — Download the helper script for your slicer host
+
+The scripts are included with the firmware and are also available on GitHub:
+
+- **Linux / macOS** — [add_md5.sh](../../overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh)
+- **Windows** — [add_md5.bat](../../overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat)
+
+If your printer is accessible over SSH, the scripts are also installed on
+the printer itself at:
+```
+/usr/local/share/firmware-config/tools/gcode-md5/
+```
+
+### Step 3 — Automate with a post-processing script
+
+#### Snapmaker Orca / OrcaSlicer / BambuStudio
+**Process → Others → Post-processing Scripts:**
+```
+/full/path/to/add_md5.sh;
+```
+
+#### PrusaSlicer
+**Print Settings → Output options → Post-processing scripts:**
+```
+/full/path/to/add_md5.sh;
+```
+
+The slicer passes the output file as the first argument automatically.
+
+## Firmware Config settings
+
+The following settings are available at **Firmware Config → Tweaks**:
+
+| Setting | Default | Description |
+|---|---|---|
+| G-code MD5 Verification | Disabled | Enable or disable the feature. Klipper restarts automatically. |
+| G-code MD5 — Delete Invalid Files | Enabled | Auto-delete corrupt files and their thumbnails on failure. Has no effect unless G-code MD5 Verification is enabled. |
+
+## Manual console commands
+
+```
+# Verify the currently-loaded file
+CHECK_MD5
+
+# Verify a specific file
+CHECK_MD5 FILENAME=/path/to/file.gcode
+
+# Verify without deleting on failure (overrides config)
+CHECK_MD5 FILENAME=/path/to/file.gcode DELETE=False
+```
+
+## Troubleshooting
+
+**Print cancelled with "MD5 checksum mismatch"**
+
+The file content does not match its checksum. Common causes:
+
+- Incomplete upload — retry the upload
+- File was edited after stamping — re-run `add_md5.sh` / `add_md5.bat`
+- Disk or storage corruption — try re-uploading to a different path
+
+**"No MD5 checksum found in G-code"**
+
+The file has no `; MD5:<hash>` header. This is a warning, not an error. The
+print continues normally. Stamp the file with the helper script if you
+want it verified in the future.
+
+**Files without a checksum print fine**
+
+Expected behaviour. Only files that carry a `; MD5:` header are checked.
+
+## Credit
+
+Ported from [DrA1ex/ff5m](https://github.com/DrA1ex/ff5m), which implements
+the same feature for the Flashforge Adventurer 5M (Pro).

--- a/docs/gcode_md5.md
+++ b/docs/gcode_md5.md
@@ -6,31 +6,32 @@ title: G-code MD5 Verification
 
 Verifies an MD5 checksum embedded in a g-code file before printing begins.
 If the file has been corrupted or truncated Klipper will detect the mismatch, 
-cancel the print, and report a clear error rather than starting a bad print.
+cancel the print, and, by default, delete the file.
 
 ## How it works
 
-The feature uses an opt-in, file-by-file approach:
+The feature requires two one-time setup steps in your slicer:
 
-1. **Slicer host**: after slicing, run one of the helper scripts provided
-   with this feature. The script computes an MD5 hash of the file and
-   prepends `; MD5:<hash>` as the very first line.
+1. **Post-processing script**: a helper script is added to your slicer's
+   post-processing configuration. After every slice, the slicer runs the
+   script automatically, which computes an MD5 hash of the output file and
+   prepends `; MD5:<hash>` as its very first line.
 
-2. **Printer**: when `PRINT_START` runs, `CHECK_MD5` reads that first line,
-   re-hashes the rest of the file, and compares the two values. A mismatch
-   triggers `CANCEL_PRINT` and a clear error message.
+2. **Machine Start G-code**: `CHECK_MD5` is added as the first command in
+   your slicer's Machine Start G-code. When a print begins, Klipper reads
+   the `; MD5:` header, re-hashes the rest of the file, and compares the
+   two values. A mismatch triggers `CANCEL_PRINT` and a clear error message.
 
-Files **without** a `; MD5:` header are printed normally so existing 
+Files **without** a `; MD5:` header are printed normally so existing
 workflows and files are unaffected.
 
 ## How the hook works
 
 When enabled, Firmware Config symlinks `gcode_md5.cfg` into Klipper's
-extended config directory. That file wraps `PRINT_START` using Klipper's
-`rename_existing` pattern: the original macro is preserved as
-`_PRINT_START_BASE` and called with all its original parameters after a
-successful check. When the feature is disabled, the symlink is removed and
-Klipper has no knowledge of the plugin.
+extended config directory, which loads the `gcode_md5` plugin and registers
+the `CHECK_MD5` command. The check is triggered by adding `CHECK_MD5` as
+the first line of your slicer's Machine Start G-code, before `PRINT_START`.
+When the feature is disabled, the symlink is removed.
 
 ## Setup
 
@@ -39,12 +40,13 @@ Klipper has no knowledge of the plugin.
 Go to **Firmware Config → Tweaks → G-code MD5 Verification** and set it
 to **Enabled**. Klipper will restart automatically.
 
-### Step 2 — Download the helper script for your slicer host
+### Step 2 — Add the post-processing script to your slicer
 
-The scripts are included with the firmware and are also available on GitHub:
+The post-processing script stamps every exported file with a checksum
+automatically. Download the script for your platform:
 
-- **Linux / macOS** — [add_md5.sh](../../overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh)
-- **Windows** — [add_md5.bat](../../overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat)
+- **Linux / macOS** — [add_md5.sh](../overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh)
+- **Windows** — [add_md5.bat](../overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat)
 
 If your printer is accessible over SSH, the scripts are also installed on
 the printer itself at:
@@ -52,7 +54,7 @@ the printer itself at:
 /usr/local/share/firmware-config/tools/gcode-md5/
 ```
 
-### Step 3 — Automate with a post-processing script
+Then add it to your slicer's post-processing configuration:
 
 #### Snapmaker Orca / OrcaSlicer / BambuStudio
 **Process → Others → Post-processing Scripts:**
@@ -68,14 +70,41 @@ the printer itself at:
 
 The slicer passes the output file as the first argument automatically.
 
-## Firmware Config settings
+### Step 3 — Add CHECK_MD5 to your slicer's Machine Start G-code
 
-The following settings are available at **Firmware Config → Tweaks**:
+Add `CHECK_MD5` as the very first line of your slicer's Machine Start
+G-code, before `PRINT_START`. This is what triggers the verification on
+the printer when a print begins.
+
+#### Snapmaker Orca / OrcaSlicer / BambuStudio
+**Printer Settings → Machine G-code → Machine Start G-code:**
+```
+CHECK_MD5
+PRINT_START ...
+```
+
+#### PrusaSlicer
+**Printer Settings → Custom G-code → Start G-code:**
+```
+CHECK_MD5
+PRINT_START ...
+```
+
+Both steps are required. The post-processing script stamps the file; the
+Machine Start G-code verifies it.
+
+## Delete Invalid Files Option
+By default, if `CHECK_MD5` detects a corrupted file, it will delete the
+file to avoid it being accidentally used.
+
+You can use `CHECK_MD5 DELETE=False` in your slicer to disable.
+
+
+## Firmware Config settings
 
 | Setting | Default | Description |
 |---|---|---|
 | G-code MD5 Verification | Disabled | Enable or disable the feature. Klipper restarts automatically. |
-| G-code MD5 — Delete Invalid Files | Enabled | Auto-delete corrupt files and their thumbnails on failure. Has no effect unless G-code MD5 Verification is enabled. |
 
 ## Manual console commands
 
@@ -96,9 +125,9 @@ CHECK_MD5 FILENAME=/path/to/file.gcode DELETE=False
 
 The file content does not match its checksum. Common causes:
 
-- Incomplete upload — retry the upload
-- File was edited after stamping — re-run `add_md5.sh` / `add_md5.bat`
-- Disk or storage corruption — try re-uploading to a different path
+- Incomplete upload: retry the upload
+- File was edited after stamping: re-run `add_md5.sh` / `add_md5.bat`
+- Disk or storage corruption: try re-uploading to a different path
 
 **"No MD5 checksum found in G-code"**
 

--- a/docs/gcode_md5.md
+++ b/docs/gcode_md5.md
@@ -4,8 +4,8 @@ title: G-code MD5 Verification
 
 # G-code MD5 Verification
 
-Verifies an MD5 checksum embedded in a g-code file before printing begins.
-If the file has been corrupted or truncated Klipper will detect the mismatch, 
+Verifies an MD5 checksum embedded in a g-code file before printing begins. If
+the file has been corrupted or truncated, Klipper will detect the mismatch, 
 cancel the print, and, by default, delete the file.
 
 ## How it works
@@ -20,24 +20,17 @@ The feature requires two one-time setup steps in your slicer:
 2. **Machine Start G-code**: `CHECK_MD5` is added as the first command in
    your slicer's Machine Start G-code. When a print begins, Klipper reads
    the `; MD5:` header, re-hashes the rest of the file, and compares the
-   two values. A mismatch triggers `CANCEL_PRINT` and a clear error message.
+   two values. A mismatch triggers `CANCEL_PRINT` and, by default,
+   deletion of the corrupted file.
 
-Files **without** a `; MD5:` header are printed normally so existing
+Files without a `; MD5:` header are printed normally so existing
 workflows and files are unaffected.
-
-## How the hook works
-
-When enabled, Firmware Config symlinks `gcode_md5.cfg` into Klipper's
-extended config directory, which loads the `gcode_md5` plugin and registers
-the `CHECK_MD5` command. The check is triggered by adding `CHECK_MD5` as
-the first line of your slicer's Machine Start G-code, before `PRINT_START`.
-When the feature is disabled, the symlink is removed.
 
 ## Setup
 
 ### Step 1 — Enable the feature
 
-Go to **Firmware Config → Tweaks → G-code MD5 Verification** and set it
+Go to **[Firmware Config](firmware_config.md) → Tweaks → G-code MD5 Verification** and set it
 to **Enabled**. Klipper will restart automatically.
 
 ### Step 2 — Add the post-processing script to your slicer
@@ -57,13 +50,13 @@ the printer itself at:
 Then add it to your slicer's post-processing configuration:
 
 #### Snapmaker Orca / OrcaSlicer / BambuStudio
-**Process → Others → Post-processing Scripts:**
+*Process → Others → Post-processing Scripts:*
 ```
 /full/path/to/add_md5.sh;
 ```
 
 #### PrusaSlicer
-**Print Settings → Output options → Post-processing scripts:**
+*Print Settings → Output options → Post-processing scripts:*
 ```
 /full/path/to/add_md5.sh;
 ```
@@ -77,34 +70,24 @@ G-code, before `PRINT_START`. This is what triggers the verification on
 the printer when a print begins.
 
 #### Snapmaker Orca / OrcaSlicer / BambuStudio
-**Printer Settings → Machine G-code → Machine Start G-code:**
+*Printer Settings → Machine G-code → Machine Start G-code:*
 ```
 CHECK_MD5
 PRINT_START ...
 ```
 
 #### PrusaSlicer
-**Printer Settings → Custom G-code → Start G-code:**
+*Printer Settings → Custom G-code → Start G-code:*
 ```
 CHECK_MD5
 PRINT_START ...
 ```
-
-Both steps are required. The post-processing script stamps the file; the
-Machine Start G-code verifies it.
 
 ## Delete Invalid Files Option
 By default, if `CHECK_MD5` detects a corrupted file, it will delete the
 file to avoid it being accidentally used.
 
 You can use `CHECK_MD5 DELETE=False` in your slicer to disable.
-
-
-## Firmware Config settings
-
-| Setting | Default | Description |
-|---|---|---|
-| G-code MD5 Verification | Disabled | Enable or disable the feature. Klipper restarts automatically. |
 
 ## Manual console commands
 
@@ -127,7 +110,7 @@ The file content does not match its checksum. Common causes:
 
 - Incomplete upload: retry the upload
 - File was edited after stamping: re-run `add_md5.sh` / `add_md5.bat`
-- Disk or storage corruption: try re-uploading to a different path
+- Disk or storage corruption
 
 **"No MD5 checksum found in G-code"**
 

--- a/overlays/firmware-extended/35-feature-gcode-md5/README.md
+++ b/overlays/firmware-extended/35-feature-gcode-md5/README.md
@@ -1,0 +1,62 @@
+# 35-feature-gcode-md5
+
+Adds MD5 checksum verification for g-code files.
+
+## What it does
+
+When a g-code file has a `; MD5:<hexdigest>` comment on its first line,
+Klipper verifies the hash before printing begins and cancels the print
+with a clear error message if the file is corrupt or was truncated during
+upload.
+
+Files **without** a checksum header are allowed through unchanged.
+
+## How enabling/disabling works
+
+Firmware Config creates or removes a symlink at
+`/oem/printer_data/config/extended/klipper/gcode_md5.cfg` pointing to the
+canonical copy at
+`/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg`.
+
+The presence of that symlink is the enabled state. When it exists, Klipper
+loads the plugin and the `PRINT_START` wrapper.
+
+## How the hook works
+
+`gcode_md5.cfg` wraps the existing `PRINT_START` macro using Klipper's
+`rename_existing` pattern. The original `PRINT_START` is renamed to
+`_PRINT_START_BASE` and called with all original parameters intact after
+a successful check.
+
+## Files installed
+
+| Destination | Purpose                                             |
+|---|-----------------------------------------------------|
+| `/home/lava/klipper/klippy/extras/gcode_md5.py` | Klipper plugin (exposes `CHECK_MD5` command)        |
+| `/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg` | Canonical config: symlinked into place when enabled |
+| `/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml` | Firmware Config UI toggles                          |
+| `/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh` | Slicer helper script: Linux / macOS                 |
+| `/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat` | Slicer helper script: Windows                       |
+
+## Slicer integration
+
+The helper scripts are installed on the printer at
+`/usr/local/share/firmware-config/tools/gcode-md5/` and are also available
+for direct download from the repository:
+
+- [add_md5.sh](root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh) — Linux / macOS
+- [add_md5.bat](root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat) — Windows
+
+Both scripts can be wired into all popular slicers as a
+post-processing script so every export is stamped automatically.
+
+## Runtime commands
+
+| Command | Description |
+|---|---|
+| `CHECK_MD5 [FILENAME=...] [DELETE=True\|False]` | Manually verify a file |
+
+## Credit
+
+Ported from [DrA1ex/ff5m](https://github.com/DrA1ex/ff5m), which
+implements the same feature for the Flashforge Adventurer 5M (Pro).

--- a/overlays/firmware-extended/35-feature-gcode-md5/README.md
+++ b/overlays/firmware-extended/35-feature-gcode-md5/README.md
@@ -4,7 +4,7 @@ Adds MD5 checksum verification for g-code files.
 
 ## What it does
 
-When a g-code file has a `; MD5:<hash>` comment on its first line, Klipper
+When a g-code file has a `; MD5:<hash>` comment on its first line Klipper
 verifies the hash before printing begins. If the file is corrupt or was
 truncated during upload, Klipper cancels the print, and, by default,
 deletes the file.
@@ -25,13 +25,13 @@ the first command, before `PRINT_START`.
 
 ## Files installed
 
-| Destination | Purpose                                             |
-|---|-----------------------------------------------------|
-| `/home/lava/klipper/klippy/extras/gcode_md5.py` | Klipper plugin (exposes `CHECK_MD5` command)        |
+| Destination | Purpose                                            |
+|---|----------------------------------------------------|
+| `/home/lava/klipper/klippy/extras/gcode_md5.py` | Klipper plugin (exposes `CHECK_MD5` command)       |
 | `/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg` | Canonical config: symlinked into place when enabled |
-| `/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml` | Firmware Config UI toggles                          |
-| `/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh` | Slicer helper script: Linux / macOS                 |
-| `/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat` | Slicer helper script: Windows                       |
+| `/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml` | Firmware Config UI toggle                          |
+| `/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh` | Slicer helper script: Linux / macOS                |
+| `/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat` | Slicer helper script: Windows                      |
 
 ## Slicer integration
 

--- a/overlays/firmware-extended/35-feature-gcode-md5/README.md
+++ b/overlays/firmware-extended/35-feature-gcode-md5/README.md
@@ -4,12 +4,12 @@ Adds MD5 checksum verification for g-code files.
 
 ## What it does
 
-When a g-code file has a `; MD5:<hexdigest>` comment on its first line,
-Klipper verifies the hash before printing begins and cancels the print
-with a clear error message if the file is corrupt or was truncated during
-upload.
+When a g-code file has a `; MD5:<hash>` comment on its first line, Klipper
+verifies the hash before printing begins. If the file is corrupt or was
+truncated during upload, Klipper cancels the print, and, by default,
+deletes the file.
 
-Files **without** a checksum header are allowed through unchanged.
+Files without a checksum header are allowed through unchanged.
 
 ## How enabling/disabling works
 
@@ -18,15 +18,10 @@ Firmware Config creates or removes a symlink at
 canonical copy at
 `/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg`.
 
-The presence of that symlink is the enabled state. When it exists, Klipper
-loads the plugin and the `PRINT_START` wrapper.
-
 ## How the hook works
 
-`gcode_md5.cfg` wraps the existing `PRINT_START` macro using Klipper's
-`rename_existing` pattern. The original `PRINT_START` is renamed to
-`_PRINT_START_BASE` and called with all original parameters intact after
-a successful check.
+`CHECK_MD5` is called directly from the slicer's Machine Start G-code as
+the first command, before `PRINT_START`.
 
 ## Files installed
 

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/home/lava/klipper/klippy/extras/gcode_md5.py
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/home/lava/klipper/klippy/extras/gcode_md5.py
@@ -1,0 +1,88 @@
+## MD5 checking support for gcode
+##
+## Ported from DrA1ex/ff5m (https://github.com/DrA1ex/ff5m) for the
+## Snapmaker U1 running paxx12 Extended Firmware.
+##
+## Changes from upstream:
+##   - Removed dependency on mod_params (ff5m-specific)
+##
+## This file may be distributed under the terms of the GNU GPLv3 license
+
+import hashlib
+import os
+
+
+class MD5Checker:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+
+        self.delete_invalid_files = config.getboolean("delete_invalid", True)
+
+        self.gcode.register_command("CHECK_MD5", self.cmd_CHECK_MD5,
+                                    desc=self.cmd_CHECK_MD5_help)
+
+        self.printer.register_event_handler("klippy:ready", self._init)
+
+    def _init(self):
+        self.vcard = self.printer.lookup_object("virtual_sdcard")
+
+    def calculate_md5(self, file_path):
+        hash_md5 = hashlib.md5()
+        with open(file_path, "rb") as f:
+            f.readline()  # Skip the first line (the "; MD5:..." header)
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash_md5.update(chunk)
+
+        return hash_md5.hexdigest()
+
+    def check_md5(self, file_path, delete):
+        self.gcode.respond_raw("INFO: Begin MD5 check...")
+
+        if os.path.isdir(file_path) or not os.path.exists(file_path):
+            self.gcode.respond_raw(f"!! ERROR: File doesn't exist: {file_path}")
+            return False
+
+        with open(file_path, 'r') as f:
+            first_line = f.readline().strip()
+            if not first_line.startswith("; MD5:"):
+                self.gcode.respond_raw("WARNING: No MD5 checksum found in G-code.")
+                return True
+
+            expected_md5 = first_line.split(':')[1]
+            calculated_md5 = self.calculate_md5(file_path)
+
+            if expected_md5 != calculated_md5:
+                self.gcode.respond_raw(f"!! ERROR: MD5 checksum mismatch: {expected_md5} != {calculated_md5}")
+                if delete and os.path.exists(file_path):
+                    self.gcode.respond_raw(f"INFO: File {file_path} deleted!")
+                    os.remove(file_path)
+
+                    bmp_file_path = file_path.rsplit('.', maxsplit=1)[0] + ".bmp"
+                    if os.path.exists(bmp_file_path):
+                        os.remove(bmp_file_path)
+
+                self.gcode.run_script_from_command('CANCEL_PRINT')
+                return False
+
+        self.gcode.respond_raw("INFO: MD5 checksum correct!")
+        return True
+
+    cmd_CHECK_MD5_help = (
+        "Verify the MD5 checksum of a g-code file. "
+        "Usage: CHECK_MD5 [FILENAME=/path/to/file.gcode] [DELETE=True|False]"
+    )
+
+    def cmd_CHECK_MD5(self, gcmd):
+        filename = gcmd.get("FILENAME", None)
+        delete = gcmd.get("DELETE", str(self.delete_invalid_files)) == "True"
+
+        if not filename:
+            filename = self.vcard.file_path() or ""
+
+        if not self.check_md5(filename, delete):
+            raise gcmd.error("MD5 check failed. Print cancelled!")
+
+
+def load_config(config):
+    return MD5Checker(config)

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/home/lava/klipper/klippy/extras/gcode_md5.py
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/home/lava/klipper/klippy/extras/gcode_md5.py
@@ -58,10 +58,6 @@ class MD5Checker:
                     self.gcode.respond_raw(f"INFO: File {file_path} deleted!")
                     os.remove(file_path)
 
-                    bmp_file_path = file_path.rsplit('.', maxsplit=1)[0] + ".bmp"
-                    if os.path.exists(bmp_file_path):
-                        os.remove(bmp_file_path)
-
                 self.gcode.run_script_from_command('CANCEL_PRINT')
                 return False
 

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml
@@ -1,0 +1,64 @@
+settings:
+  tweaks:
+    items:
+      gcode_md5:
+        label: G-code MD5 Verification
+        description: Verifies an MD5 checksum embedded in g-code files before printing.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/features/gcode-md5
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/gcode_md5.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable G-code MD5 verification? Files stamped with a checksum will be verified before printing begins. Files without a checksum header are not affected."
+            cmd:
+              - bash
+              - -xc
+              - |
+                ln -sf /usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg /oem/printer_data/config/extended/klipper/gcode_md5.cfg &&
+                echo "G-code MD5 Verification enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            confirm: "Disable G-code MD5 verification? Corrupt or incomplete files will no longer be caught before printing."
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -vf /oem/printer_data/config/extended/klipper/gcode_md5.cfg &&
+                echo "G-code MD5 Verification disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled
+
+      gcode_md5_delete_invalid:
+        label: G-code MD5 — Delete Invalid Files
+        description: Delete files that fail MD5 check. Has no effect unless G-code MD5 Verification is enabled.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/features/gcode-md5
+        get_cmd:
+          - bash
+          - -c
+          - >
+            grep -q "^delete_invalid: True" /oem/printer_data/config/extended/klipper/gcode_md5.cfg
+            && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                sed -i 's/^delete_invalid: .*/delete_invalid: True/' /oem/printer_data/config/extended/klipper/gcode_md5.cfg &&
+                echo "G-code MD5 — Delete Invalid Files enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                sed -i 's/^delete_invalid: .*/delete_invalid: False/' /oem/printer_data/config/extended/klipper/gcode_md5.cfg &&
+                echo "G-code MD5 — Delete Invalid Files disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: enabled

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml
@@ -4,7 +4,7 @@ settings:
       gcode_md5:
         label: G-code MD5 Verification
         description: Verifies an MD5 checksum embedded in g-code files before printing.
-        help_url: http://snapmakeru1-extended-firmware.pages.dev/features/gcode-md5
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/gcode_md5
         get_cmd:
           - bash
           - -c

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/functions/35_settings_tweaks_gcode_md5.yaml
@@ -31,34 +31,3 @@ settings:
                 echo "G-code MD5 Verification disabled. Restarting Klipper..." &&
                 /etc/init.d/S60klipper restart
         default: disabled
-
-      gcode_md5_delete_invalid:
-        label: G-code MD5 — Delete Invalid Files
-        description: Delete files that fail MD5 check. Has no effect unless G-code MD5 Verification is enabled.
-        help_url: http://snapmakeru1-extended-firmware.pages.dev/features/gcode-md5
-        get_cmd:
-          - bash
-          - -c
-          - >
-            grep -q "^delete_invalid: True" /oem/printer_data/config/extended/klipper/gcode_md5.cfg
-            && echo "enabled" || echo "disabled"
-        options:
-          enabled:
-            label: Enabled
-            cmd:
-              - bash
-              - -xc
-              - |
-                sed -i 's/^delete_invalid: .*/delete_invalid: True/' /oem/printer_data/config/extended/klipper/gcode_md5.cfg &&
-                echo "G-code MD5 — Delete Invalid Files enabled. Restarting Klipper..." &&
-                /etc/init.d/S60klipper restart
-          disabled:
-            label: Disabled
-            cmd:
-              - bash
-              - -xc
-              - |
-                sed -i 's/^delete_invalid: .*/delete_invalid: False/' /oem/printer_data/config/extended/klipper/gcode_md5.cfg &&
-                echo "G-code MD5 — Delete Invalid Files disabled. Restarting Klipper..." &&
-                /etc/init.d/S60klipper restart
-        default: enabled

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/README.md
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/README.md
@@ -36,13 +36,13 @@ tools\gcode-md5\add_md5.bat MyPrint.gcode
 ## Slicer post-processing integration
 
 ### Snapmaker Orca / OrcaSlicer / BambuStudio
-**Process → Others → Post-processing Scripts:**
+*Process → Others → Post-processing Scripts:*
 ```
 /full/path/to/add_md5.sh;
 ```
 
 ### PrusaSlicer
-**Print Settings → Output options → Post-processing scripts:**
+*Print Settings → Output options → Post-processing scripts:*
 ```
 /full/path/to/add_md5.sh;
 ```

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/README.md
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/README.md
@@ -1,0 +1,58 @@
+# gcode-md5 helper scripts
+
+Slicer-host helper scripts for stamping MD5 checksums onto g-code files.
+
+These scripts are installed on the printer at
+`/usr/local/share/firmware-config/tools/gcode-md5/` and are available for
+direct download from this directory in the repository.
+
+## Scripts
+
+| Script | Platform |
+|---|---|
+| `add_md5.sh` | Linux, macOS |
+| `add_md5.bat` | Windows |
+
+## How it works
+
+Each script prepends a single comment line to the g-code file:
+
+```
+; MD5:<hash>
+```
+
+The hash covers **all content after that line**.
+
+## Usage
+
+```sh
+# Linux / macOS
+./tools/gcode-md5/add_md5.sh MyPrint.gcode
+
+# Windows
+tools\gcode-md5\add_md5.bat MyPrint.gcode
+```
+
+## Slicer post-processing integration
+
+### Snapmaker Orca / OrcaSlicer / BambuStudio
+**Process → Others → Post-processing Scripts:**
+```
+/full/path/to/add_md5.sh;
+```
+
+### PrusaSlicer
+**Print Settings → Output options → Post-processing scripts:**
+```
+/full/path/to/add_md5.sh;
+```
+
+The slicer passes the output file as the first argument automatically.
+
+## Requirements
+
+| Platform | Requirement |
+|---|---|
+| Linux | `md5sum` (standard on all distros) |
+| macOS | `md5` (built-in) |
+| Windows | `CertUtil` (built into Windows Vista+) |

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.bat
@@ -1,0 +1,65 @@
+@echo off
+::
+:: add_md5.bat — Stamp an MD5 checksum onto a g-code file.
+::
+:: Usage: add_md5.bat <file.gcode>
+::
+:: Prepends "; MD5:<hash>" as the very first line of the file.
+:: The hash covers everything EXCEPT that header line, so the printer-side
+:: Klipper plugin skips the header and hashes the rest identically.
+::
+:: Run this on your slicer host after slicing and before uploading.
+:: It can be added as a post-processing script in your slicer:
+::   Snapmaker Orca / OrcaSlicer  : Process -> Others -> Post-processing Scripts
+::   PrusaSlicer : Print Settings -> Output options -> Post-processing scripts
+::
+:: Requires: CertUtil (built into Windows Vista and later — no extras needed).
+::
+:: Ported from DrA1ex/ff5m (https://github.com/DrA1ex/ff5m).
+:: License: GNU GPLv3
+
+setlocal EnableDelayedExpansion
+
+:: ---------------------------------------------------------------------------
+:: Validate arguments
+:: ---------------------------------------------------------------------------
+if "%~1"=="" (
+    echo Usage: %~nx0 ^<file.gcode^> >&2
+    exit /b 1
+)
+
+set "FILE=%~1"
+
+if not exist "%FILE%" (
+    echo Error: file not found: %FILE% >&2
+    exit /b 1
+)
+
+:: ---------------------------------------------------------------------------
+:: Compute MD5 via CertUtil (built-in on all modern Windows)
+:: ---------------------------------------------------------------------------
+for /f "skip=1 tokens=*" %%H in ('CertUtil -hashfile "%FILE%" MD5') do (
+    if not defined HASH_LINE set "HASH_LINE=%%H"
+)
+
+:: Strip any spaces from the hash line
+set "HASH=%HASH_LINE: =%"
+
+if "%HASH%"=="" (
+    echo Error: failed to compute MD5 hash. >&2
+    exit /b 2
+)
+
+:: ---------------------------------------------------------------------------
+:: Prepend the header line using a temporary file
+:: ---------------------------------------------------------------------------
+set "TMPFILE=%FILE%.md5tmp"
+
+echo ; MD5:%HASH%> "%TMPFILE%"
+type "%FILE%" >> "%TMPFILE%"
+
+move /y "%TMPFILE%" "%FILE%" >nul
+
+echo Stamped %FILE%: %HASH%
+
+endlocal

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tools/gcode-md5/add_md5.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# add_md5.sh — Stamp an MD5 checksum onto a g-code file.
+#
+# Usage: add_md5.sh <file.gcode>
+#
+# Prepends "; MD5:<hash>" as the very first line of the file.
+# The hash covers everything EXCEPT that header line, so the printer-side
+# Klipper plugin skips the header and hashes the rest identically.
+#
+# Run this on your slicer host after slicing and before uploading.
+# It can be added as a post-processing script in your slicer:
+#   Snapmaker Orca / OrcaSlicer  : Process -> Others -> Post-processing Scripts
+#   PrusaSlicer : Print Settings -> Output options -> Post-processing scripts
+#
+# Ported from DrA1ex/ff5m (https://github.com/DrA1ex/ff5m).
+# License: GNU GPLv3
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validate arguments
+# ---------------------------------------------------------------------------
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <file.gcode>" >&2
+    exit 1
+fi
+
+FILE="$1"
+
+if [ ! -f "$FILE" ]; then
+    echo "Error: file not found: $FILE" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Find an md5 utility (macOS uses md5, Linux uses md5sum)
+# ---------------------------------------------------------------------------
+if command -v md5sum &>/dev/null; then
+    HASH=$(md5sum "$FILE" | awk '{print $1}')
+elif command -v md5 &>/dev/null; then
+    HASH=$(md5 -q "$FILE")
+else
+    echo "Error: neither md5sum nor md5 found on PATH." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Prepend the header line using a temp file
+# ---------------------------------------------------------------------------
+HEADER="; MD5:${HASH}"
+TMPFILE=$(mktemp "${FILE}.XXXXXX")
+
+printf '%s\n' "$HEADER" > "$TMPFILE"
+cat "$FILE" >> "$TMPFILE"
+mv "$TMPFILE" "$FILE"
+
+echo "Stamped ${FILE}: ${HASH}"

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg
@@ -1,0 +1,37 @@
+# gcode_md5.cfg
+#
+# Enables MD5 checksum verification for g-code files.
+#
+# This file is the canonical copy stored in the firmware-config tweaks
+# directory.  Firmware Config symlinks it into
+# /oem/printer_data/config/extended/klipper/ when the feature is enabled,
+# and removes the symlink when disabled.
+#
+# To stamp a hash onto a sliced file before uploading, use one of the
+# provided helper scripts on your slicer host:
+#   Linux/macOS : tools/gcode-md5/add_md5.sh  yourfile.gcode
+#   Windows     : tools\gcode-md5\add_md5.bat yourfile.gcode
+#
+# See docs/features/gcode_md5.md for full documentation.
+
+[gcode_md5]
+# When True, files that fail the MD5 check are automatically deleted
+# (along with their .bmp thumbnail if present) to prevent re-printing
+# a corrupt file.
+delete_invalid: True
+
+# ---------------------------------------------------------------------------
+# PRINT_START wrapper
+#
+# Uses rename_existing to insert CHECK_MD5 before the existing PRINT_START
+# macro runs.  No changes to the original PRINT_START are required.
+# Removing this file (by disabling the feature) restores the original
+# PRINT_START automatically.
+# ---------------------------------------------------------------------------
+
+[gcode_macro PRINT_START]
+rename_existing: _PRINT_START_BASE
+description: Verify MD5 checksum then delegate to the original PRINT_START
+gcode:
+    CHECK_MD5
+    _PRINT_START_BASE {rawparams}

--- a/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg
+++ b/overlays/firmware-extended/35-feature-gcode-md5/root/usr/local/share/firmware-config/tweaks/klipper/gcode_md5.cfg
@@ -7,31 +7,18 @@
 # /oem/printer_data/config/extended/klipper/ when the feature is enabled,
 # and removes the symlink when disabled.
 #
-# To stamp a hash onto a sliced file before uploading, use one of the
-# provided helper scripts on your slicer host:
-#   Linux/macOS : tools/gcode-md5/add_md5.sh  yourfile.gcode
-#   Windows     : tools\gcode-md5\add_md5.bat yourfile.gcode
+# CHECK_MD5 is called from your slicer's Machine Start G-code, not from
+# a macro wrapper.  Add it as the first line of Machine Start G-code in
+# your slicer:
 #
-# See docs/features/gcode_md5.md for full documentation.
+#   CHECK_MD5
+#   PRINT_START ...
+#
+# Files without a "; MD5:<hash>" header are allowed through unchanged.
+#
+# See docs/gcode_md5.md for full documentation.
 
 [gcode_md5]
 # When True, files that fail the MD5 check are automatically deleted
-# (along with their .bmp thumbnail if present) to prevent re-printing
-# a corrupt file.
+# to prevent re-printing a corrupt file.
 delete_invalid: True
-
-# ---------------------------------------------------------------------------
-# PRINT_START wrapper
-#
-# Uses rename_existing to insert CHECK_MD5 before the existing PRINT_START
-# macro runs.  No changes to the original PRINT_START are required.
-# Removing this file (by disabling the feature) restores the original
-# PRINT_START automatically.
-# ---------------------------------------------------------------------------
-
-[gcode_macro PRINT_START]
-rename_existing: _PRINT_START_BASE
-description: Verify MD5 checksum then delegate to the original PRINT_START
-gcode:
-    CHECK_MD5
-    _PRINT_START_BASE {rawparams}


### PR DESCRIPTION
## Summary

Ports the MD5 file-integrity check from [DrA1ex/ff5m](https://github.com/DrA1ex/ff5m) to the U1 extended firmware.

When a g-code file has a `; MD5:<hash>` comment on its first line, Klipper verifies the hash before printing begins. and aborts with a clear error if the file is corrupt or was truncated during upload.  If the file has been corrupted or truncated, Klipper will detect the mismatch, cancel the print, and, by default, delete the file.

## Changes

- **`overlays/firmware-extended/35-feature-gcode-md5/`** — new overlay
  - `gcode_md5.py` — Klipper extras plugin
  - `gcode_md5.cfg` — Klipper config (loaded via extended include via Firmware Config)
  - `35_settings_tweaks_gcode_md5.yaml` — Firmware Config UI toggle
- **`tools/gcode-md5/`** — slicer-side helper scripts
  - `add_md5.sh` — Linux / macOS
  - `add_md5.bat` — Windows
- **`docs/gcode_md5.md`** — user documentation

## Testing

Tested on U1 with extended firmware:

- [X] File without MD5 header prints normally
- [X] File with correct checksum prints normally
- [X] File with corrupted content aborts with "MD5 MISMATCH" error
- [X] Firmware Config toggle enables/disables the check correctly
- [X] `VERIFY_MD5 FILE=...` console command works

## Credit

Original concept and implementation: [DrA1ex/ff5m](https://github.com/DrA1ex/ff5m) (GPLv3).