### PR TITLE
Add `hidden` support to `firmware-config`

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
@@ -259,6 +259,7 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
 
                 result[section_key] = {
                     'title': section_cfg.get('title', section_key),
+                    'hidden': section_cfg.get('hidden', False),
                     'items': section_items
                 }
 
@@ -300,6 +301,8 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
                         opt_info = {"label": opt_val["label"]}
                         if "confirm" in opt_val:
                             opt_info["confirm"] = opt_val["confirm"]
+                        if opt_val.get("hidden"):
+                            opt_info["hidden"] = True
                         options_data[opt_key] = opt_info
 
                     settings_list.append({
@@ -308,6 +311,7 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
                         "description": config.get("description"),
                         "help_url": config.get("help_url"),
                         "current": current_value,
+                        "hidden": config.get("hidden", False),
                         "options": options_data
                     })
                 if settings_list:
@@ -395,7 +399,8 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
                         "help_url": cfg.get("help_url"),
                         "confirm": cfg.get("confirm", False),
                         "background": cfg.get("background", False),
-                        "download_file": cfg.get("download_file")
+                        "download_file": cfg.get("download_file"),
+                        "hidden": cfg.get("hidden", False)
                     })
                 if actions_list:
                     result[group_key] = {

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -98,6 +98,10 @@
             Authentication required. Please <a href="/">log in to Fluidd</a> first, then return to this page.
         </div>
 
+        <div id="hidden-notice" class="notice" style="background:var(--accent);color:#000">
+            Hidden options are visible.
+        </div>
+
         <div id="main-content">
         <div class="card">
             <div class="card-header"><span class="card-title">Status</span></div>
@@ -190,6 +194,7 @@
         let selectedFile = null;
         let actionsData = [];
         let currentAction = '';
+        const showHidden = new URLSearchParams(window.location.search).has('hidden') || window.location.hash.includes('hidden');
 
         function showServiceNotice() {
             $('service-notice').classList.add('visible');
@@ -237,7 +242,9 @@
             try {
                 const status = await (await apiFetch('api/status')).json();
 
-                container.innerHTML = Object.entries(status).map(([key, section]) => {
+                container.innerHTML = Object.entries(status)
+                    .filter(([_, section]) => !section.hidden || showHidden)
+                    .map(([key, section]) => {
                     const itemsHtml = section.items.map(item =>
                         `<div><strong>${item.label}:</strong> ${item.value || 'N/A'}</div>`
                     ).join('');
@@ -276,7 +283,7 @@
                 container.innerHTML = Object.entries(grouped).map(([_, group]) =>
                     `<div class="group-section">
                         <div class="group-title">${group.label}</div>
-                        ${group.items.map(action =>
+                        ${group.items.filter(action => !action.hidden || showHidden).map(action =>
                             `<div class="row" onclick="runAction('${action.id}')">
                                 <div class="row-label-wrap">
                                     <span class="row-label">${action.label}${action.help_url ? `<a class="row-help" href="${action.help_url}" target="_blank" onclick="event.stopPropagation()">↗</a>` : ''}</span>
@@ -308,8 +315,10 @@
                 container.innerHTML = groups.map(([_, group]) =>
                     `<div class="group-section">
                         <div class="group-title">${group.label}</div>
-                        ${group.items.map(setting => {
-                            const options = Object.entries(setting.options).map(([optKey, optVal]) => {
+                        ${group.items.filter(setting => !setting.hidden || showHidden).map(setting => {
+                            const options = Object.entries(setting.options)
+                                .filter(([optKey, optVal]) => !optVal.hidden || optKey === setting.current || showHidden)
+                                .map(([optKey, optVal]) => {
                                 return `<option value="${optKey}" data-label="${encodeURIComponent(optVal.label)}" data-confirm="${encodeURIComponent(optVal.confirm || '')}"${optKey === setting.current ? ' selected' : ''}>${optVal.label}</option>`;
                             }).join('');
                             return `<div class="row"${setting.help_url ? ` onclick="if(!event.target.closest('select'))window.open('${setting.help_url}','_blank')"` : ''}>
@@ -726,6 +735,7 @@
         // Initialize
         // ========================================
 
+        if (showHidden) $('hidden-notice').classList.add('visible');
         refreshAll();
     </script>
 </body>


### PR DESCRIPTION
Adds `hidden: true` flag to settings items, settings options, actions, and status sections. Hidden entries are omitted from the UI unless `?hidden` or `#hidden` is present in the URL, in which case a notice banner is shown. Hidden options within a setting are also shown if they are the currently active value.

This allows to add some options that are not visible unless selected or explicitly requested.

## Notice

<img width="933" height="206" alt="image" src="https://github.com/user-attachments/assets/2d150759-2eac-4662-889d-939c2e8e1ec5" />

## Setting

<img width="553" height="195" alt="image" src="https://github.com/user-attachments/assets/098554c3-35bd-4129-a81a-f80d4b501cc3" />
