### PR TITLE
Add Panda Breath chamber heater documentation

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -288,3 +288,4 @@ If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
 - [Klipper Print Hooks](klipper_hooks.md) - React to print lifecycle events via hook macros
 - [Data Persistence](data_persistence.md) - Understanding persistent storage
 - [VPN Remote Access](vpn.md) - Secure remote access via Tailscale
+- [Panda Breath Chamber Heater](panda_breath.md) - BIQU Panda Breath integration with Klipper

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ Heavily expanded firmware with extensive features and customization:
 - [Klipper Print Hooks](klipper_hooks.md) - React to `PRINT_START`, `PRINT_END`, and `CANCEL_PRINT` without modifying stock macros
 - [Klipper Tweaks](tweaks.md) - Experimental [TMC driver optimizations](tweaks.md#tmc-autotune), [reduced current](tweaks.md#tmc-reduced-current), and [object processing for adaptive mesh](tweaks.md#object-processing-for-adaptive-mesh)
 - [AFC-Lite Stub](afc-lite.md) - Experimental AFC UI compatibility layer for Fluidd/Mainsail
+- [Panda Breath Chamber Heater](panda_breath.md) - BIQU Panda Breath 300 W chamber heater and air filter integration via Klipper `heater_generic`
 - [Faulty Toolhead Bypass](faulty_toolhead.md) - Temporary bypass for one failed toolhead thermistor so the other toolheads can still be used
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
 - [Alternative Filament Detection](rfid_support.md#alternative-detection-systems) - Alternative detection implementations with extended spool/tag support from Bambu, Creality, Anycubic, and others

--- a/docs/panda_breath.md
+++ b/docs/panda_breath.md
@@ -1,0 +1,111 @@
+---
+title: Panda Breath Chamber Heater
+---
+
+# Panda Breath Chamber Heater
+
+Integrates the [BIQU Panda Breath](https://biqu.equipment/products/biqu-panda-breath-smart-air-filtration-and-heating-system-with-precise-temperature-regulation) smart chamber heater and air filter with Klipper on the Snapmaker U1.
+
+The Panda Breath is a 300 W PTC chamber heater with HEPA/carbon air filtration and WiFi control. This firmware reverse-engineers its WebSocket API and exposes the device as a standard Klipper `heater_generic`, so slicer chamber temperature commands (`M141`/`M191`) work out of the box.
+
+## Risks and Warranty
+
+### Warranty
+
+Installing and operating the Panda Breath significantly raises sustained operating temperatures inside the enclosure. This accelerates wear on electronics, motors, and other components beyond their rated conditions. Any damage attributable to elevated thermal stress is unlikely to be covered under warranty. **Use at your own risk.**
+
+### Motherboard Overheating
+
+The U1 motherboard has insufficient thermal headroom for sustained elevated chamber temperatures. There are documented cases of motherboard overheating causing mid-print failures. The RK3562 main processor begins thermal throttling at 85 °C, degrading Klipper real-time performance and causing motion or communication errors.
+
+**Additional active cooling on the motherboard is required before using Panda Breath.**
+
+Printable cooling solutions available on MakerWorld:
+
+- [Snapmaker U1 MCU Mainboard Cooler Fan Holder](https://makerworld.com/pl/models/2396929-snapmaker-u1-mcu-mainboard-cooler-fanholder) — covers the full motherboard including the RK3562 main processor (**recommended**).
+- [Cooling of drivers on Snapmaker U1 (6015)](https://makerworld.com/pl/models/2464667-cooling-of-drivers-on-snapmaker-u1-6015) — cools the stepper drivers only; does **not** cover the RK3562 main processor and is not sufficient on its own.
+
+See also: [Quick overview on fan mods applied for Snapmaker U1](https://www.reddit.com/r/SnapmakerU1/comments/1tlk27r/quick_overview_on_fan_mods_applied_for_snapmaker/) — community thread covering additional fan mod approaches (to be evaluated).
+
+## Prerequisites
+
+1. **Install motherboard cooling** — see [Risks and Warranty](#risks-and-warranty) above.
+2. Panda Breath device running firmware **v1.0.3** or later (required for auto mode).
+3. **Static DHCP leases** for both the printer and the Panda Breath device on your router. The printer IP is embedded into the Panda Breath device during setup and must not change on reboot. Klipper connects to the Panda Breath by IP address on every print.
+4. Power-cycle the Panda Breath and wait at least 5 seconds before enabling.
+
+## Enabling
+
+Enable via the Firmware Config web interface at `http://<printer-ip>/firmware-config/` under **Tweaks > Panda Breath Chamber Heater**.
+
+Two modes are available:
+
+| Mode | Description |
+|------|-------------|
+| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Requires firmware v1.0.3+. |
+| **Manual** (advanced) | Pure `heater_generic` control throughout. Legacy fallback; less safe if the device or network is lost during a print. |
+
+During setup the web interface will ask for the Panda Breath IP address and will automatically bind the device to the printer.
+
+## Configuration File
+
+After enabling, a config file is placed at:
+
+```
+/home/lava/printer_data/config/extended/klipper/panda_breath.cfg
+```
+
+To change the IP address or port, edit that file directly in Fluidd/Mainsail or via SSH:
+
+```ini
+[panda_breath]
+host: 192.168.1.100
+port: 80
+```
+
+Restart Klipper after saving.
+
+## Usage
+
+Once enabled, the Panda Breath appears as a chamber heater in Fluidd/Mainsail. Use standard G-code commands to control it:
+
+| Command | Effect |
+|---------|--------|
+| `M141 S45` | Set chamber target to 45 °C |
+| `M191 S45` | Set chamber target to 45 °C and wait until reached |
+| `M141 S0` | Turn off chamber heating |
+
+In your slicer, set the chamber temperature for the filament profile as usual — `M141`/`M191` commands in start G-code are handled automatically.
+
+### Native Commands
+
+Additional commands are available for direct device control:
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `PANDA_BREATH_AUTO` | `ENABLE=1/0 TARGET=<°C>` | Enable/disable Panda native auto mode |
+| `PANDA_BREATH_DRY_RUN` | `TARGET=<°C> DURATION=<min>` | Start native filament drying cycle |
+| `PANDA_BREATH_DRY_STOP` | — | Stop active drying cycle |
+
+## Disabling
+
+Disable via **Firmware Config > Tweaks > Panda Breath Chamber Heater > Disabled**. The device is automatically unbound from the printer and the configuration file is removed.
+
+## Troubleshooting
+
+**Klipper shows heater error / verify_heater failure**
+
+The Panda Breath is a slow external heater with coarse 1 °C temperature reporting. The default `verify_heater` configuration uses extended gain check and error windows to avoid false positives. If errors still occur, check WiFi connectivity between the printer and the Panda Breath device.
+
+**Device not reachable at `PandaBreath.local`**
+
+mDNS resolution can be unreliable. Set a static DHCP lease and use the IP address directly in `panda_breath.cfg`.
+
+**Print fails or printer reboots during long high-temperature prints**
+
+This is a symptom of motherboard overheating. See [Motherboard Overheating](#motherboard-overheating) for cooling solutions.
+
+## Related Documentation
+
+- [Firmware Configuration](firmware_config.md) - Enable Panda Breath via the web interface under Snapmaker Components
+- [Klipper and Moonraker Custom Includes](klipper_includes.md) - Further customise the generated `panda_breath.cfg`

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -3,8 +3,8 @@ settings:
     items:
       panda_breath:
         label: Panda Breath Chamber Heater
-        description: Choose how Panda Breath chamber heating is integrated. Auto uses Panda native auto mode after heat-up and requires Panda firmware v1.0.3. Manual keeps the older pure heater_generic fallback.
-        help_url: https://github.com/justinh-rahb/pandabreath-klipper
+        description: BIQU Panda Breath chamber heater and air filter integration.
+        help_url: https://snapmakeru1-extended-firmware.pages.dev/panda_breath
         get_cmd:
           - bash
           - -c
@@ -41,16 +41,23 @@ settings:
           auto:
             label: Auto (Recommended)
             confirm: |
+              WARNING: Panda Breath significantly raises sustained enclosure temperatures, accelerating wear on electronics, motors, and other components beyond their rated conditions. Any damage attributable to elevated thermal stress is unlikely to be covered under warranty. Additional motherboard cooling is required before use — see the documentation for details.
+
               Before enabling Panda Breath auto mode, complete all of the following steps:
 
-              1. Ensure the Panda Breath device is running firmware v1.0.3 — this is required for auto mode.
-              2. Configure a static DHCP lease for this printer on your router — the printer IP is embedded into the Panda Breath device and must not change after a reboot.
-              3. Configure a static DHCP lease for the Panda Breath device on your router — Klipper will connect to it by IP address on every print.
-              4. Power-cycle the Panda Breath device and wait at least 5 seconds before proceeding.
-              5. Enter the Panda Breath IP address in the field below.
+              1. Install additional active cooling on the motherboard (see documentation).
+              2. Ensure the Panda Breath device is running firmware v1.0.3.
+              3. Configure a static DHCP lease for this printer on your router — the printer IP is embedded into the Panda Breath device and must not change after a reboot.
+              4. Configure a static DHCP lease for the Panda Breath device on your router — Klipper will connect to it by IP address on every print.
+              5. Power-cycle the Panda Breath device and wait at least 5 seconds before proceeding.
+              6. Enter the Panda Breath IP address in the field below.
 
               Auto mode heats the chamber with Klipper first, then hands off hold and cool-down behaviour to Panda native auto mode.
             inputs:
+              - name: ACKNOWLEDGED
+                label: "Type \"I UNDERSTAND\" to confirm you have read the documentation and accept the warranty and longevity risks"
+                placeholder: "I UNDERSTAND"
+                regex: '^I UNDERSTAND$'
               - name: PANDA_BREATH_IP
                 label: Panda Breath IP Address
                 placeholder: "192.168.1.100"
@@ -83,16 +90,23 @@ settings:
             label: Manual (Advanced)
             hidden: true
             confirm: |
+              WARNING: Panda Breath significantly raises sustained enclosure temperatures, accelerating wear on electronics, motors, and other components beyond their rated conditions. Any damage attributable to elevated thermal stress is unlikely to be covered under warranty. Additional motherboard cooling is required before use — see the documentation for details.
+
               Before enabling Panda Breath manual mode, complete all of the following steps:
 
-              1. Ensure the Panda Breath device is running firmware v1.0.3 — this is the required firmware version.
-              2. Configure a static DHCP lease for this printer on your router — the printer IP is embedded into the Panda Breath device and must not change after a reboot.
-              3. Configure a static DHCP lease for the Panda Breath device on your router — Klipper will connect to it by IP address on every print.
-              4. Power-cycle the Panda Breath device and wait at least 5 seconds before proceeding.
-              5. Enter the Panda Breath IP address in the field below.
+              1. Install additional active cooling on the motherboard (see documentation).
+              2. Ensure the Panda Breath device is running firmware v1.0.3.
+              3. Configure a static DHCP lease for this printer on your router — the printer IP is embedded into the Panda Breath device and must not change after a reboot.
+              4. Configure a static DHCP lease for the Panda Breath device on your router — Klipper will connect to it by IP address on every print.
+              5. Power-cycle the Panda Breath device and wait at least 5 seconds before proceeding.
+              6. Enter the Panda Breath IP address in the field below.
 
               Manual mode is a legacy fallback that may be less safe if the device or network connectivity is lost during a print.
             inputs:
+              - name: ACKNOWLEDGED
+                label: "Type \"I UNDERSTAND\" to confirm you have read the documentation and accept the warranty and longevity risks"
+                placeholder: "I UNDERSTAND"
+                regex: '^I UNDERSTAND$'
               - name: PANDA_BREATH_IP
                 label: Panda Breath IP Address
                 placeholder: "192.168.1.100"


### PR DESCRIPTION
- Adds `docs/panda_breath.md` covering the BIQU Panda Breath integration: setup prerequisites, enabling via Firmware Config (auto vs manual mode), configuration file location, G-code usage, and troubleshooting.
- Includes a dedicated Risks and Warranty section warning about insufficient motherboard thermal headroom, RK3562 throttling at 85°C, documented overheating failures, and warranty implications. Links two MakerWorld cooling solutions and a community fan mod thread.
- Enabling requires explicit user acknowledgement.
