### PR TITLE
camera: make internal MIPI capture FPS configurable

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -15,6 +15,9 @@ internal: paxx12
 usb: none
 # Enable RTSP streaming server: true, false
 rtsp: false
+# Internal (Case) camera capture frame rate: 30 (60 Hz mains), 25 (50 Hz mains)
+# Lower to 25 if the stream flickers/pulses in 50 Hz regions (UK/EU/most of Asia).
+fps: 30
 
 [components]
 rfid: external, snapmaker, openrfid, openrfid-generic

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
@@ -10,8 +10,11 @@ if [ "$CAMERA_LOGS" = "syslog" ]; then
     CMD_FAKE_SERVICE_ARGS="$CMD_FAKE_SERVICE_ARGS --syslog"
 fi
 RTSP_ENABLED=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera rtsp false)
+# Capture frame rate. Configurable to avoid flicker from the capture rate
+# beating against mains/LED frequency: 30 for 60 Hz regions, 25 for 50 Hz.
+CAMERA_FPS=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera fps 30)
 
-CMD_CAPTURE="/usr/local/bin/capture-v4l2-raw-mpp --device /dev/video11 --format nv12 --jpeg-quality 7 --jpeg-sock /tmp/capture-mipi-jpeg.sock --mjpeg-sock /tmp/capture-mipi-mjpeg.sock --h264-sock /tmp/capture-mipi-h264.sock --raw-frame-sock /tmp/capture-mipi-raw.sock --width 1920 --height 1080 --fps 30"
+CMD_CAPTURE="/usr/local/bin/capture-v4l2-raw-mpp --device /dev/video11 --format nv12 --jpeg-quality 7 --jpeg-sock /tmp/capture-mipi-jpeg.sock --mjpeg-sock /tmp/capture-mipi-mjpeg.sock --h264-sock /tmp/capture-mipi-h264.sock --raw-frame-sock /tmp/capture-mipi-raw.sock --width 1920 --height 1080 --fps ${CAMERA_FPS}"
 
 CMD_WEBRTC="/usr/local/bin/stream-webrtc --h264-sock /tmp/capture-mipi-h264.sock --webrtc-sock /tmp/capture-mipi-webrtc.sock"
 

--- a/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
+++ b/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
@@ -124,3 +124,37 @@ settings:
                 /etc/init.d/S99v4l2-mpp-mipi restart &&
                 /etc/init.d/S99v4l2-mpp-usb restart
         default: "false"
+
+      camera-fps:
+        label: Capture Frame Rate (paxx12 only)
+        description: >-
+          Frame rate for the internal MIPI camera. If the live view flickers or
+          pulses, the capture rate is likely beating against your mains/LED
+          frequency. Pick the rate that divides your mains frequency evenly:
+          30 fps for 60 Hz regions (e.g. North America), 25 fps for 50 Hz
+          regions (e.g. UK/EU/most of Asia).
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /home/lava/printer_data/config/extended/extended2.cfg
+          - camera
+          - fps
+          - "30"
+        options:
+          "30":
+            label: 30 fps (60 Hz mains)
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera fps 30 &&
+                /etc/init.d/S99v4l2-mpp-mipi restart
+          "25":
+            label: 25 fps (50 Hz mains)
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera fps 25 &&
+                /etc/init.d/S99v4l2-mpp-mipi restart
+        default: "30"


### PR DESCRIPTION
The internal MIPI camera capture rate is hardcoded to 30 fps, which beats against 50 Hz mains/LED PWM and produces the visible stream flicker/pulsing reported in #437 (30 fps divides 60 Hz cleanly, but not 50 Hz).

Make the capture rate configurable via a new `camera fps` key, read from extended2.cfg with a default of 30 so existing behaviour is unchanged, and expose a "Capture Frame Rate" selector in firmware-config - Camera offering 30 fps (60 Hz mains) / 25 fps (50 Hz mains). 25 fps divides 50 Hz evenly and removes the flicker for UK/EU/50 Hz users.

- S99v4l2-mpp-mipi: source `camera fps` (default 30) into the capture -fps
- 15_settings_camera.yaml: add camera-fps dropdown; restarts the mipi service
- extended2.cfg seed: document the new key

The USB camera path is unaffected (capture-v4l2-jpeg-mpp sets no -fps).

Closes #437