### PR TITLE
feat(panda-breath): independent enclosure over-temperature safety cutoff

### DIFF
--- a/docs/panda_breath.md
+++ b/docs/panda_breath.md
@@ -27,6 +27,14 @@ Printable cooling solutions available on MakerWorld:
 
 See also: [Quick overview on fan mods applied for Snapmaker U1](https://www.reddit.com/r/SnapmakerU1/comments/1tlk27r/quick_overview_on_fan_mods_applied_for_snapmaker/) — community thread covering additional fan mod approaches (to be evaluated).
 
+### Cavity Over-Temperature Safety Cutoff
+
+Because the Panda Breath is exposed to Klipper as a `heater_generic`, it regulates **only on the Panda's own sensor** and has no awareness of the U1 enclosure temperature. Active motherboard cooling is the primary mitigation, but there is no independent cutoff if the enclosure still runs away (for example a stuck heater, a failed mainboard fan, or an unusually hot bed plus high ambient).
+
+To cover this, enabling Panda Breath also installs an independent safety guard. A self-rearming `[delayed_gcode]` watches the stock `[temperature_sensor cavity]` enclosure sensor and, if it exceeds a limit (default **70 °C**, a margin below the 85 °C SoC throttle point), forces chamber heating off (`M141 S0`), drives the `cavity_fan` to full, and prints a warning to the console. This runs in both auto and manual modes and is independent of the Panda device's own sensor and network connectivity.
+
+The guard is conservative by default (it cuts heating but does not interrupt the print). To tune the limit or have it pause the print on trip, override the guard's variables from your user config — see the comments at the top of `panda_breath_cavity_guard.cfg`.
+
 ## Prerequisites
 
 1. **Install motherboard cooling** — see [Risks and Warranty](#risks-and-warranty) above.

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_cavity_guard.cfg
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_cavity_guard.cfg
@@ -1,0 +1,61 @@
+# Panda Breath — Enclosure Cavity Over-Temperature Safety Guard
+# This file is managed by firmware-config and must not be edited.
+# It is included automatically by the auto/manual heater configs and will be
+# overwritten on firmware upgrades.
+#
+# Why this exists:
+#   [heater_generic panda_breath] regulates solely on the Panda Breath device's
+#   own sensor. It has no awareness of the U1 enclosure/motherboard temperature,
+#   so it cannot protect against the failure mode documented in
+#   docs/panda_breath.md > "Motherboard Overheating": the U1 motherboard has
+#   limited thermal headroom and the RK3562 SoC begins thermal throttling at
+#   85 C, which degrades Klipper timing and causes motion/communication errors
+#   mid-print. Active motherboard cooling is required, but there is currently no
+#   independent cutoff if the enclosure still runs away (e.g. a stuck Panda
+#   heater, a failed mainboard fan, or an unusually hot bed + ambient).
+#
+# What it does:
+#   A self-rearming [delayed_gcode] polls [temperature_sensor cavity] (the stock
+#   U1 enclosure NTC). If the cavity temperature exceeds limit_c (default 70 C,
+#   a margin below the 85 C throttle point), it forces chamber heating off via
+#   M141 S0, drives [fan_generic cavity_fan] to full to actively pull heat out,
+#   and prints a warning. It can optionally PAUSE the print.
+#
+# Tuning (advanced): override the variables at runtime/persisted from your
+#   user config without editing this managed file, e.g. in
+#   /home/lava/printer_data/config/extended/klipper/panda_breath.cfg add a
+#   [delayed_gcode] that runs once at startup:
+#     SET_GCODE_VARIABLE MACRO=_panda_breath_cavity_guard VARIABLE=limit_c VALUE=65
+#     SET_GCODE_VARIABLE MACRO=_panda_breath_cavity_guard VARIABLE=pause_on_trip VALUE=1
+
+[gcode_macro _panda_breath_cavity_guard]
+description: Tunables for the Panda Breath cavity over-temperature guard
+# limit_c:        enclosure cavity cutoff temperature, in C
+# poll_interval:  seconds between cavity temperature checks
+# pause_on_trip:  1 = PAUSE the active print when tripped, 0 = only cut heat + warn
+variable_limit_c: 70
+variable_poll_interval: 10
+variable_pause_on_trip: 0
+gcode:
+    # Storage-only macro; body intentionally does nothing.
+
+[delayed_gcode panda_breath_cavity_guard]
+# Starts shortly after Klipper boots, then re-arms itself every poll_interval.
+initial_duration: 15
+gcode:
+    {% set g = printer["gcode_macro _panda_breath_cavity_guard"] %}
+    {% set sensor = printer["temperature_sensor cavity"] %}
+    {% if sensor is defined and sensor.temperature is not none
+          and sensor.temperature|float > g.limit_c|float %}
+        {% set t = sensor.temperature|float|round(1) %}
+        M141 S0
+        SET_FAN_SPEED FAN=cavity_fan SPEED=1.0
+        { action_respond_info(
+            "Panda Breath cavity guard: enclosure " ~ t ~ "C exceeds limit "
+            ~ g.limit_c|int ~ "C. Chamber heating forced OFF and cavity fan set"
+            ~ " to full. Check motherboard cooling (see docs/panda_breath.md).") }
+        {% if g.pause_on_trip|int == 1 and printer.print_stats.state == "printing" %}
+            PAUSE
+        {% endif %}
+    {% endif %}
+    UPDATE_DELAYED_GCODE ID=panda_breath_cavity_guard DURATION={ g.poll_interval|int }

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_auto.cfg
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_auto.cfg
@@ -2,6 +2,10 @@
 # This file is managed by firmware-config and must not be edited.
 # It is symlinked into your config directory and will be overwritten on firmware upgrades.
 
+# Independent enclosure over-temperature cutoff (heater_generic only watches the
+# Panda's own sensor; this guards the U1 motherboard — see docs/panda_breath.md).
+[include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_cavity_guard.cfg]
+
 [heater_generic panda_breath]
 heater_pin: panda_breath:pwm
 sensor_type: panda_breath

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg
@@ -2,6 +2,10 @@
 # This file is managed by firmware-config and must not be edited.
 # It is symlinked into your config directory and will be overwritten on firmware upgrades.
 
+# Independent enclosure over-temperature cutoff (heater_generic only watches the
+# Panda's own sensor; this guards the U1 motherboard — see docs/panda_breath.md).
+[include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_cavity_guard.cfg]
+
 [heater_generic panda_breath]
 heater_pin: panda_breath:pwm
 sensor_type: panda_breath


### PR DESCRIPTION
## Summary

The Panda Breath is exposed to Klipper as a `heater_generic`, so it regulates **solely on the Panda device's own sensor** and has no awareness of the U1 enclosure/motherboard temperature. That leaves the failure mode this repo already documents in [`docs/panda_breath.md` → *Motherboard Overheating*](../blob/develop/docs/panda_breath.md#motherboard-overheating) — the U1 motherboard's limited thermal headroom and the RK3562 SoC throttling at 85 °C — **without any independent cutoff** if the enclosure runs away (stuck Panda heater, failed mainboard fan, or a hot bed + high ambient). Active motherboard cooling is required, but cooling alone is a mitigation, not a cutoff.

This adds a small, self-contained safety net that watches the **stock** `[temperature_sensor cavity]` enclosure NTC and pulls chamber heat if the enclosure exceeds a limit.

## What it does

A self-rearming `[delayed_gcode]` (`panda_breath_cavity_guard.cfg`) polls `[temperature_sensor cavity]`. If the cavity temperature exceeds `limit_c` (**default 70 °C**, a margin below the 85 °C throttle point) it:

- forces chamber heating off (`M141 S0`),
- drives `[fan_generic cavity_fan]` to full to actively pull heat out,
- prints a warning to the console, and
- optionally `PAUSE`s the print (`pause_on_trip`, default **off**).

It re-arms every `poll_interval` seconds (default 10) and is **independent of the Panda device's own sensor and network connectivity**. The guard is included automatically by **both** the auto and manual heater configs, so it is active in either mode and is delivered to existing installs on firmware upgrade (the heater cfgs are managed/symlinked). No UI change.

Tunables (`limit_c`, `poll_interval`, `pause_on_trip`) live on a storage `[gcode_macro]` with conservative defaults and can be overridden from the user config without editing the managed file — see the header comment in `panda_breath_cavity_guard.cfg`.

## Changes

- **`tweaks/klipper/panda_breath_cavity_guard.cfg`** (new) — the guard + tunables
- **`tweaks/klipper/panda_breath_heater_auto.cfg`** / **`_manual.cfg`** — `[include]` the guard
- **`docs/panda_breath.md`** — new *Cavity Over-Temperature Safety Cutoff* subsection under *Motherboard Overheating*

## Design notes / discussion

- **Default is conservative**: it cuts heating + cools but does **not** interrupt the print, so a transient blip won't ruin a long job. Set `pause_on_trip: 1` for a hard stop.
- **70 °C default** mirrors a safe margin below the documented 85 °C RK3562 throttle point. Happy to adjust the default or the response (e.g. always-pause) to your preference.
- **No UI toggle** was added deliberately — keeping it an always-on safety net with a sane default minimizes surface area. I can add a firmware-config selector (enable/disable + limit) if you'd prefer it be user-facing, in the style of the camera FPS dropdown.
- **Not yet hardware-validated by me**: I run the enclosure control via an external bridge rather than the firmware integration, so I haven't exercised this on a live `heater_generic panda_breath` setup. The config is straightforward Klipper (`delayed_gcode` + existing `M141`/`SET_FAN_SPEED`), but flagging it honestly — a CI build artifact or a maintainer test on hardware would be the way to confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)