### PR TITLE
Fix `alpha` parsing for OpenSpool on OpenRFID

### DIFF
--- a/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
+++ b/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GIT_URL=https://github.com/suchmememanyskill/OpenRFID.git
-GIT_SHA=778bd576e436a083aa9940bf2edb0fd7d182913a
+GIT_SHA=195e47d59a70dc532dac8ff19923254f3df17f29
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."


### PR DESCRIPTION
Fixes https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/issues/430. According to specification the `alpha` is a byte hex.

```
2026-05-02 19:32:36 ERROR tag_processor:openspool_tag_processor: OpenSpool payload parsing failed: invalid literal for int() with base 10: 'FF'
Traceback (most recent call last):
  File "/usr/local/share/openrfid/tag/openspool/processor.py", line 47, in __openspool_parse_payload
    alpha = max(0x00, min(0xFF, int(data.get('alpha', 255))))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'FF'
```