### PR TITLE
Add print lifecycle hooks to `fluidd.cfg`

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -285,5 +285,6 @@ If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
 
 - [Camera Support](camera_support.md) - Camera features and WebRTC streaming
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files
+- [Klipper Print Hooks](klipper_hooks.md) - React to print lifecycle events via hook macros
 - [Data Persistence](data_persistence.md) - Understanding persistent storage
 - [VPN Remote Access](vpn.md) - Secure remote access via Tailscale

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ Heavily expanded firmware with extensive features and customization:
 **Klipper Customization:**
 
 - [Klipper and Moonraker Custom Includes](klipper_includes.md) - Add custom configuration files via Fluidd/Mainsail
+- [Klipper Print Hooks](klipper_hooks.md) - React to `PRINT_START`, `PRINT_END`, and `CANCEL_PRINT` without modifying stock macros
 - [Klipper Tweaks](tweaks.md) - Experimental [TMC driver optimizations](tweaks.md#tmc-autotune), [reduced current](tweaks.md#tmc-reduced-current), and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh)
 - [AFC-Lite Stub](afc-lite.md) - Experimental AFC UI compatibility layer for Fluidd/Mainsail
 - [Faulty Toolhead Bypass](faulty_toolhead.md) - Temporary bypass for one failed toolhead thermistor so the other toolheads can still be used

--- a/docs/klipper_hooks.md
+++ b/docs/klipper_hooks.md
@@ -1,0 +1,65 @@
+---
+title: Klipper Print Hooks
+---
+
+# Klipper Print Hooks
+
+The extended firmware patches `fluidd.cfg` to add a hook system for `PRINT_START`, `PRINT_END`, and `CANCEL_PRINT`. Features and custom macros can react to print lifecycle events without modifying any stock macro.
+
+## How It Works
+
+At the end of `PRINT_START`, and at the start of `PRINT_END` and `CANCEL_PRINT`, the macro iterates `printer.configfile.config` and calls every `gcode_macro` whose name matches the relevant prefix:
+
+| Event | Hook prefix | Called |
+|---|---|---|
+| `PRINT_START` | `_PRINT_START_` | **after** the original |
+| `PRINT_END` | `_PRINT_END_` | **before** the original |
+| `CANCEL_PRINT` | `_CANCEL_PRINT_` | **before** the original |
+
+`PRINT_END` and `CANCEL_PRINT` hooks run first so features can do cleanup (e.g. update spool state) before the printer parks and turns off heaters.
+
+## Registering a Hook
+
+Create a `gcode_macro` with the matching prefix inside any `.cfg` file loaded by Klipper. Placing it in `extended/klipper/` is the recommended location.
+
+```cfg
+[gcode_macro _PRINT_START_MY_FEATURE]
+gcode:
+    RESPOND TYPE=echo MSG="my feature: print started"
+
+[gcode_macro _PRINT_END_MY_FEATURE]
+gcode:
+    RESPOND TYPE=echo MSG="my feature: print ended"
+
+[gcode_macro _CANCEL_PRINT_MY_FEATURE]
+gcode:
+    RESPOND TYPE=echo MSG="my feature: print cancelled"
+```
+
+No existing macro needs to be modified. Hooks are discovered at runtime from the live config.
+
+## Hook Ordering
+
+Hooks are called in the order Klipper processed the config sections, which follows the alphabetical file order within each included directory. If ordering between hooks matters, use a numeric prefix in the macro name (e.g. `_PRINT_END_10_SPOOLMAN`, `_PRINT_END_20_NOTIFY`).
+
+## Passing Parameters
+
+Hooks receive no parameters. If a hook needs slicer-supplied values (e.g. bed temperature), read them from `printer.configfile.settings` or via a shared `gcode_macro` variable.
+
+## Example: Cavity LED
+
+Turn the cavity LED on when a print starts and off when it ends or is cancelled.
+
+```cfg
+[gcode_macro _PRINT_START_CAVITY_LED]
+gcode:
+    SET_LED LED=cavity_led WHITE=1.0
+
+[gcode_macro _PRINT_END_CAVITY_LED]
+gcode:
+    SET_LED LED=cavity_led WHITE=0
+
+[gcode_macro _CANCEL_PRINT_CAVITY_LED]
+gcode:
+    SET_LED LED=cavity_led WHITE=0
+```

--- a/docs/klipper_includes.md
+++ b/docs/klipper_includes.md
@@ -43,3 +43,7 @@ For camera configuration examples, see [Camera Support](camera_support.md#moonra
 ## Configuration Recovery
 
 If an invalid configuration breaks Moonraker (printer won't connect to WiFi), see [Firmware Configuration - Recovery & Reset](firmware_config.md#recovery--reset) for recovery instructions.
+
+## See Also
+
+- [Klipper Print Hooks](klipper_hooks.md) - React to `PRINT_START`, `PRINT_END`, and `CANCEL_PRINT` events from your custom includes

--- a/overlays/firmware-extended/35-feature-klipper-hooks/patches/home/lava/origin_printer_data/config/01-klipper-hooks.patch
+++ b/overlays/firmware-extended/35-feature-klipper-hooks/patches/home/lava/origin_printer_data/config/01-klipper-hooks.patch
@@ -1,0 +1,32 @@
+--- a/fluidd.cfg
++++ b/fluidd.cfg
+@@ -200,6 +200,9 @@
+     M84
+     G92 E0
+     M220 S100
++    {% for section in printer.configfile.config if section.startswith("gcode_macro _PRINT_START_") %}
++        { section[12:] }
++    {% endfor %}
+
+ [gcode_macro PRINT_STRAT]
+ gcode:
+@@ -208,6 +211,9 @@
+
+ [gcode_macro PRINT_END]
+ gcode:
++    {% for section in printer.configfile.config if section.startswith("gcode_macro _PRINT_END_") %}
++        { section[12:] }
++    {% endfor %}
+     M220 S100
+     ##### get user parameters or use default #####
+     {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
+@@ -267,6 +273,9 @@
+ description: Cancel the actual running print
+ rename_existing: CANCEL_PRINT_BASE
+ gcode:
++    {% for section in printer.configfile.config if section.startswith("gcode_macro _CANCEL_PRINT_") %}
++        { section[12:] }
++    {% endfor %}
+     M220 S100
+     ##### get user parameters or use default #####
+     {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}


### PR DESCRIPTION
Patches `origin_printer_data/config/fluidd.cfg` to iterate `printer.configfile.config` at runtime and call every `gcode_macro` whose name matches `_PRINT_START_*`, `_PRINT_END_*`, or `_CANCEL_PRINT_*`.

Hooks run after `PRINT_START` and before `PRINT_END`/`CANCEL_PRINT`, allowing features to register lifecycle callbacks without touching any stock macro.