### PR TITLE
Upgrade `fluidd` to v1.37.1

### DIFF
--- a/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
+++ b/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
@@ -7,9 +7,9 @@ fi
 
 set -eo pipefail
 
-VERSION=v1.36.3
+VERSION=v1.37.1
 URL=https://github.com/fluidd-core/fluidd/releases/download/$VERSION/fluidd.zip
-SHA256=c341e43065c3a08c22ff1b5122e9e8b934c278f39df782bb476b35eed1799c5c
+SHA256=f08e9d438fdce472553e1ce46a9be62f5ababb4b0f64f65efbd4561d9379653c
 FILENAME=fluidd-$VERSION.zip
 
 rm -rf "$ROOTFS_DIR/home/lava/fluidd"


### PR DESCRIPTION
Updates the version, download URL SHA256, and filename in `01-install-fluidd.sh`.