### PR TITLE
Add `CARD_UID` and `CARD_TYPE` tag metadata to RFID stack

### DIFF
--- a/docs/design/filament_detect.md
+++ b/docs/design/filament_detect.md
@@ -31,7 +31,8 @@ Writable fields:
 | `HOTEND_MIN_TEMP` | `int` | Integer | |
 | `HOTEND_MAX_TEMP` | `int` | Integer | |
 | `BED_TEMP` | `int` | Integer | |
-| `CARD_UID` | `list[int]` | Array of byte ints | |
+| `CARD_UID` | `list[int]` | Array of byte ints | Indicates a tag is physically present; independent of filament data |
+| `CARD_TYPE` | `string` | `NTAG`, `M1` | Tag hardware type; independent of filament data |
 | `SKU` | `int` | Integer | |
 
 Read-only fields (returned by query, not accepted by `set`):
@@ -39,7 +40,7 @@ Read-only fields (returned by query, not accepted by `set`):
 | Field | Notes |
 |---|---|
 | `ARGB_COLOR` | Derived: `(ALPHA << 24) \| RGB_1` |
-| `OFFICIAL` | `true` when `info` is non-empty (set by firmware) |
+| `OFFICIAL` | `true` when `info` contains at least one filament field other than `CARD_UID` |
 | `MANUFACTURER` | |
 | `VERSION` | |
 | `TRAY` | |
@@ -84,12 +85,33 @@ Request shape:
 | Field | Required | Type | Accepted values |
 |---|---|---|---|
 | `channel` | Yes | `int` | `0..3` |
-| `info` | No | `object` | If missing/empty, treated as clear/reset |
+| `info` | No | `object` | See set semantics below |
 
 Response:
 
 - Success: `{"state": "success"}`
 - Error: `{"state": "error", "message": "..."}`
+
+### Set semantics
+
+The endpoint has three modes determined by the filament fields present in `info`. `CARD_UID` is orthogonal — it can appear in any mode to record that a physical tag is present, even when the tag carries no filament data:
+
+| Mode | `info` content | `OFFICIAL` | Update path |
+|---|---|---|---|
+| Full update | One or more filament fields (± `CARD_UID`) | `true` | `_filament_info_update` called; `print_task_config` mirrored |
+| Tag present, no data | `CARD_UID` only | `false` | Direct assignment; if the slot was previously official, `_filament_info_update` is called to clear it |
+| Clear | Missing or empty | `false` | Direct assignment; filament fields reset to `FILAMENT_INFO_STRUCT` defaults |
+
+`CARD_UID` and `CARD_TYPE` are both popped before `has_params` is computed, so they never contribute to `OFFICIAL`. `CARD_TYPE` is populated automatically on hardware reads (`NTAG` via `filament_protocol_ndef`, `M1` via `filament_protocol`).
+
+## openrfid Integration
+
+`openrfid_u1_base.cfg` registers two webhook exporters that drive `filament_detect/set` automatically:
+
+| Exporter | Event | Payload | Effect |
+|---|---|---|---|
+| `parse_error_exporter` | `tag_parse_error` | `{"channel": N, "info": {"CARD_UID": [...]}}` | UID-only set; captures the hardware UID even when the tag payload cannot be decoded |
+| `not_present_exporter` | `tag_not_present` | `{"channel": N}` | Clear; resets the slot when no tag is present |
 
 ## OpenSpool U1 Extended Format Input
 
@@ -270,9 +292,10 @@ Transformation trace for this example:
 
 Repository overlays:
 
-- `overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py`
-- `overlays/firmware-extended/13-rfid-support/patches/02-add-ndef-protocol.patch`
-- `overlays/firmware-extended/13-rfid-support/patches/05-add-filament-detect-set-endpoint.patch`
+- `overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py`
+- `overlays/firmware-extended/13-patch-rfid/patches/02-add-ndef-protocol.patch`
+- `overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch`
+- `overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg`
 
 Klipper source code:
 

--- a/overlays/firmware-extended/13-patch-rfid/README.md
+++ b/overlays/firmware-extended/13-patch-rfid/README.md
@@ -21,6 +21,10 @@ Patch set in `overlays/firmware-extended/13-rfid-support/patches`:
     - `cmd_FILAMENT_DT_SELF_TEST`: raises early error when reader is disabled.
 - `05-add-filament-detect-set-endpoint.patch`
   - Adds webhook endpoint `filament_detect/set`.
+- `08-pass-uid-on-m1-auth-failure.patch`
+  - When M1 auth fails, sets `card_data` to the UID bytes from the anticollision/SELECT phase
+    (`self.__picc_a.UID[0:4]`) so that `CARD_UID` and `CARD_TYPE` are still populated via the
+    existing patch-07 handler in `filament_detect.py`.
 
 ## API Contract
 

