### PR TITLE
Add virtio GPU and multitouch support to QEMU dev environment

### DIFF
--- a/overlays/devel/qemu/root/etc/network/interfaces.d/eth0-hotplug
+++ b/overlays/devel/qemu/root/etc/network/interfaces.d/eth0-hotplug
@@ -1,0 +1,1 @@
+auto eth0

--- a/overlays/devel/qemu/root/etc/udev/hwdb.d/61-virtio-touch.hwdb
+++ b/overlays/devel/qemu/root/etc/udev/hwdb.d/61-virtio-touch.hwdb
@@ -1,0 +1,17 @@
+# Map the QEMU virtio multitouch device to the U1 480x320 panel range.
+#
+# NOTE: this only rewrites the *reported* axis range (absinfo). QEMU still
+# emits raw values in 0..32767, so a consumer that scales by the reported
+# max will misplace touches unless the values are also rescaled (e.g. a
+# uinput shim, or inject already-scaled values over QMP). Use this when the
+# consumer expects the chsc6540-style 0..479 / 0..319 range and you pair it
+# with value scaling.
+#
+# ABS codes: 00=ABS_X 01=ABS_Y 35=ABS_MT_POSITION_X 36=ABS_MT_POSITION_Y
+# Value format: <min>:<max>:<res>:<fuzz>:<flat>
+
+evdev:name:QEMU Virtio MultiTouch:*
+ EVDEV_ABS_00=0:479
+ EVDEV_ABS_01=0:319
+ EVDEV_ABS_35=0:479
+ EVDEV_ABS_36=0:319

--- a/overlays/devel/qemu/scripts/01-hwdb.sh
+++ b/overlays/devel/qemu/scripts/01-hwdb.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
+echo ">> Rebuilding udev hwdb inside rootfs"
+chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/udevadm hwdb --update

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -88,16 +88,16 @@ for overlay; do
     popd > /dev/null
   fi
 
+  if [[ -d "$overlay/root/" ]]; then
+    echo ">> Copying custom files..."
+    cp -rv "$overlay/root/." "$ROOTFS_DIR/"
+  fi
+
   if [[ -d "$overlay/scripts/" ]]; then
     for scriptfile in "$overlay/scripts/"*.sh; do
       echo "[+] Running script: $(basename "$scriptfile")"
       ./"$scriptfile" "$ROOTFS_DIR"
     done
-  fi
-
-  if [[ -d "$overlay/root/" ]]; then
-    echo ">> Copying custom files..."
-    cp -rv "$overlay/root/." "$ROOTFS_DIR/"
   fi
 done
 

--- a/scripts/dev/qemu.sh
+++ b/scripts/dev/qemu.sh
@@ -21,6 +21,7 @@ APPEND="console=ttyAMA0,115200 earlycon=pl011,mmio32,0x09000000"
 APPEND="$APPEND systemd.volatile=overlay ro rootwait rootfstype=squashfs root=/dev/vda"
 APPEND="$APPEND storagemedia=emmc androidboot.storagemedia=emmc androidboot.mode=normal androidboot.verifiedbootstate=orange android_slotsufix=_a vertype=rel"
 APPEND="$APPEND androidboot.fwver=ddr-v1.07-6e9ae14bbb,bl31-v1.21,bl32-v1.07,uboot-3ed3e17641-12/30/2025"
+APPEND="$APPEND video=Virtual-1:480x320 net.ifnames=0"
 
 set -e
 
@@ -61,6 +62,9 @@ qemu-system-aarch64 \
   -m 1024 \
   -serial mon:stdio \
   -display none \
+  -global virtio-mmio.force-legacy=false \
+  -device virtio-gpu-device,xres=480,yres=320 \
+  -device virtio-multitouch-device \
   -kernel "$KERNEL_FILE" \
   -append "$APPEND initcall_blacklist=rockchip_drm_init" \
   -netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2280-:80,hostfwd=tcp::2443-:443 \


### PR DESCRIPTION
Adds `virtio-gpu-device` (480×320) and `virtio-multitouch-device` to the QEMU launch command to match U1 hardware display dimensions.

`61-virtio-touch.hwdb` maps the QEMU virtio multitouch ABS axes to the chsc6540-style 0–479/0–319 range so consumers see the same coordinates as on real hardware. `01-hwdb.sh` rebuilds `udev` hwdb inside the rootfs during firmware build so the mapping is active on first boot.

`eth0-hotplug` ensures `eth0` comes up automatically via `auto eth0`.

`create_firmware.sh` now copies overlay `root/` files before running overlay scripts, so scripts can rely on those files already being present.