### PR TITLE
Updating the OctoEverywhere to `5.1.1`

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
@@ -23,12 +23,6 @@ settings:
                   echo "Please switch to Fluidd first."
                   exit 1
                 fi
-                CLOUD=$(/usr/local/bin/extended-config.py get /home/lava/printer_data/config/extended/extended2.cfg remote_access cloud none)
-                if [ "$CLOUD" = "octoeverywhere" ]; then
-                  echo "ERROR: OctoEverywhere companion mode is incompatible with authentication."
-                  echo "Disable OctoEverywhere first to enable authentication."
-                  exit 1
-                fi
                 URL="http://127.0.0.1:7125"
                 echo "Deleting existing admin user..."
                 /usr/local/bin/curl -s -X DELETE "$URL/access/user" -H "Content-Type: application/json" -d '{"username": "admin"}' > /dev/null 2>&1

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
@@ -4,10 +4,11 @@
 # OctoEverywhere package manager
 # Downloads and installs a pinned version of OctoEverywhere from GitHub
 #
+# $version = "5.1.1"; $artifact = Join-Path $env:TEMP "OctoPrint-OctoEverywhere-${version}.zip"; Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/${version}.zip" -OutFile $artifact; Get-FileHash -Algorithm SHA256 -LiteralPath $artifact | Select-Object -ExpandProperty Hash
 
-VERSION="5.1.0"
+VERSION="5.1.1"
 URL="https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/${VERSION}.zip"
-SHA256="096b477882f00ad4e356716393a906b0c55c34284cf31c07693d5dea18eb4dc0"
+SHA256="264f3fd3b1b1f326cfc019e7716b6ffa8759658852ce076b94022ef7da40f8fe"
 
 # These paths are referenced in the init.d script
 APP_DIR="/oem/apps/octoeverywhere"

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/sbin/octoeverywhered
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/sbin/octoeverywhered
@@ -11,7 +11,7 @@ if [[ ! -e "$PYTHON" ]]; then
 fi
 
 if [[ ! -e "$DIR" ]]; then
-    echo "Error: OctoEverywhere daemon not found at $DAEMON"
+    echo "Error: OctoEverywhere daemon not found at $DIR"
     exit 1
 fi
 
@@ -20,16 +20,19 @@ if [[ ! -e "$STATE_DIR" ]]; then
     exit 1
 fi
 
+# IsCompanion = false ensures OE can work with authenticated Moonraker, while DisableMoonrakerConfigFileWrites makes sure we don't edit the moonraker.conf file.
 config_json() {
     cat <<"EOF"
 {
+    "MoonrakerConfigFile": "/home/lava/printer_data/config/moonraker.conf",
     "ConfigFolder": "/home/lava/printer_data/config",
     "LogFolder": "/home/lava/printer_data/logs",
     "LocalFileStoragePath": "/home/lava/printer_data/octoeverywhere-store",
     "ServiceName": "octoeverywhere",
     "VirtualEnvPath": "/oem/apps/octoeverywhere/venv",
     "RepoRootFolder": "/oem/apps/octoeverywhere/latest",
-    "IsCompanion": true
+    "IsCompanion": false,
+    "DisableMoonrakerConfigFileWrites": true,
 }
 EOF
 }

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
@@ -29,11 +29,6 @@ settings:
               - bash
               - -ec
               - |
-                if test -f /oem/printer_data/config/extended/moonraker/authorization.cfg; then
-                  echo "ERROR: Authentication is incompatible with OctoEverywhere companion mode."
-                  echo "Disable authentication first to enable OctoEverywhere."
-                  exit 1
-                fi
                 echo "WARNING: OctoEverywhere support is experimental. Higher resource usage may affect print quality."
                 sleep 5
 


### PR DESCRIPTION
Bumps the pinned OctoEverywhere package in octoeverywhere-pkg from 5.1.0 to 5.1.1 (VERSION, derived URL, and verified SHA256), removes blocks regarding OctoEverywhere not working with local Moonraker auth, and sets the `IsCompanion=true`, `DisableMoonrakerConfigFileWrites=true` to enable support for local auth **without** allowing the plugin to edit the `moonraker.conf` file.

Changes introduced by OctoEverywhere between 5.1.0 and 5.1.1:

- Fixed current layer query logic for Klipper-based 3D printers.
- Added printing substate strings for the Snapmaker U1
- Added better error and pause notification context for all Klipper-based 3D printers (including the U1).
- Added a new `DisableMoonrakerConfigFileWrites` to prevent the plugin from editing the `moonraker.conf`.