### PR TITLE
Fix `Printer Preferences` to apply changes only when in printing state

### DIFF
--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg
@@ -2,16 +2,21 @@
 rename_existing: _BED_MESH_CALIBRATE_BASE
 description: Force adaptive bed mesh calibration (falls back to full mesh when exclude_object is not active)
 gcode:
-    {% set prev_state = printer["machine_state_manager"].main_state %}
-    SET_MAIN_STATE MAIN_STATE=IDLE
-    SET_PRINT_PREFERENCES BED_LEVEL=1
-    SET_MAIN_STATE MAIN_STATE={prev_state}
-    _BED_LEVELING_FORCE_VALIDATE
-    _BED_MESH_CALIBRATE_BASE {rawparams} ADAPTIVE=1
+    {% if printer["machine_state_manager"].main_state | string == "PRINTING" %}
+        SET_MAIN_STATE MAIN_STATE=IDLE
+        SET_PRINT_PREFERENCES BED_LEVEL=1
+        SET_MAIN_STATE MAIN_STATE=PRINTING
+        _BED_LEVELING_FORCE_VALIDATE
+    {% endif %}
+    {% if params.ADAPTIVE is defined %}
+        _BED_MESH_CALIBRATE_BASE {rawparams}
+    {% else %}
+        _BED_MESH_CALIBRATE_BASE {rawparams} ADAPTIVE=1
+    {% endif %}
 
 [gcode_macro _BED_LEVELING_FORCE_VALIDATE]
 gcode:
     {% set ptc = printer["print_task_config"] %}
     {% if ptc is not defined or not ptc.auto_bed_leveling %}
-        { action_raise_error("bed_leveling_force: AUTO_BED_LEVELING was not set — SET_MAIN_STATE workaround did not take effect") }
+        { action_raise_error("bed_leveling_force: AUTO_BED_LEVELING was not set") }
     {% endif %}

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
@@ -2,16 +2,17 @@
 rename_existing: _BED_MESH_CALIBRATE_BASE
 description: Force full bed mesh calibration
 gcode:
-    {% set prev_state = printer["machine_state_manager"].main_state %}
-    SET_MAIN_STATE MAIN_STATE=IDLE
-    SET_PRINT_PREFERENCES BED_LEVEL=1
-    SET_MAIN_STATE MAIN_STATE={prev_state}
-    _BED_LEVELING_FORCE_VALIDATE
+    {% if printer["machine_state_manager"].main_state | string == "PRINTING" %}
+        SET_MAIN_STATE MAIN_STATE=IDLE
+        SET_PRINT_PREFERENCES BED_LEVEL=1
+        SET_MAIN_STATE MAIN_STATE=PRINTING
+        _BED_LEVELING_FORCE_VALIDATE
+    {% endif %}
     _BED_MESH_CALIBRATE_BASE {rawparams}
 
 [gcode_macro _BED_LEVELING_FORCE_VALIDATE]
 gcode:
     {% set ptc = printer["print_task_config"] %}
     {% if ptc is not defined or not ptc.auto_bed_leveling %}
-        { action_raise_error("bed_leveling_force: AUTO_BED_LEVELING was not set — SET_MAIN_STATE workaround did not take effect") }
+        { action_raise_error("bed_leveling_force: AUTO_BED_LEVELING was not set") }
     {% endif %}

--- a/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
+++ b/overlays/firmware-extended/35-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
@@ -2,16 +2,17 @@
 rename_existing: _TIMELAPSE_START_BASE
 description: Force timelapse start regardless of print preferences
 gcode:
-    {% set prev_state = printer["machine_state_manager"].main_state %}
-    SET_MAIN_STATE MAIN_STATE=IDLE
-    SET_PRINT_PREFERENCES TIME_LAPSE_CAMERA=1
-    SET_MAIN_STATE MAIN_STATE={prev_state}
-    _TIMELAPSE_FORCE_VALIDATE
+    {% if printer["machine_state_manager"].main_state | string == "PRINTING" %}
+        SET_MAIN_STATE MAIN_STATE=IDLE
+        SET_PRINT_PREFERENCES TIME_LAPSE_CAMERA=1
+        SET_MAIN_STATE MAIN_STATE=PRINTING
+        _TIMELAPSE_FORCE_VALIDATE
+    {% endif %}
     _TIMELAPSE_START_BASE {rawparams}
 
 [gcode_macro _TIMELAPSE_FORCE_VALIDATE]
 gcode:
     {% set ptc = printer["print_task_config"] %}
     {% if ptc is not defined or not ptc.time_lapse_camera %}
-        { action_raise_error("timelapse_force: TIME_LAPSE_CAMERA was not set — SET_MAIN_STATE workaround did not take effect") }
+        { action_raise_error("timelapse_force: TIME_LAPSE_CAMERA was not set") }
     {% endif %}


### PR DESCRIPTION
`SET_PRINT_PREFERENCES` rejects `BED_LEVEL` and `TIME_LAPSE_CAMERA`
only when `main_state` is `PRINTING`. The overrides previously switched
to `IDLE` unconditionally; now the switch, preference set, restore, and
validate call are skipped entirely outside of a print.

`bed_leveling_adaptive_force.cfg` also skips injecting `ADAPTIVE=1`
when the caller already passes the `ADAPTIVE` parameter explicitly.