### PR TITLE
Disable `access_log` globally in mainsail nginx config

### DIFF
--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
@@ -13,7 +13,6 @@ location /screen/snapshot {
     proxy_pass http://127.0.0.1:8092/snapshot;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
-    access_log off;
 }
 
 location /screen/touch {

--- a/overlays/firmware-extended/63-app-mainsail/root/etc/nginx/sites-available/mainsail
+++ b/overlays/firmware-extended/63-app-mainsail/root/etc/nginx/sites-available/mainsail
@@ -5,7 +5,7 @@ server {
     # uncomment the next line to activate IPv6
     # listen [::]:80 default_server;
 
-    # access_log /var/log/nginx/mainsail-access.log;
+    access_log off;
     error_log /var/log/nginx/mainsail-error.log;
 
     # disable this section on smaller hardware like a pi zero


### PR DESCRIPTION
Replaces the previously reverted per-location `access_log` suppression
for `/screen/snapshot` with a server-level `access_log off;` directive.
This silences all access logging for the mainsail vhost, avoiding log
spam from high-frequency polling endpoints without needing per-location
overrides.

This fixes bug where mainsail would have access log, and fluidd not.
