### PR TITLE
Update OpenRFID to support SpoolEase

### DIFF
--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -142,6 +142,7 @@ To enable it, navigate to the [firmware-config](firmware_config.md) web interfac
 | [OpenSpool](https://openspool.io/) | Yes | - |
 | TigerTag | Yes | Fully offline implementation |
 | Qidi | Yes | - |
+| [SpoolEase](https://spoolease.io/) | No | NTAG NDEF tags; enable the processor to use |
 
 ### Bambu / Creality Spool Configuration
 
@@ -178,6 +179,13 @@ Enable them by removing the `#` prefix from the tag processor.
 
 ```
 # [elegoo_tag_processor]
+```
+
+[SpoolEase](https://spoolease.io/) tags (NTAG NDEF) are also supported but not
+enabled by default. Add the processor to the same file to use them:
+
+```ini
+[spoolease_tag_processor]
 ```
 
 ## Troubleshooting

--- a/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
+++ b/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GIT_URL=https://github.com/suchmememanyskill/OpenRFID.git
-GIT_SHA=195e47d59a70dc532dac8ff19923254f3df17f29
+GIT_SHA=ddd1609e9abe9cd37c4b8fa1a0e4307b976d5fd4
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
@@ -13,3 +13,7 @@
 # Elegoo spools are disabled by default. They are not detected reliably on Snapmaker U1
 # due to tag placement. Uncomment to enable.
 #[elegoo_tag_processor]
+
+# SpoolEase tags (NTAG NDEF, https://spoolease.io) are disabled by default.
+# Uncomment to enable.
+#[spoolease_tag_processor]


### PR DESCRIPTION
- Spoolease tag support (disabled by default)
- Do not retry auth failures for MIFARE Classic
- Log extra info on tag scan's
- Update tigertag data