--- a/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
@@ -10,7 +10,7 @@
      def _ready(self):
          self.filament_feed_objects = self.printer.lookup_objects('filament_feed')
          self._fm175xx_reader = self.printer.lookup_object('fm175xx_reader')
-@@ -173,6 +176,67 @@
+@@ -173,6 +176,70 @@
  
          return error, info
  
@@ -25,9 +25,13 @@
 +                                        % (channel, self._channel_nums - 1))
 +
 +            params = web_request.get_dict('info', {})
-+            has_params = len(params) > 0
 +            filament_info = dict(filament_protocol.FILAMENT_INFO_STRUCT)
++            if 'CARD_UID' in params:
++                filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]
++            if 'CARD_TYPE' in params:
++                filament_info['CARD_TYPE'] = str(params.pop('CARD_TYPE'))
 +
++            has_params = len(params) > 0
 +            if 'VENDOR' in params:
 +                filament_info['VENDOR'] = str(params.pop('VENDOR'))
 +            if 'MAIN_TYPE' in params:
@@ -55,9 +59,6 @@
 +
 +            if 'MULTI_MODE' in params:
 +                filament_info['MULTI_MODE'] = int(params.pop('MULTI_MODE')) & 0xFF
-+
-+            if 'CARD_UID' in params:
-+                filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]
 +            if 'SKU' in params:
 +                filament_info['SKU'] = int(params.pop('SKU'))
 +
@@ -70,6 +71,8 @@
 +            ptc = self.printer.lookup_object('print_task_config', None)
 +            if has_params or ptc is not None and ptc.print_task_config['filament_official'][channel]:
 +                self._filament_info_update(channel, filament_info, True)
++            else:
++                self._filament_info[channel] = filament_info
 +            web_request.send({'state': 'success'})
 +        except Exception as e:
 +            logging.error("[filament_detect] set: %s", str(e))

--- a/overlays/firmware-extended/13-patch-rfid/patches/06-add-card-type-to-filament-protocol.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/06-add-card-type-to-filament-protocol.patch
@@ -1,0 +1,10 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_protocol.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_protocol.py
+@@ -36,6 +36,7 @@
+     'RSA_KEY_VERSION': 0,
+     'OFFICIAL': False,
+     'CARD_UID': 0,
++    'CARD_TYPE': '',
+ }
+
+ # Filament main type

--- a/overlays/firmware-extended/13-patch-rfid/patches/07-detect-card-type-on-parse-failure.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/07-detect-card-type-on-parse-failure.patch
@@ -1,0 +1,20 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_detect.py
+@@ -132,6 +132,17 @@
+         else:
+             self._self_test_success_cnt += 1
+ 
++        if fm175xx_reader.FM175XX_CARD_INFO_READ == operation:
++            if card_type == fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_NTAG:
++                filament_info['CARD_TYPE'] = 'NTAG'
++                if card_data and len(card_data) >= 8:
++                    filament_info['CARD_UID'] = [card_data[0], card_data[1], card_data[2],
++                                                 card_data[4], card_data[5], card_data[6], card_data[7]]
++            elif card_type == fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_M1:
++                filament_info['CARD_TYPE'] = 'M1'
++                if card_data and len(card_data) >= filament_protocol.M1_PROTO_UID_LEN:
++                    filament_info['CARD_UID'] = list(card_data[:filament_protocol.M1_PROTO_UID_LEN])
++
+         self._state[channel] = FILAMENT_DT_STATE_IDLE
+         self._filament_info_update(channel, filament_info, is_clear)
+ 

--- a/overlays/firmware-extended/13-patch-rfid/patches/08-pass-uid-on-m1-auth-failure.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/08-pass-uid-on-m1-auth-failure.patch
@@ -1,0 +1,10 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py
++++ rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
+@@ -1059,6 +1059,8 @@
+                             if (FM175XX_OK != ret.err_code):
+                                 card_op_result = FM175XX_CARD_READ_ERR
++                                card_data = list(self.__picc_a.UID[0:4])
++                                logging.info("M1 auth failed, UID: %s", ' '.join('%02X' % b for b in card_data))
+                             else:
+                                 card_data = ret.out_param[0:FM175XX_M1_CARD_EEPROM_SIZE]
+                                 card_op_result = FM175XX_OK

--- a/overlays/firmware-extended/13-patch-rfid/pre-scripts/01_klippy_fix_lf.sh
+++ b/overlays/firmware-extended/13-patch-rfid/pre-scripts/01_klippy_fix_lf.sh
@@ -8,4 +8,5 @@ fi
 ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
 
 dos2unix "$1/home/lava/klipper/klippy/extras/filament_detect.py" \
