### PR TITLE
Add `quick_actions` and component upgrade support

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
@@ -23,7 +23,7 @@ def deep_merge(base, override):
 
 def load_functions_from_dir(functions_dir):
     """Load and deep merge all YAML files from a directory in sorted order."""
-    config = {'links': {}, 'settings': {}, 'actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
+    config = {'links': {}, 'settings': {}, 'actions': {}, 'quick_actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
 
     if not os.path.isdir(functions_dir):
         log(f"Functions directory not found: {functions_dir}")
@@ -58,7 +58,7 @@ def shell_to_cmd(shell, *args):
 
 class FirmwareConfigHandler(SimpleHTTPRequestHandler):
     html_dir = None
-    functions = {'settings': {}, 'links': {}, 'actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
+    functions = {'settings': {}, 'links': {}, 'actions': {}, 'quick_actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=self.html_dir, **kwargs)
@@ -74,8 +74,10 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
             self.handle_get_settings()
         elif path == "/api/links":
             self.handle_get_links()
+        elif path == "/api/quick-actions":
+            self.handle_get_actions('quick_actions')
         elif path == "/api/actions":
-            self.handle_get_actions()
+            self.handle_get_actions('actions')
         else:
             super().do_GET()
 
@@ -380,22 +382,26 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
             self.send_error(500, str(e))
 
     def _get_action_config(self, action_key):
-        actions = self.functions.get('actions', {})
-        for group_key, group_cfg in actions.items():
-            items = group_cfg.get('items', {})
-            if action_key in items:
-                return items[action_key]
+        for actions_cfg in (self.functions.get('quick_actions', {}), self.functions.get('actions', {})):
+            for group_key, group_cfg in actions_cfg.items():
+                items = group_cfg.get('items', {})
+                if action_key in items:
+                    return items[action_key]
         return None
 
-    def handle_get_actions(self):
+    def handle_get_actions(self, key):
         try:
-            actions_cfg = self.functions.get('actions', {})
+            actions_cfg = self.functions.get(key, {})
             result = {}
             for group_key, group_cfg in actions_cfg.items():
                 group_label = group_cfg.get('label', group_key)
                 items = group_cfg.get('items', {})
                 actions_list = []
                 for action_id, cfg in items.items():
+                    if_cmd = cfg.get('if_cmd')
+                    if if_cmd and not self._check_condition(if_cmd):
+                        continue
+
                     actions_list.append({
                         "id": action_id,
                         "label": cfg.get("label", action_id),
@@ -414,7 +420,7 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
 
             self.send_json(result)
         except Exception as e:
-            log(f"Get actions error: {e}")
+            log(f"Get {key} error: {e}")
             self.send_error(500, str(e))
 
     def handle_update_setting(self, setting_key, value):

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
@@ -1,3 +1,7 @@
+quick_actions:
+  upgrades:
+    label: Upgrades
+
 actions:
   troubleshooting:
     label: Troubleshooting

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -108,6 +108,11 @@
             <div id="status-container" class="info-grid"><div class="loading"><span class="spinner"></span> Loading...</div></div>
         </div>
 
+        <div class="card" id="quick-actions-card" style="display:none">
+            <div class="card-header"><span class="card-title">Quick Actions</span></div>
+            <div id="quick-actions-container"><div class="loading"><span class="spinner"></span> Loading...</div></div>
+        </div>
+
         <div class="card">
             <div class="card-header"><span class="card-title">Quick Links</span></div>
             <div id="links-container" class="links-grid"><div class="loading"><span class="spinner"></span> Loading...</div></div>
@@ -276,13 +281,23 @@
             }
         }
 
-        async function loadActions() {
-            const container = $('actions-container');
+        async function loadActions(containerId, apiPath, cardId) {
+            const container = $(containerId);
+            const card = cardId ? $(cardId) : null;
             try {
-                const grouped = await (await apiFetch('api/actions')).json();
-                actionsData = Object.values(grouped).flatMap(g => g.items);
+                const grouped = await (await apiFetch(apiPath)).json();
 
-                container.innerHTML = Object.entries(grouped).map(([_, group]) =>
+                if (card) {
+                    if (Object.keys(grouped).length === 0) {
+                        card.style.display = 'none';
+                        return;
+                    }
+                    card.style.display = 'block';
+                }
+
+                const groupActions = Object.values(grouped).flatMap(g => g.items);
+                actionsData.push(...groupActions);
+                container.innerHTML = Object.values(grouped).map(group =>
                     `<div class="group-section">
                         <div class="group-title">${group.label}</div>
                         ${group.items.filter(action => !action.hidden || showHidden).map(action =>
@@ -297,6 +312,7 @@
                     </div>`
                 ).join('');
             } catch (e) {
+                if (card) card.style.display = 'block';
                 container.innerHTML = `<div class="loading" style="color:var(--error)">Error: ${e.message}</div>`;
             }
         }
@@ -670,6 +686,7 @@
             try {
                 const resp = await apiFetch(`api/action/${id}`, { method: 'POST' });
                 await streamResponse(resp, id);
+                refreshAll();
             } catch (e) {
                 appendLog(`\nERROR: ${e.message}`);
                 setMessage('Failed', 'var(--error)');
@@ -800,8 +817,15 @@
             const btn = document.querySelector('h1 .btn');
             btn.innerHTML = '<span class="spinner"></span> Refresh';
             btn.disabled = true;
+            actionsData = [];
             try {
-                await Promise.all([loadStatus(), loadLinks(), loadSettings(), loadActions()]);
+                await Promise.all([
+                    loadStatus(),
+                    loadLinks(),
+                    loadSettings(),
+                    loadActions('quick-actions-container', 'api/quick-actions', 'quick-actions-card'),
+                    loadActions('actions-container', 'api/actions')
+                ]);
             } finally {
                 btn.innerHTML = '&#x21bb; Refresh';
                 btn.disabled = false;

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
@@ -22,18 +22,36 @@ check() {
     fi
 }
 
-download() {
+needs_upgrade() {
+    if [[ -L "$APP_DIR/latest" ]]; then
+        [[ "$(readlink "$APP_DIR/latest")" != "OctoPrint-OctoEverywhere-${VERSION}" ]]
+    else
+        return 1
+    fi
+}
+
+upgrade() {
+    download
+}
+
+clean() {
+    echo "Removing OctoEverywhere installation..."
     rm -rf "$APP_DIR"
-    mkdir -p "$APP_DIR"
+    echo "Removed."
+}
+
+download() {
+    rm -rf "$APP_DIR/tmp"
+    mkdir -p "$APP_DIR/tmp"
 
     echo "Downloading OctoEverywhere ${VERSION} From GitHub..."
-    if ! /usr/local/bin/curl -sfSL -o "$APP_DIR/octoeverywhere.zip" "$URL"; then
+    if ! /usr/local/bin/curl -sfSL -o "$APP_DIR/tmp/octoeverywhere.zip" "$URL"; then
         echo "Download failed"
         return 1
     fi
 
     echo "Verifying SHA256 checksum..."
-    ACTUAL_SHA256=$(sha256sum "$APP_DIR/octoeverywhere.zip" | awk '{print $1}')
+    ACTUAL_SHA256=$(sha256sum "$APP_DIR/tmp/octoeverywhere.zip" | awk '{print $1}')
     if [[ "$ACTUAL_SHA256" != "$SHA256" ]]; then
         echo "SHA256 mismatch!"
         echo "  Expected: $SHA256"
@@ -43,13 +61,13 @@ download() {
     echo "Checksum verified."
 
     echo "Extracting..."
-    if ! unzip -q "$APP_DIR/octoeverywhere.zip" -d "$APP_DIR"; then
+    if ! unzip -q "$APP_DIR/tmp/octoeverywhere.zip" -d "$APP_DIR/tmp"; then
         echo "Extraction failed"
         return 1
     fi
     echo "Extraction successful."
 
-    rm -rf "$APP_DIR/octoeverywhere.zip"
+    rm -rf "$APP_DIR/tmp/octoeverywhere.zip"
 
     echo "Setting up Python virtual environment (this can take up to 60 seconds)..."
     if ! python3 -m venv "$APP_DIR/venv"; then
@@ -58,7 +76,7 @@ download() {
     fi
 
     echo "Installing dependencies (this can also take a bit)..."
-    if ! "$APP_DIR/venv/bin/pip" install --disable-pip-version-check -r "$APP_DIR/OctoPrint-OctoEverywhere-${VERSION}/requirements.txt"; then
+    if ! "$APP_DIR/venv/bin/pip" install --disable-pip-version-check -r "$APP_DIR/tmp/OctoPrint-OctoEverywhere-${VERSION}/requirements.txt"; then
         echo "Failed to install dependencies"
         return 1
     fi
@@ -69,7 +87,9 @@ download() {
     fi
 
     # GitHub archives extract to OctoPrint-OctoEverywhere-<tag>
-    ln -s "OctoPrint-OctoEverywhere-${VERSION}" "$APP_DIR/latest"
+    rm -rf "$APP_DIR/OctoPrint-OctoEverywhere-"*
+    mv "$APP_DIR/tmp/OctoPrint-OctoEverywhere-${VERSION}" "$APP_DIR/"
+    ln -sf "OctoPrint-OctoEverywhere-${VERSION}" "$APP_DIR/latest"
     echo "OctoEverywhere installed successfully to $APP_DIR"
 }
 
@@ -77,30 +97,35 @@ case "$1" in
     check)
         check
         ;;
+    needs_upgrade)
+        needs_upgrade
+        ;;
     download)
         if check; then
             echo "OctoEverywhere is already installed."
             exit 0
         fi
+        if ! clean; then
+            echo "Failed to clean old installation"
+            exit 1
+        fi
         if ! download; then
             rm -rf "$APP_DIR"
             exit 1
         fi
         ;;
-    update)
-        echo "Updating OctoEverywhere..."
-        if ! download; then
-            rm -rf "$APP_DIR"
+    upgrade)
+        echo "Upgrading OctoEverywhere..."
+        if ! upgrade; then
+            rm -rf "$APP_DIR/tmp"
             exit 1
         fi
         ;;
     clean)
-        echo "Removing OctoEverywhere installation..."
-        rm -rf "$APP_DIR"
-        echo "Removed."
+        clean
         ;;
     *)
-        echo "Usage: $0 check|download|update|clean"
+        echo "Usage: $0 check|needs_upgrade|download|upgrade|clean"
         exit 1
         ;;
 esac

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/25_actions_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/25_actions_cloud.yaml
@@ -1,0 +1,15 @@
+quick_actions:
+  upgrades:
+    items:
+      octoeverywhere-upgrade:
+        label: Upgrade OctoEverywhere
+        description: Download and install the latest pinned OctoEverywhere version.
+        if_cmd: /usr/local/bin/octoeverywhere-pkg needs_upgrade
+        confirm: "Upgrade OctoEverywhere and restart the cloud service?"
+        cmd:
+          - bash
+          - -ec
+          - |
+            /usr/local/bin/octoeverywhere-pkg upgrade
+            /etc/init.d/S99cloud restart
+        message: "Upgrading OctoEverywhere..."

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/bin/tailscale-pkg
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/bin/tailscale-pkg
@@ -4,9 +4,16 @@ VERSION=1.92.5
 URL="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
 SHA256=13a59c3181337dfc9fdf9dea433b04c1fbf73f72ec059f64d87466b79a3a313c
 
-TAILSCALE_DIR="/oem/apps/tailscale-${VERSION}"
+APP_DIR="/oem/apps/tailscale"
 TAILSCALE_STATE_DIR="/home/lava/printer_data/tailscale"
-TMP_DIR="$TAILSCALE_DIR.tmp"
+LEGACY_DIR="/oem/apps/tailscale-1.92.5"
+
+# Follow the `latest` symlink to the installed version, so an older binary
+# keeps working until an upgrade replaces it with the pinned version.
+TAILSCALE_DIR="$APP_DIR/latest"
+if [[ ! -L "$TAILSCALE_DIR" || ! -e "$TAILSCALE_DIR" ]]; then
+    TAILSCALE_DIR="$LEGACY_DIR"
+fi
 
 case "$(basename "$0")" in
     tailscaled)
@@ -28,7 +35,7 @@ esac
 
 check() {
     if [[ -x "$TAILSCALE_DIR/tailscale" && -x "$TAILSCALE_DIR/tailscaled" ]]; then
-        echo "Tailscale is installed (version $VERSION)."
+        echo "Tailscale is installed."
         return 0
     else
         echo "Tailscale is not installed."
@@ -36,64 +43,93 @@ check() {
     fi
 }
 
+needs_upgrade() {
+    if [[ -L "$APP_DIR/latest" && -e "$APP_DIR/latest" ]]; then
+        [[ "$(readlink "$APP_DIR/latest")" != "tailscale-${VERSION}" ]]
+    elif check; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+upgrade() {
+    download
+}
+
+clean() {
+    echo "Removing Tailscale installation..."
+    rm -rf "$APP_DIR" "$LEGACY_DIR" "$TAILSCALE_STATE_DIR"
+    echo "Removed."
+}
+
 download() {
-    rm -rf "$TMP_DIR"
-    mkdir -p "$TMP_DIR"
+    rm -rf "$APP_DIR/tmp"
+    mkdir -p "$APP_DIR/tmp/tailscale-${VERSION}"
 
     echo "Downloading Tailscale $VERSION..."
-    if ! /usr/local/bin/curl -fSL -o "$TMP_DIR/tailscale.tgz" "$URL"; then
+    if ! /usr/local/bin/curl -fSL -o "$APP_DIR/tmp/tailscale-${VERSION}.tgz" "$URL"; then
         echo "Download failed"
         return 1
     fi
 
     echo "Verifying checksum..."
-    if ! echo "$SHA256  $TMP_DIR/tailscale.tgz" | sha256sum -c; then
+    if ! echo "$SHA256  $APP_DIR/tmp/tailscale-${VERSION}.tgz" | sha256sum -c; then
         echo "Checksum verification failed"
         return 1
     fi
 
     echo "Installing..."
-    if ! tar --strip-components=1 -xzf "$TMP_DIR/tailscale.tgz" -C "$TMP_DIR"; then
+    mkdir -p "$APP_DIR/tailscale-${VERSION}"
+    if ! tar --strip-components=1 -xzf "$APP_DIR/tmp/tailscale-${VERSION}.tgz" -C "$APP_DIR/tmp/tailscale-${VERSION}"; then
         echo "Extraction failed"
         return 1
     fi
 
-    if [[ ! -x "$TMP_DIR/tailscale" || ! -x "$TMP_DIR/tailscaled" ]]; then
+    if [[ ! -x "$APP_DIR/tmp/tailscale-${VERSION}/tailscale" || ! -x "$APP_DIR/tmp/tailscale-${VERSION}/tailscaled" ]]; then
         echo "Installation failed: binaries not found"
         return 1
     fi
 
-    rm -rf "$TAILSCALE_DIR" "$TMP_DIR/tailscale.tgz"
-
-    if ! mv "$TMP_DIR" "$TAILSCALE_DIR"; then
-        echo "Failed to move Tailscale to $TAILSCALE_DIR"
-        return 1
-    fi
-
-    echo "Tailscale $VERSION installed to $TAILSCALE_DIR"
+    rm -rf "$LEGACY_DIR" "$APP_DIR/tmp/tailscale-${VERSION}.tgz"
+    rm -rf "$APP_DIR/tailscale-"*
+    mv "$APP_DIR/tmp/tailscale-${VERSION}" "$APP_DIR/"
+    ln -sf "tailscale-${VERSION}" "$APP_DIR/latest"
+    echo "Tailscale $VERSION installed to $APP_DIR"
 }
 
 case "$1" in
     check)
         check
         ;;
+    needs_upgrade)
+        needs_upgrade
+        ;;
+    upgrade)
+        if ! upgrade; then
+            rm -rf "$APP_DIR/tmp"
+            exit 1
+        fi
+        ;;
     download)
         if check; then
             echo "Tailscale is already installed."
             exit 0
         fi
+        if ! clean; then
+            echo "Failed to clean old installation"
+            exit 1
+        fi
         if ! download; then
-            rm -rf "$TMP_DIR"
+            rm -rf "$APP_DIR"
             exit 1
         fi
         ;;
     clean)
-        echo "Removing Tailscale installation..."
-        rm -rf "$TAILSCALE_DIR" "$TAILSCALE_STATE_DIR"
-        echo "Removed."
+        clean
         ;;
     *)
