### PR TITLE
docs(ssh): document firmware-config web interface as SSH fallback

### DIFF
--- a/docs/ssh_access.md
+++ b/docs/ssh_access.md
@@ -8,6 +8,11 @@ Starting with v1.2.0, SSH access is supported natively via the printer GUI.
 
 Navigate to `Settings` > `Maintenance` > `Root Access` > Agree (scroll down to accept) > `Open`.
 
+Toggle SSH from the printer's web interface:
+
+1. Open `http://<printer-ip>/firmware-config/` in a browser.
+2. Scroll down to the SSH access section and enable it.
+
 ## Credentials
 
 - User: `root` / Password: `snapmaker`


### PR DESCRIPTION
## Summary

- Document the `http://<printer-ip>/firmware-config/` to enable SSH. The printer GUI `Root Access` toggle is not sufficient to produce a working SSH server.

## Context

Surfaced in https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/issues/441#issuecomment-4413961560, where it was reported SSH connection refused after enabling Root Access via the GUI and got it working through the web `firmware-config` page instead.