### PR TITLE
Ignore `__pycache__/` directories [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tools/rk2918_tools/img_maker
 tools/rk2918_tools/img_unpack
 tools/rk2918_tools/mkkrnlimg
 _site/
+__pycache__/


### PR DESCRIPTION
Python compiles `firmware-config.py` to a `.pyc` cache under `__pycache__/`, which was getting picked up as an untracked stray directory in the working tree.