### PR TITLE
Update `filament_detect/set` to add `MULTI_MODE`, `RGB_2..5`, and `COLOR_NUMS`

### DIFF
--- a/docs/design/filament_detect.md
+++ b/docs/design/filament_detect.md
@@ -23,6 +23,10 @@ Writable fields:
 | `MAIN_TYPE` | `string` | `PLA`, `PETG`, `ABS`, `TPU`, `PVA` | Other values accepted but not RFID-protocol-mapped |
 | `SUB_TYPE` | `string` | `Basic`, `Matte`, `SnapSpeed`, `Silk`, `Support`, `HF`, `95A`, `95A HF` | Other values accepted but not RFID-protocol-mapped |
 | `RGB_1` | `int` | Integer RGB value | |
+| `RGB_2` | `int` | Integer RGB value | Requires `COLOR_NUMS` >= 2 on read |
+| `RGB_3` | `int` | Integer RGB value | Requires `COLOR_NUMS` >= 3 on read |
+| `RGB_4` | `int` | Integer RGB value | Requires `COLOR_NUMS` >= 4 on read |
+| `RGB_5` | `int` | Integer RGB value | Requires `COLOR_NUMS` >= 5 on read |
 | `ALPHA` | `int` | Integer 0..255 | |
 | `HOTEND_MIN_TEMP` | `int` | Integer | |
 | `HOTEND_MAX_TEMP` | `int` | Integer | |
@@ -39,8 +43,7 @@ Read-only fields (returned by query, not accepted by `set`):
 | `MANUFACTURER` | |
 | `VERSION` | |
 | `TRAY` | |
-| `COLOR_NUMS` | |
-| `RGB_2..RGB_5` | |
+| `COLOR_NUMS` | Derived: count of `RGB_x` fields provided (minimum 1) |
 | `DIAMETER` | |
 | `WEIGHT` | |
 | `LENGTH` | |
@@ -137,7 +140,7 @@ OpenSpool U1 Extended mapping profile:
 | `bed_min_temp`/`bed_max_temp` | `BED_TEMP` | `N/A` | collapsed to single bed temp |
 | `protocol` | `N/A` | `N/A` | parser validation only |
 | `version` | `N/A` | `N/A` | no endpoint field |
-| `additional_color_hexes` | `N/A` | `N/A` | no endpoint field; parser-only path supports extra colors |
+| `additional_color_hexes` | `RGB_2`..`RGB_N` | `N/A` | mapped to `RGB_2`..`RGB_5`; `COLOR_NUMS` derived from total color count |
 | `diameter` | `N/A` | `N/A` | no endpoint field |
 | `weight` | `N/A` | `N/A` | no endpoint field |
 

--- a/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
@@ -10,7 +10,7 @@
      def _ready(self):
          self.filament_feed_objects = self.printer.lookup_objects('filament_feed')
          self._fm175xx_reader = self.printer.lookup_object('fm175xx_reader')
-@@ -173,6 +176,59 @@
+@@ -173,6 +176,67 @@
  
          return error, info
  
@@ -46,7 +46,15 @@
 +                filament_info['ALPHA'] = int(params.pop('ALPHA')) & 0xFF
 +            if 'RGB_1' in params:
 +                filament_info['RGB_1'] = int(params.pop('RGB_1')) & 0xFFFFFF
++            filament_info['COLOR_NUMS'] = 1
++            for key in ('RGB_2', 'RGB_3', 'RGB_4', 'RGB_5'):
++                if key in params:
++                    filament_info[key] = int(params.pop(key)) & 0xFFFFFF
++                    filament_info['COLOR_NUMS'] += 1
 +            filament_info['ARGB_COLOR'] = filament_info['ALPHA'] << 24 | filament_info['RGB_1']
++
++            if 'MULTI_MODE' in params:
++                filament_info['MULTI_MODE'] = int(params.pop('MULTI_MODE')) & 0xFF
 +
 +            if 'CARD_UID' in params:
 +                filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]


### PR DESCRIPTION
`FILAMENT_INFO_STRUCT` includes `MULTI_MODE` and `RGB_2`..`RGB_5` bytes
but the `filament_detect/set` webhook handler never accepted them, making
it impossible to write these fields to an RFID tag via the API.

Accept an optional `MULTI_MODE` parameter (0-255) stored directly in
`filament_info`. Accept optional `RGB_2`..`RGB_5` parameters and derive
`COLOR_NUMS` automatically from the count of `RGB_x` fields provided
(minimum 1), so callers do not need to compute it themselves.