### PR TITLE
Add automatic spool detection and Spoolman/SpoolLink integration

### DIFF
--- a/docs/afc-lite.md
+++ b/docs/afc-lite.md
@@ -76,3 +76,7 @@ rm /oem/printer_data/config/extended/klipper/afc.cfg
 
 ![AFC Tools Remapping](images/afc_tools.gif)
 
+## See Also
+
+- [Spoolman Integration](spoolman.md) — automatic spool lookup, card UID binding, and active spool tracking via the SpoolLink component
+

--- a/docs/design/spoolman.md
+++ b/docs/design/spoolman.md
@@ -1,0 +1,169 @@
+---
+title: Spoolman Integration Design
+---
+
+# Spoolman Integration Design
+
+# Spoolman Custom Fields
+
+| Entity | Key | Purpose |
+|--------|-----|---------|
+| `spool` | `card_uids` | Comma-separated uppercase hex NFC UIDs associated with the spool |
+| `filament` | `variant` | Filament subtype / variant (e.g. "Silk", "Matte") |
+
+Both fields use Spoolman's double-serialised string convention: the inner value is
+JSON-encoded before storage, so a single UID `"AABBCCDD"` is stored as `"\"AABBCCDD\""`.
+`spoollink` decodes these on read and re-encodes on write.
+
+## `card_uids` Custom Field
+
+NFC tag UIDs are stored in a Spoolman custom field named `card_uids` on the spool entity.
+
+### Field definition (created on first connection test)
+
+```json
+{
+  "key": "card_uids",
+  "name": "Card UIDs",
+  "entity_type": "spool",
+  "field_type": "text",
+  "order": 1,
+  "default_value": "\"\""
+}
+```
+
+### Wire format
+
+The `extra.card_uids` value is a **JSON-encoded string** — the string value itself is
+wrapped in JSON quotes by the client before sending, so it arrives as a JSON string
+containing another JSON string:
+
+```
+extra.card_uids = "\"AABBCCDD,11223344\""
+```
+
+When decoded, the inner string is a comma-separated list of uppercase hex UIDs:
+
+```
+AABBCCDD,11223344
+```
+
+### Encoding rule
+
+Before writing, the comma-separated UID string must be JSON-encoded:
+
+```
+jsonEncode("AABBCCDD,11223344") → "\"AABBCCDD,11223344\""
+```
+
+### Decoding rule
+
+On read, strip the outer JSON quotes if present; handle both encoded and raw forms:
+
+```
+raw = "\"AABBCCDD,11223344\""
+decoded = AABBCCDD,11223344
+uids = ["AABBCCDD", "11223344"]
+```
+
+### PATCH body for `card_uids`
+
+```json
+{
+  "extra": {
+    "card_uids": "\"AABBCCDD,11223344\""
+  }
+}
+```
+
+---
+
+## UID Format
+
+NFC tag UIDs are formatted as **uppercase hex with no separators**:
+
+```
+AABBCCDD        (4-byte UID)
+04A1B2C3D4E5F6  (7-byte UID)
+```
+
+---
+
+## Sync Logic ("Add to current, remove from others")
+
+When an NFC tag is scanned or assigned to a spool:
+
+1. **Fetch** the target spool via `GET api/v1/spool/{id}`.
+2. **Append** the tag UID to `extra.card_uids` if not already present.
+3. **Write** the updated UID list via `PATCH api/v1/spool/{id}`.
+4. **Search** for other spools that contain the same UID by fetching all spools
+   (`limit=1000&allow_archived=true`) and filtering client-side on `card_uids`.
+5. **Remove** the UID from each other spool's `card_uids` and write back via `PATCH`.
+
+---
+
+## `variant` Custom Field (Filament)
+
+The filament variant (e.g. "Silk", "Matte") is stored in a Spoolman custom field named
+`variant` on the filament entity.
+
+### Field definition (created on first connection test)
+
+```json
+{
+  "key": "variant",
+  "name": "Variant",
+  "entity_type": "filament",
+  "field_type": "text",
+  "order": 1,
+  "default_value": "\"\""
+}
+```
+
+The value follows the same JSON-encoded string convention as `card_uids`:
+
+```
+extra.variant = "\"Silk\""
+```
+
+### Create Filament body with variant
+
+```json
+{
+  "name": "Galaxy Black Silk",
+  "material": "PLA",
+  "extra": {
+    "variant": "\"Silk\""
+  }
+}
+```
+
+# `spoollink` Component Flow
+
+`spoollink` is a Moonraker component (`moonraker/components/spoollink.py`), loaded when a
+`[spoollink]` section is present in the Moonraker config. It runs in Moonraker's event loop
+and uses the built-in `http_client`, `klippy_apis`, and `spoolman` components directly, so
+it does not maintain its own WebSocket connection.
+
+1. On construction, `spoollink` calls `server.register_remote_method("spoollink_resolve_spool", ...)`;
+   Moonraker re-registers it with Klipper on every Klippy `ready`, so the binding survives
+   Klipper restarts.
+2. On startup (`component_init`), `spoollink` calls `GET api/v1/field/spool` and
+   `GET api/v1/field/filament` to verify the `card_uids` and `variant` custom fields exist,
+   creating them via `POST api/v1/field/{entity}/{key}` if missing.
+3. Klipper (or AFC) calls `spoollink_resolve_spool` with `channel`, `spool_id`, and/or `card_uid`.
+4. `spoollink` resolves the spool from Spoolman:
+   - By ID: `GET api/v1/spool/{id}`
+   - By card UID: `GET api/v1/spool?limit=1000`, then filter client-side
+     on `extra.card_uids` (comma-separated, JSON-encoded uppercase hex UIDs).
+5. If both `spool_id` and `card_uid` are given and the card is not yet in the spool's
+   `card_uids`, `spoollink` appends it via `PATCH api/v1/spool/{id}` with
+   `{"extra": {"card_uids": "\"UID1,UID2\""}}` (JSON-encoded string, as required by
+   Spoolman's custom field API). Any other spool that already carries the same UID has it
+   removed via a subsequent `PATCH` — a UID can only belong to one spool at a time.
+6. On success, `spoollink` pushes the resolved filament info into Klipper by calling the
+   `spoollink/set` endpoint (registered by the Klipper `[spoollink]` router), which merges
+   it onto `filament_protocol.FILAMENT_INFO_STRUCT` and applies it to `print_task_config`.
+7. Klipper stores the metadata in `print_task_config` and notifies subscribers.
+   `AFC_lane.get_status()` surfaces `spool_id` to Fluidd/Mainsail.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Heavily expanded firmware with extensive features and customization:
 - [Faulty Toolhead Bypass](faulty_toolhead.md) - Temporary bypass for one failed toolhead thermistor so the other toolheads can still be used
 - [RFID Filament Tag Support](rfid_support.md) - NTAG213/215/216 support for OpenSpool format
 - [Alternative Filament Detection](rfid_support.md#alternative-detection-systems) - Alternative detection implementations with extended spool/tag support from Bambu, Creality, Anycubic, and others
+- [Spoolman Integration](spoolman.md) - Automatic filament metadata sync and spool tracking via Spoolman, resolving spools by ID or RFID card UID
 
 **Monitoring & Notifications:**
 

--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -1,0 +1,50 @@
+---
+title: Spoolman Integration
+---
+
+# Spoolman Integration
+
+Automatic filament metadata sync and spool tracking via
+[Spoolman](https://github.com/Donkie/Spoolman).
+
+## What It Provides
+
+- Resolves a Spoolman spool by ID or RFID card UID and applies its
+  metadata (vendor, material, variant, colour) to the extruder channel.
+- Associates RFID card UIDs with spools automatically, so scanning a
+  known card loads its filament without any manual step.
+- Tracks the active spool in Moonraker so Spoolman can update remaining
+  filament weight as you print.
+
+## Enabling
+
+Enable via Fluidd/Mainsail settings under
+**Snapmaker Components > Spoolman Integration**, set the Spoolman host,
+and reboot. Set the same toggle to **Disabled** to turn it off.
+
+## GCode Commands
+
+### `SET_SPOOL_ID`
+
+Assign a Spoolman spool to an AFC lane. Reads the lane's RFID card UID,
+binds it to the spool (so a later scan resolves automatically), and
+applies the filament metadata to the channel:
+
+```
+SET_SPOOL_ID LANE=E0 SPOOL_ID=5
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `LANE` | — | AFC lane name (e.g. `E0`) |
+| `SPOOL_ID` | `0` | Spoolman spool ID; `0` clears the assignment |
+
+## Limitations
+
+- Spoolman must be reachable from the printer over HTTP.
+- Variant defaults to `Basic` for Snapmaker-branded filaments when not
+  set in Spoolman; empty for all other vendors.
+
+For the wire format, custom fields, and component flow see the
+[design notes](design/spoolman.md). For AFC lane status that surfaces
+`spool_id` see [AFC-Lite](afc-lite.md).

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -37,3 +37,7 @@ cloud: none
 [monitoring]
 # Enable Klipper Prometheus exporter on specified address
 # klipper_exporter: :9101
+
+# Spoolman server URL for filament tracking; managed via firmware-config.
+# Example: host: http://192.168.1.100:7912
+[spoolman]

--- a/overlays/firmware-extended/13-patch-rfid/patches/06-add-spool-id-support.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/06-add-spool-id-support.patch
@@ -1,0 +1,59 @@
+--- a/home/lava/klipper/klippy/extras/print_task_config.py
++++ b/home/lava/klipper/klippy/extras/print_task_config.py
+@@ -24,6 +24,7 @@
+     'filament_edit': [True] * PHYSICAL_EXTRUDER_NUM,
+     'filament_exist': [False] * PHYSICAL_EXTRUDER_NUM,
+     'filament_soft': [False] * PHYSICAL_EXTRUDER_NUM,
++    'filament_spool_id': [0] * PHYSICAL_EXTRUDER_NUM,
+     'extruder_map_table': [i for i in range(PHYSICAL_EXTRUDER_NUM)] + [0] * (LOGICAL_EXTRUDER_NUM - PHYSICAL_EXTRUDER_NUM),
+     'extruders_used' : [False] * PHYSICAL_EXTRUDER_NUM,
+     'extruders_replenished': [i for i in range(PHYSICAL_EXTRUDER_NUM)],
+@@ -181,6 +182,7 @@
+
+             tmp_print_task_config['filament_official'][channel] = info['OFFICIAL']
+             tmp_print_task_config['filament_sku'][channel] = info['SKU']
++            tmp_print_task_config['filament_spool_id'][channel] = info.get('SPOOL_ID', 0)
+             if self.filament_param_obj is not None:
+                 tmp_print_task_config['filament_soft'][channel] = \
+                     self.filament_param_obj.get_is_soft(info['VENDOR'], info['MAIN_TYPE'], info['SUB_TYPE'])
+@@ -282,7 +284,10 @@
+             allowed_edit = False
+             if self.print_task_config['filament_exist'][ch]:
+                 if self.print_task_config['filament_official'][ch] == False:
+-                    allowed_edit = True
++                    if (self.print_task_config['filament_spool_id'][ch] or 0) > 0 and self.printer.lookup_object('webhooks').has_remote_method('spoolman_set_active_spool'):
++                        allowed_edit = False
++                    else:
++                        allowed_edit = True
+
+             tmp_filament_edit[ch] = allowed_edit
+         if tmp_filament_edit != self.print_task_config['filament_edit']:
+@@ -343,6 +347,7 @@
+         filament_soft = gcmd.get_int('SOFT', None)
+         filament_color = gcmd.get_int('FILAMENT_COLOR', None)
+         filament_color_rgba = gcmd.get('FILAMENT_COLOR_RGBA', None)
++        filament_spool_id = gcmd.get_int('FILAMENT_SPOOL_ID', None)
+         filament_alpha = gcmd.get_int('ALPHA', None, minval=0, maxval=255)
+         filament_color_nums = gcmd.get_int('COLOR_NUMS', None, minval=1, maxval=FILAMENT_COLOR_NUMS_MAX)
+         filament_colors_str = gcmd.get('COLORS', None)
+@@ -359,6 +365,8 @@
+
+             if tmp_print_task_config['filament_official'][config_extruder] and bool(force) == False:
+                 raise gcmd.error("[print_task_config] filament_config, official filament, not configurable!")
++            if (tmp_print_task_config['filament_spool_id'][config_extruder] or 0) > 0 and not force and filament_spool_id == None and self.printer.lookup_object('webhooks').has_remote_method('spoolman_set_active_spool'):
++                raise gcmd.error("[print_task_config] filament_spool_id, is configured, use FORCE=1 to overwrite")
+
+             # alpha
+             if filament_alpha == None:
+@@ -403,9 +411,11 @@
+
+             tmp_print_task_config['filament_official'][config_extruder] = False
+             tmp_print_task_config['filament_sku'][config_extruder] = 0
++            tmp_print_task_config['filament_spool_id'][config_extruder] = filament_spool_id or 0
+
+             self.print_task_config = tmp_print_task_config
+             self.backup_filament_info(config_extruder)
++            self.update_filament_edit_flag()
+
+             if not self.printer.update_snapmaker_config_file(self.config_path,
+                     self.print_task_config, DEFAULT_PRINT_TASK_CONFIG):

--- a/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC.py
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC.py
@@ -10,6 +10,7 @@ class AFC:
         self.printer = config.get_printer()
         config.get("enabled", "True")
         self.gcode = self.printer.lookup_object("gcode")
+        self.webhooks = self.printer.lookup_object('webhooks')
 
         self.units = {}
         self.lanes = {}
@@ -44,7 +45,7 @@ class AFC:
         str['current_state'] = AFCState.IDLE
         str["current_toolchange"] = 0
         str["number_of_toolchanges"] = 0
-        str['spoolman'] = True
+        str['spoolman'] = self.webhooks.has_remote_method('spoolman_set_active_spool')
         str["td1_present"] = False
         str["lane_data_enabled"] = False
         str['error_state'] = False

--- a/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -1,6 +1,4 @@
-import json
 import logging
-import os
 
 class AFCLaneState:
     EMPTY = "empty"
@@ -69,6 +67,7 @@ class AFCLane:
             state['type'] = dict(enumerate(status.get('filament_type', []))).get(self.lane_index, 'NONE')
             state['subtype'] = dict(enumerate(status.get('filament_sub_type', []))).get(self.lane_index, 'NONE')
             state['color'] = dict(enumerate(status.get('filament_color_rgba', []))).get(self.lane_index, 'FFFFFFFF')
+            state['spool_id'] = dict(enumerate(status.get('filament_spool_id', []))).get(self.lane_index, 0)
             if status.get('auto_replenish_filament', False):
                 state['runout_lane'] = 'AUTO'
 
@@ -104,9 +103,16 @@ class AFCLane:
         response['tool_loaded'] = state.get('tool_loaded', response['load'])
         response['loaded_to_hub'] = False
         response['material'] = state.get('type', 'NONE')
-        response['spool_id'] = None
+        filament_name = ' '.join(
+            p for p in (state.get('vendor', 'NONE'),
+                        state.get('type', 'NONE'),
+                        state.get('subtype', 'NONE'))
+            if p and p != 'NONE')
+        if filament_name:
+            response['filament_name'] = filament_name
+        response['spool_id'] = state.get('spool_id', 0)
         response['color'] = f"#{state.get('color', 'FFFFFFFF')[:6]}" # RGB only, ignore alpha
-        response['weight'] = 1000 # AFC doesn't track weight
+        # weight intentionally omitted; AFC doesn't track it and the UI hides it when absent
         response['runout_lane'] = state.get('runout_lane', '?')
         response['filament_status'] = 'unknown'
         response['filament_status_led'] = 'gray'

--- a/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -54,6 +54,10 @@ gcode:
     {% set index = printer['AFC_lane ' + lane].lane %}
     SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER='{index}' VENDOR='{vendor}'
 
+[gcode_macro SET_WEIGHT]
+gcode:
+    { action_raise_error("SET_WEIGHT is not supported.") }
+
 [gcode_macro SET_MAP]
 gcode:
     {% set lane = params.LANE|default('E0') %}
@@ -73,11 +77,23 @@ gcode:
 
 [gcode_macro SET_SPOOL_ID]
 gcode:
-    { action_raise_error("SET_SPOOL_ID is not supported.") }
-
-[gcode_macro SET_WEIGHT]
-gcode:
-    { action_raise_error("SET_WEIGHT is not supported.") }
+    {% set lane     = params.LANE %}
+    {% set channel  = printer['AFC_lane ' + lane].lane %}
+    {% set spool_id = params.SPOOL_ID|default(0)|int %}
+    {% if spool_id == 0 %}
+        SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER={channel} FILAMENT_SPOOL_ID=0 FORCE=1
+    {% else %}
+        {% set uid_raw = printer.filament_detect.info[channel].CARD_UID %}
+        {% if uid_raw is iterable and uid_raw is not string %}
+            {% set ns = namespace(uid='') %}
+            {% for b in uid_raw %}{% set ns.uid = ns.uid ~ ('%02X' % b) %}{% endfor %}
+            {% set card_uid = ns.uid %}
+        {% else %}
+            {% set card_uid = '' %}
+        {% endif %}
+        { action_call_remote_method("spoollink_resolve_spool",
+            channel=channel, spool_id=spool_id, card_uid=card_uid) }
+    {% endif %}
 
 [gcode_macro CHANGE_TOOL]
 description: Change tool/lane with automatic load/unload
@@ -105,3 +121,4 @@ gcode:
     M118 Unloading {lane} (lane {index})...
     AUTO_FEEDING EXTRUDER={index} UNLOAD=1
     M118 Unload {lane} complete
+

--- a/overlays/firmware-extended/31-feature-afc-lite/test/spoolman.sh
+++ b/overlays/firmware-extended/31-feature-afc-lite/test/spoolman.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <url> <method> <path> [key=value ...]"
+    echo ""
+    echo "Arguments:"
+    echo "  url     Spoolman base URL (e.g., http://localhost:7912)"
+    echo "  method  HTTP method: GET, POST, PATCH"
+    echo "  path    API path (e.g., spool/1)"
+    echo "  args    Key=value pairs (query params for GET, JSON for POST/PATCH)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 http://localhost:7912 GET spool/1"
+    echo "  $0 http://localhost:7912 POST spool filament_id=1 remaining_weight=800"
+    echo "  $0 http://localhost:7912 PATCH spool/1 remaining_weight=750"
+    exit 1
+}
+
+build_query() {
+    local query=""
+    for arg in "$@"; do
+        key="${arg%%=*}"
+        value="${arg#*=}"
+        value=$(printf '%s' "$value" | jq -sRr @uri)
+        if [[ -z "$query" ]]; then
+            query="?${key}=${value}"
+        else
+            query="${query}&${key}=${value}"
+        fi
+    done
+    echo "$query"
+}
+
+build_json() {
+    local json="{}"
+    for arg in "$@"; do
+        key="${arg%%=*}"
+        value="${arg#*=}"
+        if [[ "$value" =~ ^[0-9]+$ ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" == "true" || "$value" == "false" ]]; then
+            json=$(echo "$json" | jq --arg k "$key" --argjson v "$value" '. + {($k): $v}')
+        elif [[ "$value" == "null" ]]; then
+            json=$(echo "$json" | jq --arg k "$key" '. + {($k): null}')
+        else
+            json=$(echo "$json" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}')
+        fi
+    done
+    echo "$json"
+}
+
+if [[ $# -lt 3 ]]; then
+    usage
+fi
+
+url="$1"
+method="$2"
+path="$3"
+shift 3
+
+endpoint="${url}/api/v1/${path}"
+
+case "${method^^}" in
+    GET)
+        query=$(build_query "$@")
+        echo ">> GET ${endpoint}${query}"
+        curl -s -X GET "${endpoint}${query}" | jq
+        ;;
+    POST|PATCH)
+        json=$(build_json "$@")
+        echo ">> ${method^^} $endpoint"
+        curl -s -X "${method^^}" -H "Content-Type: application/json" -d "$json" "$endpoint" | jq
+        ;;
+    *)
+        echo "Error: Unsupported method '$method'. Use GET, POST, or PATCH."
+        exit 1
+        ;;
+esac

--- a/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/klipper.d/10-spoollink.sh
+++ b/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/klipper.d/10-spoollink.sh
@@ -1,0 +1,21 @@
+# Reconcile the Klipper `[spoollink]` include with the Spoolman configuration.
+#
+# `[spoolman] host` in `extended2.cfg` is the single source of truth for whether
+# the integration is enabled. Symlink the Klipper snippet into the extended
+# config directory when a host is configured, and remove the symlink otherwise,
+# so enabling/disabling Spoolman from `firmware-config` does not have to manage
+# the Klipper side directly.
+if [ "$1" = start ]; then
+    EXTENDED_CFG="/oem/printer_data/config/extended/extended2.cfg"
+    KLIPPER_CFG_SRC="/usr/local/share/spoollink/klipper.cfg"
+    KLIPPER_CFG_LINK="/oem/printer_data/config/extended/klipper/spoollink.cfg"
+
+    if [ -n "$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" spoolman host "" 2>/dev/null)" ]; then
+        if [ ! -L "$KLIPPER_CFG_LINK" ]; then
+            ln -sf "$KLIPPER_CFG_SRC" "$KLIPPER_CFG_LINK"
+            chown -h lava:lava "$KLIPPER_CFG_LINK"
+        fi
+    else
+        rm -f "$KLIPPER_CFG_LINK"
+    fi
+fi

--- a/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/moonraker.d/10-spoollink.sh
+++ b/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/moonraker.d/10-spoollink.sh
@@ -1,0 +1,34 @@
+# Render the Moonraker `[spoolman]` and `[spoollink]` config from the Spoolman
+# configuration.
+#
+# `[spoolman] host` in `extended2.cfg` is the single source of truth. When a host
+# is configured, generate the Moonraker `[spoolman]` block (built-in usage
+# tracking) and the `[spoollink]` block (the SpoolLink component that bridges
+# Spoolman to the AFC/RFID stack) into the extended config directory pointing at
+# it; otherwise remove the generated config.
+if [ "$1" = start ]; then
+    EXTENDED_CFG="/oem/printer_data/config/extended/extended2.cfg"
+    MOONRAKER_CFG="/oem/printer_data/config/extended/moonraker/spoollink.cfg"
+    CACHE_DIR="/oem/printer_data/config/extended/spoollink"
+
+    SPOOLMAN_HOST=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" spoolman host "" 2>/dev/null)
+    if [ -n "$SPOOLMAN_HOST" ]; then
+        mkdir -p "$(dirname "$MOONRAKER_CFG")" "$CACHE_DIR"
+        chown lava:lava "$CACHE_DIR"
+        cat > "$MOONRAKER_CFG" <<EOF
+# Spoolman Integration (generated from extended2.cfg [spoolman] host).
+# See: https://moonraker.readthedocs.io/en/latest/configuration/#spoolman
+[spoolman]
+server: $SPOOLMAN_HOST
+sync_rate: 5
+
+# SpoolLink component: bridges Spoolman to the Snapmaker AFC/RFID stack.
+[spoollink]
+server: $SPOOLMAN_HOST
+cache_dir: $CACHE_DIR
+EOF
+        chown lava:lava "$MOONRAKER_CFG"
+    else
+        rm -f "$MOONRAKER_CFG"
+    fi
+fi

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/klipper/klippy/extras/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/klipper/klippy/extras/spoollink.py
@@ -1,0 +1,60 @@
+import logging
+
+from . import filament_protocol
+
+class SpoolLink:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.printer.lookup_object('webhooks').register_endpoint(
+            'spoollink/set', self._handle_set)
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+
+    def _handle_ready(self):
+        fd = self.printer.lookup_object('filament_detect', None)
+        if fd is not None:
+            fd.register_cb_2_update_filament_info(self._on_filament_info)
+
+    def _on_filament_info(self, channel, info, is_clear):
+        if is_clear:
+            return
+        spool_id = info.get('SPOOL_ID', 0) or 0
+        uid_raw = info.get('CARD_UID') or []
+        card_uid = (''.join('%02X' % b for b in uid_raw)
+                    if uid_raw and any(b != 0 for b in uid_raw) else '')
+        wh = self.printer.lookup_object('webhooks')
+        if spool_id != 0 or not wh.has_remote_method('spoollink_resolve_spool'):
+            return
+        if card_uid:
+            wh.call_remote_method('spoollink_resolve_spool',
+                                  channel=channel, spool_id=spool_id,
+                                  card_uid=card_uid)
+        else:
+            self.gcode.respond_raw('// SpoolLink: E%d no card present' % (channel + 1))
+
+    def _handle_set(self, web_request):
+        wh = self.printer.lookup_object('webhooks')
+        if not wh.has_remote_method('spoollink_resolve_spool'):
+            raise web_request.error('spoollink not supported')
+
+        channel = web_request.get_int('channel')
+        message = web_request.get_str('message', '')
+        status = web_request.get_str('status', 'ok')
+
+        if status == 'error':
+            logging.warning('[spoollink] ch%d error: %s', channel, message)
+            self.gcode.respond_raw('!! %s' % message)
+            web_request.send({})
+            return
+
+        info = dict(filament_protocol.FILAMENT_INFO_STRUCT)
+        info.update(web_request.get('info', {}))
+        if message:
+            logging.info('[spoollink] ch%d: %s', channel, message)
+        ptc = self.printer.lookup_object('print_task_config')
+        ptc._rfid_filament_info_update_cb(channel, info, is_clear=True)
+        self.gcode.respond_raw('// %s' % message)
+        web_request.send({})
+
+def load_config(config):
+    return SpoolLink(config)

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -1,0 +1,501 @@
+# SpoolLink — bridge between Spoolman and the Snapmaker AFC/RFID stack.
+#
+# Runs inside Moonraker as a component. It registers the
+# `spoollink_resolve_spool` remote method for the Klipper `[spoollink]`
+# router, resolves scanned cards (or explicit spool IDs) against the
+# Spoolman REST API, binds card UIDs to spools, keeps Moonraker's active
+# spool in sync with the toolhead, and pushes the resolved filament info
+# back into Klipper via the `spoollink/set` endpoint.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from __future__ import annotations
+import asyncio
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ..confighelper import ConfigHelper
+    from .http_client import HttpClient, HttpResponse
+    from .klippy_apis import KlippyAPI as APIComp
+
+RESOLVE_METHOD = "spoollink_resolve_spool"
+SET_ENDPOINT = "spoollink/set"
+
+
+def _unquote(value: str) -> str:
+    s = value.strip()
+    if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+        s = s[1:-1]
+    return s
+
+
+def _parse_card_uids(spool: dict) -> List[str]:
+    raw = _unquote((spool.get("extra") or {}).get("card_uids") or "")
+    return [u.strip().upper() for u in raw.split(",") if u.strip()]
+
+
+def _parse_variant(vendor: str, filament: dict) -> str:
+    variant = _unquote((filament.get("extra") or {}).get("variant") or "")
+    if variant:
+        return variant
+    return "Basic" if vendor.lower() == "snapmaker" else ""
+
+
+class SpoolLink:
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        url = config.get("server").strip().rstrip("/")
+        if "://" not in url:
+            url = "http://" + url
+        self._spoolman_url = url
+        self._cache_dir: Optional[str] = config.get("cache_dir", None)
+        self.http_client: HttpClient = self.server.lookup_component("http_client")
+        self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
+
+        self._channel_uids: Dict[int, str] = {}
+        self._toolhead_extruder: str = "extruder"
+        self._ptc_spool_ids: List[int] = []
+        self._active_spool_id: Optional[int] = None
+
+        self.server.register_remote_method(RESOLVE_METHOD, self._resolve_spool)
+        self.server.register_event_handler(
+            "server:klippy_ready", self._handle_klippy_ready)
+        self.server.register_event_handler(
+            "server:klippy_disconnect", self._handle_klippy_disconnect)
+        self.server.register_event_handler(
+            "spoolman:active_spool_set", self._handle_active_spool_set)
+
+    async def component_init(self) -> None:
+        logging.info(
+            "spoollink starting (spoolman: %s, cache: %s)",
+            self._spoolman_url, self._cache_dir or "disabled")
+        await self._ensure_fields()
+
+    # -- Klippy lifecycle ---------------------------------------------------
+
+    async def _handle_klippy_ready(self) -> None:
+        logging.info("[spoollink] Klippy ready, subscribing to objects")
+        status = await self.klippy_apis.subscribe_objects({
+            "filament_detect": None,
+            "print_task_config": ["filament_spool_id"],
+            "toolhead": ["extruder"],
+        }, self._handle_status_update, {})
+        self._handle_status_update(status, 0.)
+
+    def _handle_klippy_disconnect(self) -> None:
+        logging.info("[spoollink] Klippy disconnected")
+        self._channel_uids = {}
+        self._ptc_spool_ids = []
+        self._active_spool_id = None
+
+    # -- Remote method / subscription callbacks -----------------------------
+
+    def _handle_active_spool_set(self, payload: Dict[str, Any]) -> None:
+        spool_id = payload.get("spool_id")
+        if spool_id != self._active_spool_id:
+            self._active_spool_id = spool_id
+            logging.info("[spoollink] active spool received: spool_id=%s", spool_id)
+            self._fire(self._sync_active_spool())
+
+    def _handle_status_update(self, status: Dict[str, Any], eventtime: float) -> None:
+        th = status.get("toolhead")
+        if th is not None:
+            extruder = th.get("extruder")
+            if extruder is not None and extruder != self._toolhead_extruder:
+                logging.info("[spoollink] toolhead extruder changed: %s → %s",
+                             self._toolhead_extruder, extruder)
+                self._toolhead_extruder = extruder
+                self._fire(self._sync_active_spool())
+
+        ptc = status.get("print_task_config")
+        if ptc is not None:
+            spool_ids = ptc.get("filament_spool_id")
+            new_ids = list(spool_ids or [])
+            if new_ids != self._ptc_spool_ids:
+                logging.info("[spoollink] spool_ids changed: %s → %s",
+                             self._ptc_spool_ids, new_ids)
+                self._ptc_spool_ids = new_ids
+                self._fire(self._sync_active_spool())
+
+        fd = status.get("filament_detect")
+        if fd is None:
+            return
+        info_list = fd.get("info", [])
+        for ch, info in enumerate(info_list):
+            self._handle_filament_detect_channel(ch, info)
+
+    def _handle_filament_detect_channel(self, ch: int, info: Any) -> None:
+        if not isinstance(info, dict):
+            return
+        uid_hex = self._uid_to_hex(info.get("CARD_UID"))
+        prev = self._channel_uids.get(ch, "")
+        self._channel_uids[ch] = uid_hex
+        if uid_hex and uid_hex != prev:
+            logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
+                         ch, uid_hex)
+            self._fire(self._resolve_spool(ch, card_uid=uid_hex))
+
+    # -- Active spool sync --------------------------------------------------
+
+    @staticmethod
+    def _uid_to_hex(uid_raw: Any) -> str:
+        if not uid_raw:
+            return ""
+        if isinstance(uid_raw, (list, tuple)):
+            if all(b == 0 for b in uid_raw):
+                return ""
+            return "".join(f"{b:02X}" for b in uid_raw)
+        return ""
+
+    @staticmethod
+    def _extruder_to_channel(extruder: str) -> int:
+        if extruder == "extruder":
+            return 0
+        try:
+            return int(extruder.replace("extruder", ""))
+        except ValueError:
+            return 0
+
+    async def _sync_active_spool(self) -> None:
+        channel = self._extruder_to_channel(self._toolhead_extruder)
+        spool_id = (self._ptc_spool_ids[channel]
+                    if channel < len(self._ptc_spool_ids) else 0) or 0
+        if spool_id == self._active_spool_id:
+            return
+        logging.info("[spoollink] set active spool: channel=%d spool_id=%s → %s",
+                     channel, self._active_spool_id, spool_id)
+        self._active_spool_id = spool_id
+        spoolman = self.server.lookup_component("spoolman", None)
+        if spoolman is None:
+            return
+        try:
+            spoolman.set_active_spool(spool_id or None)
+        except Exception:
+            self._active_spool_id = None
+            raise
+
+    # -- Klipper push -------------------------------------------------------
+
+    async def _spoollink_set(self, channel: int, message: str,
+                             info: Optional[dict] = None,
+                             status: str = "ok") -> Optional[dict]:
+        params: Dict[str, Any] = {
+            "channel": channel, "message": message, "status": status}
+        if info is not None:
+            params["info"] = info
+        try:
+            return await self.klippy_apis._send_klippy_request(SET_ENDPOINT, params)
+        except self.server.error as e:
+            logging.error("[spoollink] ch%d: %s failed: %s", channel, SET_ENDPOINT, e)
+            await self.klippy_apis.run_gcode(
+                'RESPOND TYPE=error MSG="SpoolLink: Spoolman integration '
+                'appears disabled on the printer — re-enable it via '
+                'firmware-config and reboot"', None)
+            return None
+
+    # -- Task helpers -------------------------------------------------------
+
+    def _fire(self, coro) -> "asyncio.Future":
+        task = asyncio.ensure_future(coro)
+        task.add_done_callback(self._task_done)
+        return task
+
+    @staticmethod
+    def _task_done(task: "asyncio.Future") -> None:
+        if not task.cancelled() and task.exception() is not None:
+            logging.error("[spoollink] background task failed: %s",
+                          task.exception(), exc_info=task.exception())
+
+    async def _retry(self, fn, *args, retries=3, **kwargs):
+        delay = 1.0
+        for attempt in range(retries + 1):
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as e:
+                if attempt == retries:
+                    raise
+                logging.debug("[spoollink] attempt %d/%d failed: %s",
+                              attempt + 1, retries, e)
+                await asyncio.sleep(delay)
+                delay *= 2
+
+    # -- Local cache --------------------------------------------------------
+
+    def _cache_path(self, card_uid: str) -> Optional[str]:
+        if not self._cache_dir:
+            return None
+        return os.path.join(self._cache_dir, f"{card_uid.upper()}.json")
+
+    def _load_cache(self, card_uid: str) -> Optional[dict]:
+        path = self._cache_path(card_uid)
+        if not path:
+            return None
+        try:
+            with open(path) as f:
+                spool = json.load(f)
+            logging.info("[spoollink] cache hit for card %s (spool %s)",
+                         card_uid, spool.get("id"))
+            return spool
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            logging.warning("[spoollink] cache read failed for %s: %s", card_uid, e)
+            return None
+
+    def _save_cache(self, card_uid: str, spool: dict) -> None:
+        path = self._cache_path(card_uid)
+        if not path:
+            return
+        try:
+            os.makedirs(self._cache_dir, exist_ok=True)
+            with open(path, "w") as f:
+                json.dump(spool, f)
+            logging.info("[spoollink] cached spool %s for card %s",
+                         spool.get("id"), card_uid)
+        except Exception as e:
+            logging.warning("[spoollink] cache write failed for %s: %s", card_uid, e)
+
+    def _delete_cache(self, card_uid: str) -> None:
+        path = self._cache_path(card_uid)
+        if not path:
+            return
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logging.warning("[spoollink] cache delete failed for %s: %s", card_uid, e)
+
+    # -- Spoolman REST ------------------------------------------------------
+
+    async def _ensure_fields(self) -> None:
+        await self._ensure_field("spool", "card_uids", "Card UIDs")
+        await self._ensure_field("filament", "variant", "Variant")
+
+    async def _ensure_field(self, entity_type: str, key: str, name: str) -> None:
+        base = f"{self._spoolman_url}/api/v1/field/{entity_type}"
+        try:
+            resp = await self.http_client.get(base, enable_cache=False)
+            if resp.status_code != 200:
+                logging.warning(
+                    "[spoollink] could not read custom fields for %s (HTTP %s)",
+                    entity_type, resp.status_code)
+                return
+            fields = resp.json()
+            if any(f.get("key") == key for f in fields):
+                logging.info("[spoollink] field %s/%s: exists", entity_type, key)
+                return
+            body = {
+                "name": name,
+                "field_type": "text",
+                "order": 1,
+                "default_value": json.dumps(""),
+            }
+            resp = await self.http_client.post(f"{base}/{key}", body=body)
+            if resp.status_code in (200, 201):
+                logging.info("[spoollink] field %s/%s: created", entity_type, key)
+            else:
+                logging.warning(
+                    "[spoollink] could not create field %s/%s: HTTP %s %s",
+                    entity_type, key, resp.status_code, resp.text())
+        except Exception as e:
+            logging.warning(
+                "[spoollink] custom fields check failed (%s/%s): %s",
+                entity_type, key, e)
+
+    async def _spoolman_get_by_id(self, spool_id: int) -> Optional[dict]:
+        resp = await self.http_client.get(
+            f"{self._spoolman_url}/api/v1/spool/{spool_id}", enable_cache=False)
+        if resp.status_code == 200:
+            return resp.json()
+        if resp.status_code == 404:
+            return None
+        raise RuntimeError(f"HTTP {resp.status_code}: {resp.text()}")
+
+    async def _spoolman_find_by_card(self, card_uid: str) -> List[dict]:
+        resp = await self.http_client.get(
+            f"{self._spoolman_url}/api/v1/spool?limit=1000", enable_cache=False)
+        if resp.status_code != 200:
+            raise RuntimeError(f"HTTP {resp.status_code}: {resp.text()}")
+        spools = resp.json()
+        uid_upper = card_uid.upper()
+        return [s for s in spools if uid_upper in _parse_card_uids(s)]
+
+    async def _spoolman_patch_card_uids(self, spool: dict, uids: List[str]) -> dict:
+        encoded = json.dumps(",".join(uids))
+        resp = await self.http_client.request(
+            "PATCH", f"{self._spoolman_url}/api/v1/spool/{spool['id']}",
+            body={"extra": {"card_uids": encoded}})
+        if resp.status_code == 200:
+            return resp.json()
+        raise RuntimeError(f"HTTP {resp.status_code}: {resp.text()}")
+
+    async def _spoolman_add_card_uid(self, spool: dict, card_uid: str) -> dict:
+        uid_upper = card_uid.upper()
+        existing = _parse_card_uids(spool)
+        if uid_upper in existing:
+            return spool
+        return await self._spoolman_patch_card_uids(spool, existing + [uid_upper])
+
+    async def _spoolman_remove_card_uid(self, spool: dict, card_uid: str) -> dict:
+        uid_upper = card_uid.upper()
+        existing = _parse_card_uids(spool)
+        if uid_upper not in existing:
+            return spool
+        return await self._spoolman_patch_card_uids(
+            spool, [u for u in existing if u != uid_upper])
+
+    # -- Resolution ---------------------------------------------------------
+
+    async def _resolve_spool(self, channel: int, spool_id: Any = None,
+                             card_uid: Any = None) -> None:
+        spool_id = spool_id or None
+        card_uid = card_uid or None
+        if channel is None:
+            logging.error("[spoollink] resolve_spool: missing channel")
+            return
+        logging.debug("[spoollink] ch%d: resolve spool_id=%s card_uid=%s",
+                      channel, spool_id, card_uid)
+        spool_by_id = None
+        spools_by_card: List[dict] = []
+        spoolman_ok = True
+
+        if spool_id is not None:
+            try:
+                spool_by_id = await self._retry(self._spoolman_get_by_id, spool_id)
+            except Exception as e:
+                logging.error("[spoollink] ch%d: fetch spool %s failed: %s",
+                              channel, spool_id, e)
+                spoolman_ok = False
+
+        if card_uid is not None:
+            try:
+                spools_by_card = await self._retry(
+                    self._spoolman_find_by_card, card_uid)
+            except Exception as e:
+                logging.error("[spoollink] ch%d: fetch by card failed: %s",
+                              channel, e)
+                spoolman_ok = False
+
+        if len(spools_by_card) > 1:
+            ids = ", ".join(f"#{s['id']}" for s in spools_by_card)
+            logging.warning("[spoollink] ch%d: card %s assigned to multiple spools: %s",
+                            channel, card_uid, ids)
+            await self._spoollink_set(
+                channel,
+                f"SpoolLink: E{channel + 1} card {card_uid} "
+                f"assigned to multiple spools: {ids}",
+                status="error")
+            return
+        spool_by_card = spools_by_card[0] if spools_by_card else None
+        spool = spool_by_id or spool_by_card
+        cached = False
+        if spool is None:
+            if card_uid is not None and not spoolman_ok:
+                spool = self._load_cache(card_uid)
+                if spool is not None:
+                    logging.warning("[spoollink] ch%d: using cached data for card %s",
+                                    channel, card_uid)
+            cached = spool is not None and not spoolman_ok
+            if spool is None:
+                if card_uid is not None:
+                    if spoolman_ok:
+                        self._delete_cache(card_uid)
+                    await self._spoollink_set(
+                        channel,
+                        f"SpoolLink: E{channel + 1} no spool found for card {card_uid}",
+                        status="error")
+                return
+
+        if card_uid is not None and spool_by_id is not None:
+            if card_uid.upper() not in _parse_card_uids(spool_by_id):
+                try:
+                    spool = await self._retry(
+                        self._spoolman_add_card_uid, spool_by_id, card_uid)
+                    logging.info("[spoollink] ch%d: bound spool %s to card %s",
+                                 channel, spool_by_id["id"], card_uid)
+                except Exception as e:
+                    logging.error("[spoollink] ch%d: bind spool %s failed: %s",
+                                  channel, spool_by_id["id"], e)
+
+            for stale in spools_by_card:
+                if stale["id"] == spool_by_id["id"]:
+                    continue
+                try:
+                    await self._retry(
+                        self._spoolman_remove_card_uid, stale, card_uid)
+                    logging.info("[spoollink] ch%d: unbound card %s from spool %s",
+                                 channel, card_uid, stale["id"])
+                except Exception as e:
+                    logging.error(
+                        "[spoollink] ch%d: unbind card %s from spool %s failed: %s",
+                        channel, card_uid, stale["id"], e)
+
+        if card_uid is not None and spoolman_ok:
+            self._save_cache(card_uid, spool)
+
+        await self._apply_spool(channel, spool, card_uid or "", cached=cached)
+
+    async def _apply_spool(self, channel: int, spool: dict, uid_hex: str,
+                           cached: bool = False) -> None:
+        spool_id = spool.get("id", 0)
+        filament = spool.get("filament", {})
+        material = filament.get("material", "PLA")
+        vendor = (filament.get("vendor") or {}).get("name", "Generic")
+        variant = _parse_variant(vendor, filament)
+
+        raw_multi = filament.get("multi_color_hexes") or ""
+        colors = [c.strip().upper()[:6] for c in raw_multi.split(",") if c.strip()]
+        color_hex = colors[0] if colors else (filament.get("color_hex") or "FFFFFF")[:6].upper()
+
+        color_list = colors or [color_hex]
+        color_nums = len(color_list)
+        while len(color_list) < 5:
+            color_list.append("000000")
+
+        card_uid = [int(uid_hex[i:i+2], 16)
+                    for i in range(0, len(uid_hex), 2)] if uid_hex else []
+        alpha = 0xFF
+        info = {
+            "VENDOR": vendor,
+            "MAIN_TYPE": material,
+            "SUB_TYPE": variant,
+            "RGB_1": int(color_list[0], 16),
+            "RGB_2": int(color_list[1], 16),
+            "RGB_3": int(color_list[2], 16),
+            "RGB_4": int(color_list[3], 16),
+            "RGB_5": int(color_list[4], 16),
+            "ALPHA": alpha,
+            "ARGB_COLOR": (alpha << 24) | int(color_list[0], 16),
+            "COLOR_NUMS": color_nums,
+            "MULTI_MODE": 0,
+            "OFFICIAL": True,
+            "SKU": 0,
+            "SPOOL_ID": spool_id,
+            "CARD_UID": card_uid,
+            "CARD_TYPE": 0,
+        }
+
+        label = f"{vendor} {material}"
+        if variant:
+            label += f" {variant}"
+        label += f" #{color_list[0]} (spool #{spool_id}, card {uid_hex or 'none'})"
+        if cached:
+            label += " [cached]"
+        message = f"SpoolLink: E{channel + 1} loaded {label}"
+
+        logging.info(
+            "[spoollink] ch%d: applying spool %s — %s %s%s #%s (card %s)",
+            channel, spool_id, vendor, material,
+            f" {variant}" if variant else "",
+            color_hex, uid_hex or "none")
+        reply = await self._spoollink_set(channel, message, info=info)
+        if reply is not None:
+            logging.info("[spoollink] ch%d: spool %s applied", channel, spool_id)
+
+
+def load_component(config: ConfigHelper) -> SpoolLink:
+    return SpoolLink(config)

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/firmware-config/functions/24_settings_snapmaker_components_spoolman.yaml
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/firmware-config/functions/24_settings_snapmaker_components_spoolman.yaml
@@ -1,0 +1,48 @@
+settings:
+  snapmaker_components:
+    items:
+      spoolman:
+        label: Spoolman Integration
+        description: Track filament usage and metadata with Spoolman spool management.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/spoolman
+        get_cmd:
+          - bash
+          - -c
+          - /usr/local/bin/extended-config.py get /oem/printer_data/config/extended/extended2.cfg spoolman host 2>/dev/null | grep -q . && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable Spoolman integration? Enter the Spoolman server URL below.\n\nSpoolman tracks filament usage and lets you manage spool metadata from your web frontend."
+            inputs:
+              - name: SPOOLMAN_URL
+                label: Spoolman URL
+                placeholder: "http://192.168.1.100:7912"
+                regex: "^https?://.+"
+            cmd:
+              - bash
+              - -c
+              - |
+                URL="${SPOOLMAN_URL%/}"
+                if ! curl -fsS --max-time 10 "${URL}/api/v1/info" | grep -q '"version"'; then
+                  echo "ERROR: Spoolman validation failed (could not reach ${URL})."
+                  exit 1
+                fi
+                /usr/local/bin/extended-config.py uncomment /oem/printer_data/config/extended/extended2.cfg spoolman
+                /usr/local/bin/extended-config.py add /oem/printer_data/config/extended/extended2.cfg spoolman host "${URL}" || {
+                  echo "ERROR: Failed to set Spoolman host."
+                  exit 1
+                }
+                echo "Spoolman enabled. Restarting Klipper and Moonraker to start SpoolLink..."
+                /etc/init.d/S60klipper restart
+                /etc/init.d/S61moonraker restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py comment /oem/printer_data/config/extended/extended2.cfg spoolman
+                echo "SpoolLink disabled. Restarting Klipper and Moonraker..."
+                /etc/init.d/S60klipper restart
+                /etc/init.d/S61moonraker restart
+        default: disabled

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -1,0 +1,5 @@
+# Klipper `[spoollink]` router: exposes the `spoollink/set` endpoint and
+# forwards scanned RFID cards to the SpoolLink Moonraker component.
+# Symlinked into the extended Klipper config by klipper.d/10-spoollink.sh
+# when `[spoolman] host` is set in extended2.cfg.
+[spoollink]


### PR DESCRIPTION
## Summary

Automatic spool detection and mapping for the Snapmaker U1 multi-filament
stack, bridging the physical RFID card reader with
[Spoolman](https://github.com/Donkie/Spoolman).

The in-printer web UI has been split out and merged separately as #581
(`Filament Manager`); this PR is the Spoolman/SpoolLink backend it drives.

### Docs

- [Spoolman Integration](https://github.com/paxx12/fork-SnapmakerU1-Extended-Firmware/blob/spoolman-spoollink/docs/spoolman.md) — user guide
- [Design notes](https://github.com/paxx12/fork-SnapmakerU1-Extended-Firmware/blob/spoolman-spoollink/docs/design/spoolman.md) — wire format, custom fields, component flow

### What it does (`38-feature-spoollink`)

SpoolLink is a **Moonraker component** paired with a thin Klipper
`[spoollink]` router. When a channel's RFID card is scanned (or a spool ID
is set from the AFC lane config), it resolves the spool against Spoolman by
ID or card UID, binds the card to that spool, and pushes the filament
metadata back into Klipper. Moonraker's built-in `[spoolman]` active spool
is kept in sync with the toolhead so remaining weight tracks the print. A
local JSON cache keeps things working while Spoolman is unreachable.

The resolution pipeline, custom fields, and wire format are documented in
the design notes above.

### Config-driven enablement

`[spoolman] host` in `extended2.cfg` is the single source of truth. Service
hooks derive the Klipper `[spoollink]` include and the Moonraker
`[spoolman]` / `[spoollink]` blocks from it on start; `firmware-config` only
toggles the `[spoolman]` section.

### AFC wiring

AFC lane status reports a `filament_name` built from vendor, material, and
subtype. Weight is not tracked by AFC-Lite, so `SET_WEIGHT` is a stub.
`06-add-spool-id-support.patch` is rebased for firmware `1.5.1`.

## Why not a `spool_id` on the tag?

An earlier direction was to carry the Spoolman `spool_id` directly on the tag.
That was dropped because it only works with tags written in the OpenSpool
format: the `spool_id` has to be programmed onto the tag, so it excludes every
spool that already ships with an RFID tag that cannot be (re)programmed or uses
a different format. Those spools are still detectable by their hardware UID —
they just can't carry a `spool_id`. It also lets a blank, non-programmed tag be
used as-is: assign it to a spool once and its UID resolves on every later scan,
with nothing written to the tag.

SpoolLink maps the tag UID to a spool inside Spoolman, so it works with any
RFID-detected spool regardless of tag format or writability: the tag stays
read-only, and the card UID ↔ spool association lives in Spoolman's `card_uids`
custom field.

### Prior attempts

- #285 — *Idea 1: add OpenSpool `spool_id` extension* (closed) — required
  specially programmed tags carrying `spool_id`.
- #173 — *NFC tag `spool_id` for Spoolman integration* (closed) — optional
  `spool_id` field parsed from OpenSpool JSON.
- #163 — *Spoolman Helper* (closed) — parsed `SPOOL_ID` off the tag as well,
  bundled with a full Spoolman usage-tracking module (Moonraker proxy,
  print-lifecycle tracking, macros).
- #364 — *Idea 2: store the RFID tag ID in Spoolman* (closed) — the pivot to
  UID-based mapping (via `lot_nr`), superseding #285.
- #445 — *Idea 2b: same, via a Moonraker agent* (closed).

This PR continues the #364/#445 direction, moving the mapping to the dedicated
`card_uids` custom field and the SpoolLink Moonraker component.

## Warning

The format where the spool mapping is stored changed in this PR https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/364! It is no longer stored in the `lot_nr` field, instead a new special `extra.card_uid` field was introduced. This means that all current mappings are incorrect.

You can convert those manually via Spoolman. Enable this PR, and then manually move the data from `Lot Nr` to `Extra Fields > Card UID`, removing the `card_uid:` prefix:

<img width="967" height="625" alt="image" src="https://github.com/user-attachments/assets/d0918a35-58fc-4969-a8b5-5a712dc4f84d" />