-        echo "Usage: $0 check|download|clean"
+        echo "Usage: $0 check|needs_upgrade|download|upgrade|clean"
         exit 1
         ;;
 esac

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
@@ -1,3 +1,19 @@
+quick_actions:
+  upgrades:
+    items:
+      tailscale-upgrade:
+        label: Upgrade Tailscale
+        description: Download and install the latest pinned Tailscale version.
+        if_cmd: /usr/local/bin/tailscale-pkg needs_upgrade
+        confirm: "Upgrade Tailscale and restart the VPN service?"
+        cmd:
+          - bash
+          - -ec
+          - |
+            /usr/local/bin/tailscale-pkg upgrade
+            /etc/init.d/S99vpn restart
+        message: "Upgrading Tailscale..."
+
 actions:
   troubleshooting:
     items:


### PR DESCRIPTION
- Adds a `quick_actions` config section, parallel to `actions`, served via a new `/api/quick-actions` endpoint and rendered in its own "Quick Actions" card above "Quick Links" in Firmware Config
- Updates `tailscale-pkg` to install versions into `/oem/apps/tailscale/<version>` with a `latest` symlink, falling back to and migrating the legacy `/oem/apps/tailscale-1.92.5` layout, and adds a `needs_upgrade` check.
- Adds a `needs_upgrade` check and `upgrade` subcommand to `octoeverywhere-pkg` that removes old version directories before downloading the pinned version.
- Registers `tailscale-upgrade` and `octoeverywhere-upgrade` quick actions, gated on their respective `needs_upgrade` checks, that run the upgrade and restart the relevant service.

## Screenshots

<img width="867" height="520" alt="image" src="https://github.com/user-attachments/assets/0ac7d664-f3b2-4e5a-94e9-59c6bd8fdaa8" />
