### PR TITLE
Use draft release instead of pre-release

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -67,7 +67,7 @@ jobs:
         tag: "v${{ env.GIT_VERSION }}"
         allowUpdates: false
         updateOnlyUnreleased: true
-        prerelease: true
+        draft: true
         bodyFile: RELEASE.md
         artifacts: "U1_*_upgrade.bin"
 


### PR DESCRIPTION
Switches `pre_release.yaml` from `prerelease: true` to `draft: true` so new releases are created as drafts rather than marked as pre-releases. [ci skip]