### PR TITLE
Update OctoEverywhere to `5.1.0` and add cloud `help_url`

### DIFF
--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
@@ -5,9 +5,9 @@
 # Downloads and installs a pinned version of OctoEverywhere from GitHub
 #
 
-VERSION="4.6.8"
+VERSION="5.1.0"
 URL="https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/${VERSION}.zip"
-SHA256="fd16e88824f9b8026b1879a03a48f015f81a4f96b28448cd94fe3093ad52e750"
+SHA256="096b477882f00ad4e356716393a906b0c55c34284cf31c07693d5dea18eb4dc0"
 
 # These paths are referenced in the init.d script
 APP_DIR="/oem/apps/octoeverywhere"

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
@@ -4,6 +4,7 @@ settings:
       cloud:
         label: Cloud Access (Experimental)
         description: Enable alternative cloud access from outside your network.
+        help_url: https://snapmakeru1-extended-firmware.pages.dev/cloud
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get
@@ -50,6 +51,8 @@ settings:
                 echo "If you need help, follow this guide:"
                 echo "https://octoeverywhere.com/s/snapmaker-u1"
                 echo "Contact Support: https://octoeverywhere.com/support"
+                echo ""
+                echo "If the plugin is already connected to your account, you can ignore this message."
                 echo
 
                 for i in {1..15}; do
@@ -62,4 +65,5 @@ settings:
                 done
 
                 echo "Authorization URL not found in logs. Please check the logs for more details."
+                echo "If the plugin is already connected to your account, you can ignore this message."
         default: none


### PR DESCRIPTION
Bumps the pinned OctoEverywhere package in `octoeverywhere-pkg` from `4.6.8` to `5.1.0` (`VERSION`, derived `URL`, and verified `SHA256`) and adds a `help_url` to the Cloud Access setting in `24_settings_cloud.yaml` pointing at the extended firmware cloud docs.

Changes introduced by OctoEverywhere between `4.6.8` and `5.1.0` (releases `4.7.0` and `5.1.0`):

- Major performance improvements to webcam and remote-access streaming, especially on low-powered devices.
- Chamber light control for Bambu Lab, Elegoo Centauri Carbon, and Klipper printers.
- Snapmaker U1 support for running the plugin directly on the printer.
- Bambu Lab now surfaces error messages and sends pause notifications for gcode/user-triggered pauses.
- OctoPrint moved to the new plugin install template.
- Fixed companion plugins using the wrong target IP.
- Large reductions in RAM usage and CPU load, so the plugin runs better on less powerful devices.
