### PR TITLE
Enable `tigertag_tag_processor` by default in base config

### DIFF
--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -140,7 +140,7 @@ To enable it, navigate to the [firmware-config](firmware_config.md) web interfac
 | Snapmaker | Yes | - |
 | Elegoo | No | Elegoo spools tagged with RFID work unreliably |
 | [OpenSpool](https://openspool.io/) | Yes | - |
-| TigerTag | No | Fully offline implementation |
+| TigerTag | Yes | Fully offline implementation |
 | Qidi | Yes | - |
 
 ### Bambu / Creality Spool Configuration
@@ -174,12 +174,10 @@ Some tag formats are disabled by default, for example as they do not read reliab
 /oem/printer_data/config/extended/openrfid_user.cfg
 ```
 
-Enable them by removing the `#` prefix from the tag processor. 
+Enable them by removing the `#` prefix from the tag processor.
 
 ```
 # [elegoo_tag_processor]
-
-# [tigertag_tag_processor]
 ```
 
 ## Troubleshooting

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
@@ -70,6 +70,8 @@ gpio_pins_low = upper_rfid_coils_enable_pin
 # From https://github.com/Snapmaker/u1-klipper/blob/318c47e02e5809deaef20a1c97051101b1b948e1/klippy/extras/fm175xx_reader.py#L138
 key = 536e61706d616b65725f71776572747975696f705b2c2e3b5d5f317132773365
 
+[tigertag_tag_processor]
+
 [webhook_exporter parse_error_exporter]
 method = POST
 event = tag_parse_error

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
@@ -13,6 +13,3 @@
 # Elegoo spools are disabled by default. They are not detected reliably on Snapmaker U1
 # due to tag placement. Uncomment to enable.
 #[elegoo_tag_processor]
-
-# Tigertag is disabled by default. Uncomment to enable.
-#[tigertag_tag_processor]


### PR DESCRIPTION
Moves `[tigertag_tag_processor]` from opt-in comment in `openrfid_user.cfg` to always-present section in `openrfid_u1_base.cfg`, enabling tigertag processing out of the box without requiring manual user configuration.