### PR TITLE
Suppress `eth0` error on WiFi-only devices in Panda Breath setup

### DIFF
--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -68,7 +68,7 @@ settings:
               - |
                 echo ""
                 echo ">> Detecting printer IP address..."
-                PRINTER_IP=$((ip -4 -o addr show eth0 || ip -4 -o addr show wlan0) | awk '{print $4}' | cut -d/ -f1)
+                PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) | awk '{print $4}' | cut -d/ -f1)
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."
@@ -117,7 +117,7 @@ settings:
               - |
                 echo ""
                 echo ">> Detecting printer IP address..."
-                PRINTER_IP=$((ip -4 -o addr show eth0 || ip -4 -o addr show wlan0) | awk '{print $4}' | cut -d/ -f1)
+                PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) | awk '{print $4}' | cut -d/ -f1)
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."


### PR DESCRIPTION
## Summary

- `ip addr show eth0` exits non-zero on WiFi-only machines, printing a visible error in the firmware-config UI before the `wlan0` fallback runs.
- Adds `2>/dev/null` to both the `eth0` and `wlan0` probes in the `auto` and `manual` Panda Breath setup commands so the subshell silently falls through to whichever interface is present.

Closes #510 (Fix 3).
