### PR TITLE
Disable access log for `/screen/snapshot`

### DIFF
--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
@@ -13,6 +13,7 @@ location /screen/snapshot {
     proxy_pass http://127.0.0.1:8092/snapshot;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    access_log off;
 }
 
 location /screen/touch {


### PR DESCRIPTION
Suppresses per-request logging on the high-frequency snapshot endpoint to avoid log spam.