+  "$1/home/lava/klipper/klippy/extras/filament_protocol.py" \
   "$1/home/lava/klipper/klippy/extras/fm175xx_reader.py"

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
@@ -76,13 +76,21 @@ key = 536e61706d616b65725f71776572747975696f705b2c2e3b5d5f317132773365
 method = POST
 event = tag_parse_error
 url = http://localhost/printer/filament_detect/set
-body_json_template = {"channel":{{reader.slot}},"info":{}}
+body_json_template = {
+    "channel":{{reader.slot}},
+    "info": {
+      "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+      "CARD_TYPE": "{{ {'MifareUltralight': 'NTAG', 'MifareClassic1k': 'M1'}.get(scan.tag_type, scan.tag_type) }}"
+    }
+  }
 
 [webhook_exporter not_present_exporter]
 method = POST
 event = tag_not_present
 url = http://localhost/printer/filament_detect/set
-body_json_template = {"channel":{{reader.slot}},"info":{}}
+body_json_template = {
+    "channel":{{reader.slot}}
+  }
 
 [moonraker_on_property_change]
 moonraker_socket_path = /oem/printer_data/comms/moonraker.sock

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
@@ -13,6 +13,7 @@ body_json_template = {
             "BED_TEMP": {{ filament.bed_temp_c | int }},
             "ALPHA": {{ filament.alpha }},
             "RGB_1": {{ filament.rgb }},
-            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}]
+            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+            "CARD_TYPE": "{{ {'MifareUltralight': 'NTAG', 'MifareClassic1k': 'M1'}.get(scan.tag_type, scan.tag_type) }}"
         }
     }

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
@@ -13,6 +13,7 @@ body_json_template = {
             "BED_TEMP": {{ filament.bed_temp_c | int }},
             "ALPHA": {{ filament.alpha }},
             "RGB_1": {{ filament.rgb }},
-            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}]
+            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+            "CARD_TYPE": "{{ {'MifareUltralight': 'NTAG', 'MifareClassic1k': 'M1'}.get(scan.tag_type, scan.tag_type) }}"
         }
     }


### PR DESCRIPTION
## Summary

Refines `CARD_UID` semantics in `filament_detect/set` and adds a new
`CARD_TYPE` field (`NTAG` / `M1`) throughout the RFID stack so
consumers can distinguish NDEF from MIFARE Classic reads.

## Changes

### Refine `CARD_UID` handling and document set semantics

- Move `CARD_UID` extraction before `has_params` so the UID is never
  counted as a filament field that would trigger a slot clear.
- Skip `_filament_info_update` when no filament fields are present and
  the slot is not official (tag-present-only path).
- `openrfid_u1_base.cfg`: send `CARD_UID` even when tag read fails, so
  downstream consumers still receive the UID from anticollision.
- Design doc: add `CARD_UID` orthogonality note, a set-semantics table
  (three modes: full update / tag present with no data / clear), and an
  OpenRFID integration section covering `parse_error_exporter` and
  `not_present_exporter`.  Fix overlay path reference
  (`13-rfid-support` → `13-patch-rfid`).

### Add `CARD_TYPE` field throughout RFID stack

Introduces `CARD_TYPE` (`NTAG` or `M1`) as a new tag-metadata field
parallel to `CARD_UID`:

- `filament_detect/set` accepts `CARD_TYPE`; it is extracted before
  `has_params` and never contributes to `OFFICIAL`.
- Patch `06`: `FILAMENT_INFO_STRUCT` gains `'CARD_TYPE': ''`;
  `m1_proto_data_parse` sets it to `'M1'` for MIFARE Classic reads.
- `filament_protocol_ndef.py`: `openspool_parse_payload` sets
  `CARD_TYPE = 'NTAG'` for NDEF reads.
- Patch `07`: `_fm175xx_card_info_deal_callback` populates both
  `CARD_TYPE` and `CARD_UID` before `FILAMENT_DT_STATE_IDLE` on every
  `FM175XX_CARD_INFO_READ` event where the card type is known — covers
  parse failures and read errors where the UID is still available from
  anticollision.
- OpenRFID exporters (`openrfid_u1_base.cfg`, `openrfid_u1_generic.cfg`,
  `openrfid_u1_vendor.cfg`): `CARD_TYPE` added to all webhook bodies,
  mapped from `scan.tag_type` via Jinja2 dict lookup
  (`MifareUltralight` → `NTAG`, `MifareClassic1k` → `M1`).
- Design doc updated to list `CARD_TYPE` in the writable fields table.