### PR TITLE
Prepare `v1.4.1-paxx12-20`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ Quick steps:
 
 ## Troubleshooting
 
-- **Klipper failed to start**: Open Firmware Config at `http://IP/firmware-config`, go to `Recovery` and select `Reset Extended to Defaults`. This will reset all extended settings and reboot the printer.
+- **Custom extensions installed via SSH**: Installing third-party extensions or modifications over SSH (for example [helixscreen](https://github.com/prestonbrown/helixscreen)) can break the system. Because such changes are made outside the supported extended configuration, the built-in recovery may not undo them, and in some cases the system becomes very hard to recover. Do this only if you understand the risks and know how to restore the printer. If something breaks, try recovery in order: first `extended-recover.txt` (resets extended configuration), then `full-recover.txt` (also clears persisted changes, printer data and the debug flag), and only if neither works, reflash stock firmware via the [Snapmaker U1 Wiki](https://wiki.snapmaker.com/en/snapmaker_u1/firmware/release_notes).
 
 ## Revert
 

--- a/docs/design/filament_detect.md
+++ b/docs/design/filament_detect.md
@@ -31,7 +31,8 @@ Writable fields:
 | `HOTEND_MIN_TEMP` | `int` | Integer | |
 | `HOTEND_MAX_TEMP` | `int` | Integer | |
 | `BED_TEMP` | `int` | Integer | |
-| `CARD_UID` | `list[int]` | Array of byte ints | |
+| `CARD_UID` | `list[int]` | Array of byte ints | Indicates a tag is physically present; independent of filament data |
+| `CARD_TYPE` | `string` | `NTAG`, `M1` | Tag hardware type; independent of filament data |
 | `SKU` | `int` | Integer | |
 
 Read-only fields (returned by query, not accepted by `set`):
@@ -39,7 +40,7 @@ Read-only fields (returned by query, not accepted by `set`):
 | Field | Notes |
 |---|---|
 | `ARGB_COLOR` | Derived: `(ALPHA << 24) \| RGB_1` |
-| `OFFICIAL` | `true` when `info` is non-empty (set by firmware) |
+| `OFFICIAL` | `true` when `info` contains at least one filament field other than `CARD_UID` |
 | `MANUFACTURER` | |
 | `VERSION` | |
 | `TRAY` | |
@@ -84,12 +85,33 @@ Request shape:
 | Field | Required | Type | Accepted values |
 |---|---|---|---|
 | `channel` | Yes | `int` | `0..3` |
-| `info` | No | `object` | If missing/empty, treated as clear/reset |
+| `info` | No | `object` | See set semantics below |
 
 Response:
 
 - Success: `{"state": "success"}`
 - Error: `{"state": "error", "message": "..."}`
+
+### Set semantics
+
+The endpoint has three modes determined by the filament fields present in `info`. `CARD_UID` is orthogonal — it can appear in any mode to record that a physical tag is present, even when the tag carries no filament data:
+
+| Mode | `info` content | `OFFICIAL` | Update path |
+|---|---|---|---|
+| Full update | One or more filament fields (± `CARD_UID`) | `true` | `_filament_info_update` called; `print_task_config` mirrored |
+| Tag present, no data | `CARD_UID` only | `false` | Direct assignment; if the slot was previously official, `_filament_info_update` is called to clear it |
+| Clear | Missing or empty | `false` | Direct assignment; filament fields reset to `FILAMENT_INFO_STRUCT` defaults |
+
+`CARD_UID` and `CARD_TYPE` are both popped before `has_params` is computed, so they never contribute to `OFFICIAL`. `CARD_TYPE` is populated automatically on hardware reads (`NTAG` via `filament_protocol_ndef`, `M1` via `filament_protocol`).
+
+## openrfid Integration
+
+`openrfid_u1_base.cfg` registers two webhook exporters that drive `filament_detect/set` automatically:
+
+| Exporter | Event | Payload | Effect |
+|---|---|---|---|
+| `parse_error_exporter` | `tag_parse_error` | `{"channel": N, "info": {"CARD_UID": [...]}}` | UID-only set; captures the hardware UID even when the tag payload cannot be decoded |
+| `not_present_exporter` | `tag_not_present` | `{"channel": N}` | Clear; resets the slot when no tag is present |
 
 ## OpenSpool U1 Extended Format Input
 
@@ -270,9 +292,10 @@ Transformation trace for this example:
 
 Repository overlays:
 
-- `overlays/firmware-extended/13-rfid-support/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py`
-- `overlays/firmware-extended/13-rfid-support/patches/02-add-ndef-protocol.patch`
-- `overlays/firmware-extended/13-rfid-support/patches/05-add-filament-detect-set-endpoint.patch`
+- `overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py`
+- `overlays/firmware-extended/13-patch-rfid/patches/02-add-ndef-protocol.patch`
+- `overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch`
+- `overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg`
 
 Klipper source code:
 

--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -281,6 +281,47 @@ If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
 4. The extended configuration will be backed up to `extended.backup.N` and reset to defaults
 5. Remove the USB drive (the recovery file will be automatically deleted)
 
+On Windows with "Hide extensions for known file types" enabled, the file may be
+saved as `extended-recover.txt.txt`. Both names are recognised.
+
+### Full Recovery
+
+If the extended reset above is not enough — for example a persisted change or
+`/oem/.debug` flag keeps a broken state across reboots — use full recovery. In
+addition to resetting the extended configuration, it removes `/oem/.printer_data`
+and `/oem/.debug`, then reboots so the overlay (`S01aoverlayfs`) and printer data
+(`S48setup-lava-env`) are rebuilt from defaults on the next boot.
+
+1. Create an empty file named `full-recover.txt` on a USB drive
+   (`full-recover.txt.txt` is also recognised)
+2. Insert the USB drive into the printer
+3. Restart the printer
+4. The printer removes the recovery file, clears the persistence and debug flags,
+   flags the extended configuration for reset, and reboots
+5. Remove the USB drive
+
+**Important:** Full recovery resets ALL extended configuration and clears
+persisted changes and printer data. Use it only when a normal
+`extended-recover.txt` reset does not resolve the issue.
+
+### Custom Extensions Installed via SSH
+
+The recovery methods above only reset changes made through the supported extended
+configuration. Installing third-party extensions or modifications over SSH (for
+example [helixscreen](https://github.com/prestonbrown/helixscreen)) writes files
+outside that mechanism, so neither `extended-recover.txt` nor `full-recover.txt`
+is guaranteed to undo them. Such changes can break the system, and in some cases
+make it very hard to recover.
+
+Only install custom extensions over SSH if you understand the risks and know how
+to restore the printer. If something breaks, try recovery in this order:
+
+1. `extended-recover.txt` — resets the extended configuration only
+2. `full-recover.txt` — also clears persisted changes, printer data and the debug
+   flag, then reboots
+3. Reflash stock or extended firmware (see [Installation Guide](install.md)) if
+   neither recovery method fixes the problem
+
 ## Related Documentation
 
 - [Camera Support](camera_support.md) - Camera features and WebRTC streaming

--- a/docs/rfid_support.md
+++ b/docs/rfid_support.md
@@ -142,6 +142,7 @@ To enable it, navigate to the [firmware-config](firmware_config.md) web interfac
 | [OpenSpool](https://openspool.io/) | Yes | - |
 | TigerTag | Yes | Fully offline implementation |
 | Qidi | Yes | - |
+| [SpoolEase](https://spoolease.io/) | No | NTAG NDEF tags; enable the processor to use |
 
 ### Bambu / Creality Spool Configuration
 
@@ -178,6 +179,13 @@ Enable them by removing the `#` prefix from the tag processor.
 
 ```
 # [elegoo_tag_processor]
+```
+
+[SpoolEase](https://spoolease.io/) tags (NTAG NDEF) are also supported but not
+enabled by default. Add the processor to the same file to use them:
+
+```ini
+[spoolease_tag_processor]
 ```
 
 ## Troubleshooting

--- a/docs/ssh_access.md
+++ b/docs/ssh_access.md
@@ -8,6 +8,11 @@ Starting with v1.2.0, SSH access is supported natively via the printer GUI.
 
 Navigate to `Settings` > `Maintenance` > `Root Access` > Agree (scroll down to accept) > `Open`.
 
+Toggle SSH from the printer's web interface:
+
+1. Open `http://<printer-ip>/firmware-config/` in a browser.
+2. Scroll down to the SSH access section and enable it.
+
 ## Credentials
 
 - User: `root` / Password: `snapmaker`

--- a/overlays/devel/qemu/root/etc/network/interfaces.d/eth0-hotplug
+++ b/overlays/devel/qemu/root/etc/network/interfaces.d/eth0-hotplug
@@ -1,0 +1,1 @@
+auto eth0

--- a/overlays/devel/qemu/root/etc/udev/hwdb.d/61-virtio-touch.hwdb
+++ b/overlays/devel/qemu/root/etc/udev/hwdb.d/61-virtio-touch.hwdb
@@ -1,0 +1,17 @@
+# Map the QEMU virtio multitouch device to the U1 480x320 panel range.
+#
+# NOTE: this only rewrites the *reported* axis range (absinfo). QEMU still
+# emits raw values in 0..32767, so a consumer that scales by the reported
+# max will misplace touches unless the values are also rescaled (e.g. a
+# uinput shim, or inject already-scaled values over QMP). Use this when the
+# consumer expects the chsc6540-style 0..479 / 0..319 range and you pair it
+# with value scaling.
+#
+# ABS codes: 00=ABS_X 01=ABS_Y 35=ABS_MT_POSITION_X 36=ABS_MT_POSITION_Y
+# Value format: <min>:<max>:<res>:<fuzz>:<flat>
+
+evdev:name:QEMU Virtio MultiTouch:*
+ EVDEV_ABS_00=0:479
+ EVDEV_ABS_01=0:319
+ EVDEV_ABS_35=0:479
+ EVDEV_ABS_36=0:319

--- a/overlays/devel/qemu/scripts/01-hwdb.sh
+++ b/overlays/devel/qemu/scripts/01-hwdb.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
+echo ">> Rebuilding udev hwdb inside rootfs"
+chroot_firmware.sh "$ROOTFS_DIR" /usr/bin/udevadm hwdb --update

--- a/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S49extended-config
+++ b/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S49extended-config
@@ -4,7 +4,24 @@ DEFAULT_DIR="/usr/local/share/firmware-config/extended"
 EXTENDED_DIR="/home/lava/printer_data/config/extended"
 
 start() {
-    if [ -f /mnt/udisk/extended-recover.txt ] || [ -f /oem/.extended-recover ]; then
+    # `.txt.txt` covers Windows users with "Hide extensions for known file types" enabled,
+    # who type `extended-recover.txt`/`full-recover.txt` but get a double extension from Explorer.
+
+    # Full recovery clears the extended config, printer data and the debug/overlay
+    # persistence flag, then reboots so the cleared flags take effect: `/oem/.debug`
+    # is read by `S01aoverlayfs` and `/oem/.printer_data` by `S48setup-lava-env`,
+    # both of which run before this script, so the reset only applies on next boot.
+    if [ -f /mnt/udisk/full-recover.txt ] || [ -f /mnt/udisk/full-recover.txt.txt ] || [ -f /oem/.full-recover ]; then
+        echo "Performing full recovery: removing extended config, printer data and debug flag, then rebooting..."
+        rm -f /mnt/udisk/full-recover.txt /mnt/udisk/full-recover.txt.txt /oem/.full-recover
+        rm -f /oem/.printer_data /oem/.debug
+        touch /oem/.extended-recover
+        sync
+        /sbin/reboot
+        exit 0
+    fi
+
+    if [ -f /mnt/udisk/extended-recover.txt ] || [ -f /mnt/udisk/extended-recover.txt.txt ] || [ -f /oem/.extended-recover ]; then
         # Move existing extended config to a backup location
         # find the next available backup number
         if [ -d "$EXTENDED_DIR" ]; then
@@ -14,7 +31,7 @@ start() {
             done
             mv "$EXTENDED_DIR" "$EXTENDED_DIR.backup.$BACKUP_NUM"
         fi
-        rm -f /mnt/udisk/extended-recover.txt /oem/.extended-recover
+        rm -f /mnt/udisk/extended-recover.txt /mnt/udisk/extended-recover.txt.txt /oem/.extended-recover
     fi
 
     mkdir -p "$EXTENDED_DIR"

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
@@ -23,7 +23,7 @@ def deep_merge(base, override):
 
 def load_functions_from_dir(functions_dir):
     """Load and deep merge all YAML files from a directory in sorted order."""
-    config = {'links': {}, 'settings': {}, 'actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
+    config = {'links': {}, 'settings': {}, 'actions': {}, 'quick_actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
 
     if not os.path.isdir(functions_dir):
         log(f"Functions directory not found: {functions_dir}")
@@ -58,7 +58,7 @@ def shell_to_cmd(shell, *args):
 
 class FirmwareConfigHandler(SimpleHTTPRequestHandler):
     html_dir = None
-    functions = {'settings': {}, 'links': {}, 'actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
+    functions = {'settings': {}, 'links': {}, 'actions': {}, 'quick_actions': {}, 'status': {}, 'upgrade_url': {}, 'upgrade_upload': {}}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=self.html_dir, **kwargs)
@@ -74,8 +74,10 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
             self.handle_get_settings()
         elif path == "/api/links":
             self.handle_get_links()
+        elif path == "/api/quick-actions":
+            self.handle_get_actions('quick_actions')
         elif path == "/api/actions":
-            self.handle_get_actions()
+            self.handle_get_actions('actions')
         else:
             super().do_GET()
 
@@ -380,22 +382,26 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
             self.send_error(500, str(e))
 
     def _get_action_config(self, action_key):
-        actions = self.functions.get('actions', {})
-        for group_key, group_cfg in actions.items():
-            items = group_cfg.get('items', {})
-            if action_key in items:
-                return items[action_key]
+        for actions_cfg in (self.functions.get('quick_actions', {}), self.functions.get('actions', {})):
+            for group_key, group_cfg in actions_cfg.items():
+                items = group_cfg.get('items', {})
+                if action_key in items:
+                    return items[action_key]
         return None
 
-    def handle_get_actions(self):
+    def handle_get_actions(self, key):
         try:
-            actions_cfg = self.functions.get('actions', {})
+            actions_cfg = self.functions.get(key, {})
             result = {}
             for group_key, group_cfg in actions_cfg.items():
                 group_label = group_cfg.get('label', group_key)
                 items = group_cfg.get('items', {})
                 actions_list = []
                 for action_id, cfg in items.items():
+                    if_cmd = cfg.get('if_cmd')
+                    if if_cmd and not self._check_condition(if_cmd):
+                        continue
+
                     actions_list.append({
                         "id": action_id,
                         "label": cfg.get("label", action_id),
@@ -414,7 +420,7 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
 
             self.send_json(result)
         except Exception as e:
-            log(f"Get actions error: {e}")
+            log(f"Get {key} error: {e}")
             self.send_error(500, str(e))
 
     def handle_update_setting(self, setting_key, value):

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
@@ -1,3 +1,7 @@
+quick_actions:
+  upgrades:
+    label: Upgrades
+
 actions:
   troubleshooting:
     label: Troubleshooting

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -108,6 +108,11 @@
             <div id="status-container" class="info-grid"><div class="loading"><span class="spinner"></span> Loading...</div></div>
         </div>
 
+        <div class="card" id="quick-actions-card" style="display:none">
+            <div class="card-header"><span class="card-title">Quick Actions</span></div>
+            <div id="quick-actions-container"><div class="loading"><span class="spinner"></span> Loading...</div></div>
+        </div>
+
         <div class="card">
             <div class="card-header"><span class="card-title">Quick Links</span></div>
             <div id="links-container" class="links-grid"><div class="loading"><span class="spinner"></span> Loading...</div></div>
@@ -276,13 +281,23 @@
             }
         }
 
-        async function loadActions() {
-            const container = $('actions-container');
+        async function loadActions(containerId, apiPath, cardId) {
+            const container = $(containerId);
+            const card = cardId ? $(cardId) : null;
             try {
-                const grouped = await (await apiFetch('api/actions')).json();
-                actionsData = Object.values(grouped).flatMap(g => g.items);
+                const grouped = await (await apiFetch(apiPath)).json();
 
-                container.innerHTML = Object.entries(grouped).map(([_, group]) =>
+                if (card) {
+                    if (Object.keys(grouped).length === 0) {
+                        card.style.display = 'none';
+                        return;
+                    }
+                    card.style.display = 'block';
+                }
+
+                const groupActions = Object.values(grouped).flatMap(g => g.items);
+                actionsData.push(...groupActions);
+                container.innerHTML = Object.values(grouped).map(group =>
                     `<div class="group-section">
                         <div class="group-title">${group.label}</div>
                         ${group.items.filter(action => !action.hidden || showHidden).map(action =>
@@ -297,6 +312,7 @@
                     </div>`
                 ).join('');
             } catch (e) {
+                if (card) card.style.display = 'block';
                 container.innerHTML = `<div class="loading" style="color:var(--error)">Error: ${e.message}</div>`;
             }
         }
@@ -670,6 +686,7 @@
             try {
                 const resp = await apiFetch(`api/action/${id}`, { method: 'POST' });
                 await streamResponse(resp, id);
+                refreshAll();
             } catch (e) {
                 appendLog(`\nERROR: ${e.message}`);
                 setMessage('Failed', 'var(--error)');
@@ -800,8 +817,15 @@
             const btn = document.querySelector('h1 .btn');
             btn.innerHTML = '<span class="spinner"></span> Refresh';
             btn.disabled = true;
+            actionsData = [];
             try {
-                await Promise.all([loadStatus(), loadLinks(), loadSettings(), loadActions()]);
+                await Promise.all([
+                    loadStatus(),
+                    loadLinks(),
+                    loadSettings(),
+                    loadActions('quick-actions-container', 'api/quick-actions', 'quick-actions-card'),
+                    loadActions('actions-container', 'api/actions')
+                ]);
             } finally {
                 btn.innerHTML = '&#x21bb; Refresh';
                 btn.disabled = false;

--- a/overlays/firmware-extended/11-patch-klipper/patches/home/lava/klipper/07_aht10_mainline_klipper.patch
+++ b/overlays/firmware-extended/11-patch-klipper/patches/home/lava/klipper/07_aht10_mainline_klipper.patch
@@ -1,0 +1,336 @@
+From 355b6cee8cbd0f7ddc886525b6b468470bf30c2b Mon Sep 17 00:00:00 2001
+From: minicx <minicx@disroot.org>
+Date: Sat, 15 Nov 2025 15:31:37 +0300
+Subject: [PATCH 1/3] aht10: Fix status bit masks
+
+Signed-off-by: Lev Voronov <minicx@disroot.org>
+---
+ klippy/extras/aht10.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/klippy/extras/aht10.py b/klippy/extras/aht10.py
+index 001f7e54d..c4773be3a 100644
+--- a/klippy/extras/aht10.py
++++ b/klippy/extras/aht10.py
+@@ -91,8 +91,8 @@ class AHT10:
+                                     " expected 6 [%d]"%len(data))
+                     continue
+ 
+-                self.is_calibrated = True if (data[0] & 0b00000100) else False
+-                is_busy = True if (data[0] & 0b01000000) else False
++                self.is_calibrated = True if (data[0] & 0b00001000) else False
++                is_busy = True if (data[0] & 0b10000000) else False
+ 
+             if is_busy:
+                 return False
+-- 
+2.32.0.windows.1
+
+
+From 1f43be0b8b55d90753578d06ac06356d1ab9a768 Mon Sep 17 00:00:00 2001
+From: minicx <minicx@disroot.org>
+Date: Sat, 15 Nov 2025 15:34:43 +0300
+Subject: [PATCH 2/3] aht10: Add support for AHT2x/AHT3x families
+
+Split into three classes with proper init commands:
+- AHT1x: 0xE1 (AHT10, AHT15)
+- AHT2x: 0xBE (AHT20, AHT21, AHT25)
+- AHT3x: auto-cal (AHT30)
+
+Signed-off-by: Lev Voronov <minicx@disroot.org>
+---
+ klippy/extras/aht10.py | 167 +++++++++++++++++++++++++----------------
+ 1 file changed, 102 insertions(+), 65 deletions(-)
+
+diff --git a/klippy/extras/aht10.py b/klippy/extras/aht10.py
+index c4773be3a..6e4b5562e 100644
+--- a/klippy/extras/aht10.py
++++ b/klippy/extras/aht10.py
+@@ -1,6 +1,7 @@
+-# AHT10/AHT20/AHT21 I2c-based humiditure sensor support
++# Support for AHTxx family I2C temperature and humidity sensors
+ #
+ # Copyright (C) 2023 Scott Mudge <mail@scottmudge.com>
++# Copyright (C) 2025 Lev Voronov <minicx@disroot.org>
+ #
+ # This file may be distributed under the terms of the GNU GPLv3 license.
+ import logging
+@@ -9,49 +10,67 @@ from . import bus
+ ######################################################################
+ # Compatible Sensors:
+ #       AHT10      -    Tested w/ BTT GTR 1.0 MCU on i2c3
+-#       AHT20      -    Untested but should work
++#       AHT20      -    Tested w/ N32G455 on i2c2
+ #       AHT21      -    Tested w/ BTT GTR 1.0 MCU on i2c3
++#       AHT30      -    Untested, but should work
+ ######################################################################
+ 
+-AHT10_I2C_ADDR= 0x38
++I2C_ADDR = 0x38
+ 
+-AHT10_COMMANDS = {
+-    'INIT'              :[0xE1, 0x08, 0x00],
+-    'MEASURE'           :[0xAC, 0x33, 0x00],
+-    'RESET'             :[0xBA, 0x08, 0x00]
+-}
++CMD_MEASURE = [0xAC, 0x33, 0x00]
++CMD_RESET = [0xBA]
++CMD_INIT_AHT1X = [0xE1, 0x08, 0x00]
++CMD_INIT_AHT2X = [0xBE, 0x08, 0x00]
+ 
+-AHT10_MAX_BUSY_CYCLES= 5
++# Status bits
++STATUS_BUSY = 0x80
++STATUS_CALIBRATED = 0x08
++
++MAX_BUSY_CYCLES = 5
++
++class AHTBase:
++    model = None
+ 
+-class AHT10:
+     def __init__(self, config):
+         self.printer = config.get_printer()
+         self.name = config.get_name().split()[-1]
+         self.reactor = self.printer.get_reactor()
+         self.i2c = bus.MCU_I2C_from_config(
+-            config, default_addr=AHT10_I2C_ADDR, default_speed=100000)
+-        self.report_time = config.getint('aht10_report_time',30,minval=5)
++            config, default_addr=I2C_ADDR, default_speed=100000)
++        self.report_time = config.getint('aht10_report_time', 30, minval=5)
+         self.temp = self.min_temp = self.max_temp = self.humidity = 0.
+-        self.sample_timer = self.reactor.register_timer(self._sample_aht10)
++        self.sample_timer = self.reactor.register_timer(self._sample_aht)
++
+         self.printer.add_object("aht10 " + self.name, self)
+         self.printer.register_event_handler("klippy:connect",
+-                                            self.handle_connect)
+-        self.is_calibrated  = False
++                                                self.handle_connect)
++        self.is_calibrated = False
+         self.init_sent = False
++        self._callback = None
+ 
+     def handle_connect(self):
+-        self._init_aht10()
++        self._init_sensor()
+         self.reactor.update_timer(self.sample_timer, self.reactor.NOW)
+ 
+-    def setup_minmax(self, min_temp, max_temp):
+-        self.min_temp = min_temp
+-        self.max_temp = max_temp
++    def _send_init(self):
++        raise NotImplementedError("Subclass must implement _send_init")
+ 
+-    def setup_callback(self, cb):
+-        self._callback = cb
++    def _init_sensor(self):
++        self._send_init()
+ 
+-    def get_report_time_delta(self):
+-        return self.report_time
++        self.init_sent = True
++
++        if self._make_measurement():
++            if not self.is_calibrated:
++                logging.warning("%s %s: not calibrated, possible OTP fault"
++                                % (self.model, self.name))
++            logging.info("%s %s: successfully initialized, "
++                         "initial temp: %.3f, humidity: %.3f"
++                         % (self.model, self.name, self.temp, self.humidity))
++    def _soft_reset(self):
++        logging.info("%s %s: performing soft reset" % (self.model, self.name))
++        self.i2c.i2c_write(CMD_RESET)
++        self.reactor.pause(self.reactor.monotonic() + 0.020)
+ 
+     def _make_measurement(self):
+         if not self.init_sent:
+@@ -66,45 +85,51 @@ class AHT10:
+             while is_busy:
+                 # Check if we're constantly busy. If so, send soft-reset
+                 # and issue warning.
+-                if is_busy and cycles > AHT10_MAX_BUSY_CYCLES:
+-                    logging.warning("aht10: device reported busy after " +
+-                        "%d cycles, resetting device"% AHT10_MAX_BUSY_CYCLES)
+-                    self._reset_device()
++                if is_busy and cycles > MAX_BUSY_CYCLES:
++                    logging.warning("%s %s: device reported busy after "
++                                    "%d cycles, resetting device"
++                                    % (self.model, self.name, MAX_BUSY_CYCLES))
++                    self._soft_reset()
+                     data = None
+                     break
+ 
+                 cycles += 1
+                 # Write command for updating temperature+status bit
+-                self.i2c.i2c_write(AHT10_COMMANDS['MEASURE'])
++                self.i2c.i2c_write(CMD_MEASURE)
+                 # Wait 110ms after first read, 75ms minimum
+                 self.reactor.pause(self.reactor.monotonic() + .110)
+ 
+-                # Read data
++                # Read 6 bytes of data
+                 read = self.i2c.i2c_read([], 6)
+                 if read is None:
+-                    logging.warning("aht10: received data from" +
+-                                    " i2c_read is None")
++                    logging.warning("%s %s: received data from i2c_read is None"
++                                    % (self.model, self.name))
+                     continue
++
+                 data = bytearray(read['response'])
+                 if len(data) < 6:
+-                    logging.warning("aht10: received bytes less than" +
+-                                    " expected 6 [%d]"%len(data))
++                    logging.warning("%s %s: received bytes less than expected:"
++                                    " got %d, need 6"
++                                    % (self.model, self.name, len(data)))
+                     continue
+ 
+-                self.is_calibrated = True if (data[0] & 0b00001000) else False
+-                is_busy = True if (data[0] & 0b10000000) else False
++                self.is_calibrated = bool(data[0] & STATUS_CALIBRATED)
++                is_busy = bool(data[0] & STATUS_BUSY)
+ 
+             if is_busy:
+                 return False
+         except Exception as e:
+-            logging.exception("aht10: exception encountered" +
+-                              " reading data: %s"%str(e))
++            logging.exception("%s %s: exception encountered reading data: %s"
++                              % (self.model, self.name, str(e)))
+             return False
+ 
+-        temp = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5]
+-        self.temp = ((temp*200) / 1048576) - 50
+-        hum = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4
+-        self.humidity = int(hum * 100 / 1048576)
++        # Parse temperature: 20 bits starting at data[3] (low nibble)
++        temp_raw = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5]
++        self.temp = ((temp_raw * 200.0) / 1048576.0) - 50.0
++
++        # Parse humidity: 20 bits starting at data[1]
++        hum_raw = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4
++        self.humidity = int(hum_raw * 100 / 1048576)
+ 
+         # Clamp humidity
+         if (self.humidity > 100):
+@@ -114,49 +139,61 @@ class AHT10:
+ 
+         return True
+ 
+-    def _reset_device(self):
+-        if not self.init_sent:
+-            return
+-
+-        # Reset device
+-        self.i2c.i2c_write(AHT10_COMMANDS['RESET'])
+-        # Wait 100ms after reset
+-        self.reactor.pause(self.reactor.monotonic() + .10)
+-
+-    def _init_aht10(self):
+-        # Init device
+-        self.i2c.i2c_write(AHT10_COMMANDS['INIT'])
+-        # Wait 100ms after init
+-        self.reactor.pause(self.reactor.monotonic() + .10)
+-        self.init_sent = True
+-
+-        if self._make_measurement():
+-            logging.info("aht10: successfully initialized, initial temp: " +
+-                         "%.3f, humidity: %.3f"%(self.temp, self.humidity))
+-
+-    def _sample_aht10(self, eventtime):
++    def _sample_aht(self, eventtime):
+         if not self._make_measurement():
+             self.temp = self.humidity = .0
+             return self.reactor.NEVER
+ 
+         if self.temp < self.min_temp or self.temp > self.max_temp:
+             self.printer.invoke_shutdown(
+-                "AHT10 temperature %0.1f outside range of %0.1f:%.01f"
+-                % (self.temp, self.min_temp, self.max_temp))
++                "%s temperature %.1f outside range of %.1f:%.1f" %
++                (self.model.upper(), self.temp, self.min_temp, self.max_temp))
+ 
+         measured_time = self.reactor.monotonic()
+         print_time = self.i2c.get_mcu().estimated_print_time(measured_time)
+         self._callback(print_time, self.temp)
+         return measured_time + self.report_time
+ 
++    def setup_minmax(self, min_temp, max_temp):
++        self.min_temp = min_temp
++        self.max_temp = max_temp
++
++    def setup_callback(self, cb):
++        self._callback = cb
++
++    def get_report_time_delta(self):
++        return self.report_time
++
+     def get_status(self, eventtime):
+         return {
+             'temperature': round(self.temp, 2),
+             'humidity': self.humidity,
+         }
+ 
++class AHT1x(AHTBase):
++    model = "aht1x"
++
++    def _send_init(self):
++        self.i2c.i2c_write(CMD_INIT_AHT1X)
++        self.reactor.pause(self.reactor.monotonic() + 0.040)
++
++class AHT2x(AHTBase):
++    model = "aht2x"
++
++    def _send_init(self):
++        self.i2c.i2c_write(CMD_INIT_AHT2X)
++        self.reactor.pause(self.reactor.monotonic() + 0.100)
++
++class AHT3x(AHTBase):
++    model = "aht3x"
++
++    def _send_init(self):
++        # Wait for auto-calibration at power-on
++        self.reactor.pause(self.reactor.monotonic() + 0.100)
+ 
+ def load_config(config):
+     # Register sensor
+     pheater = config.get_printer().lookup_object("heaters")
+-    pheater.add_sensor_factory("AHT10", AHT10)
++    pheater.add_sensor_factory("AHT1X", AHT1x)
++    pheater.add_sensor_factory("AHT2X", AHT2x)
++    pheater.add_sensor_factory("AHT3X", AHT3x)
+-- 
+2.32.0.windows.1
+
+
+From 9ac90f8752ce4b9d0e875ede07f7ba5efff085b1 Mon Sep 17 00:00:00 2001
+From: minicx <minicx@disroot.org>
+Date: Thu, 27 Nov 2025 10:44:56 +0300
+Subject: [PATCH 3/3] aht10: Add AHT10 as alias for AHT1X for backwards
+ compatibility
+
+Signed-off-by: Lev Voronov <minicx@disroot.org>
+---
+ klippy/extras/aht10.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/klippy/extras/aht10.py b/klippy/extras/aht10.py
+index 6e4b5562e..ead58fbce 100644
+--- a/klippy/extras/aht10.py
++++ b/klippy/extras/aht10.py
+@@ -194,6 +194,10 @@ class AHT3x(AHTBase):
+ def load_config(config):
+     # Register sensor
+     pheater = config.get_printer().lookup_object("heaters")
++
++    # Backwards compatibility alias
++    pheater.add_sensor_factory("AHT10", AHT1x)
++
+     pheater.add_sensor_factory("AHT1X", AHT1x)
+     pheater.add_sensor_factory("AHT2X", AHT2x)
+     pheater.add_sensor_factory("AHT3X", AHT3x)
+-- 
+2.32.0.windows.1
+

--- a/overlays/firmware-extended/11-patch-klipper/patches/home/lava/klipper/08_temperature_combined.patch
+++ b/overlays/firmware-extended/11-patch-klipper/patches/home/lava/klipper/08_temperature_combined.patch
@@ -1,0 +1,27 @@
+From 62351025f7a8bde0de99bc5b1ea3964d6d4f816b Mon Sep 17 00:00:00 2001
+From: jimmyjon711 <jcmadill1@gmail.com>
+Date: Sat, 30 May 2026 13:45:04 -0700
+Subject: [PATCH 1/1] Adding set_read_tolerance method to temperature_combined
+ file so that users can combine sensors to become one
+
+---
+ klippy/extras/temperature_combined.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/klippy/extras/temperature_combined.py b/klippy/extras/temperature_combined.py
+index 95416619..8f89aeb3 100644
+--- a/klippy/extras/temperature_combined.py
++++ b/klippy/extras/temperature_combined.py
+@@ -116,6 +116,9 @@ class PrinterSensorCombined:
+         # set next update time
+         return measured_time + REPORT_TIME
+ 
++    def set_read_tolerance(self, read_time_tol, min_update_ratio):
++        pass
++
+ 
+ def mean(values):
+     if not values:
+-- 
+2.32.0.windows.1
+

--- a/overlays/firmware-extended/13-patch-rfid/README.md
+++ b/overlays/firmware-extended/13-patch-rfid/README.md
@@ -21,6 +21,10 @@ Patch set in `overlays/firmware-extended/13-rfid-support/patches`:
     - `cmd_FILAMENT_DT_SELF_TEST`: raises early error when reader is disabled.
 - `05-add-filament-detect-set-endpoint.patch`
   - Adds webhook endpoint `filament_detect/set`.
+- `08-pass-uid-on-m1-auth-failure.patch`
+  - When M1 auth fails, sets `card_data` to the UID bytes from the anticollision/SELECT phase
+    (`self.__picc_a.UID[0:4]`) so that `CARD_UID` and `CARD_TYPE` are still populated via the
+    existing patch-07 handler in `filament_detect.py`.
 
 ## API Contract
 

--- a/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
@@ -10,7 +10,7 @@
      def _ready(self):
          self.filament_feed_objects = self.printer.lookup_objects('filament_feed')
          self._fm175xx_reader = self.printer.lookup_object('fm175xx_reader')
-@@ -173,6 +176,67 @@
+@@ -173,6 +176,70 @@
  
          return error, info
  
@@ -25,9 +25,13 @@
 +                                        % (channel, self._channel_nums - 1))
 +
 +            params = web_request.get_dict('info', {})
-+            has_params = len(params) > 0
 +            filament_info = dict(filament_protocol.FILAMENT_INFO_STRUCT)
++            if 'CARD_UID' in params:
++                filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]
++            if 'CARD_TYPE' in params:
++                filament_info['CARD_TYPE'] = str(params.pop('CARD_TYPE'))
 +
++            has_params = len(params) > 0
 +            if 'VENDOR' in params:
 +                filament_info['VENDOR'] = str(params.pop('VENDOR'))
 +            if 'MAIN_TYPE' in params:
@@ -55,9 +59,6 @@
 +
 +            if 'MULTI_MODE' in params:
 +                filament_info['MULTI_MODE'] = int(params.pop('MULTI_MODE')) & 0xFF
-+
-+            if 'CARD_UID' in params:
-+                filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]
 +            if 'SKU' in params:
 +                filament_info['SKU'] = int(params.pop('SKU'))
 +
@@ -70,6 +71,8 @@
 +            ptc = self.printer.lookup_object('print_task_config', None)
 +            if has_params or ptc is not None and ptc.print_task_config['filament_official'][channel]:
 +                self._filament_info_update(channel, filament_info, True)
++            else:
++                self._filament_info[channel] = filament_info
 +            web_request.send({'state': 'success'})
 +        except Exception as e:
 +            logging.error("[filament_detect] set: %s", str(e))

--- a/overlays/firmware-extended/13-patch-rfid/patches/06-add-card-type-to-filament-protocol.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/06-add-card-type-to-filament-protocol.patch
@@ -1,0 +1,10 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_protocol.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_protocol.py
+@@ -36,6 +36,7 @@
+     'RSA_KEY_VERSION': 0,
+     'OFFICIAL': False,
+     'CARD_UID': 0,
++    'CARD_TYPE': '',
+ }
+
+ # Filament main type

--- a/overlays/firmware-extended/13-patch-rfid/patches/07-detect-card-type-on-parse-failure.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/07-detect-card-type-on-parse-failure.patch
@@ -1,0 +1,20 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_detect.py
+@@ -132,6 +132,17 @@
+         else:
+             self._self_test_success_cnt += 1
+ 
++        if fm175xx_reader.FM175XX_CARD_INFO_READ == operation:
++            if card_type == fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_NTAG:
++                filament_info['CARD_TYPE'] = 'NTAG'
++                if card_data and len(card_data) >= 8:
++                    filament_info['CARD_UID'] = [card_data[0], card_data[1], card_data[2],
++                                                 card_data[4], card_data[5], card_data[6], card_data[7]]
++            elif card_type == fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_M1:
++                filament_info['CARD_TYPE'] = 'M1'
++                if card_data and len(card_data) >= filament_protocol.M1_PROTO_UID_LEN:
++                    filament_info['CARD_UID'] = list(card_data[:filament_protocol.M1_PROTO_UID_LEN])
++
+         self._state[channel] = FILAMENT_DT_STATE_IDLE
+         self._filament_info_update(channel, filament_info, is_clear)
+ 

--- a/overlays/firmware-extended/13-patch-rfid/patches/08-pass-uid-on-m1-auth-failure.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/08-pass-uid-on-m1-auth-failure.patch
@@ -1,0 +1,10 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/fm175xx_reader.py
++++ rootfs/home/lava/klipper/klippy/extras/fm175xx_reader.py
+@@ -1059,6 +1059,8 @@
+                             if (FM175XX_OK != ret.err_code):
+                                 card_op_result = FM175XX_CARD_READ_ERR
++                                card_data = list(self.__picc_a.UID[0:4])
++                                logging.info("M1 auth failed, UID: %s", ' '.join('%02X' % b for b in card_data))
+                             else:
+                                 card_data = ret.out_param[0:FM175XX_M1_CARD_EEPROM_SIZE]
+                                 card_op_result = FM175XX_OK

--- a/overlays/firmware-extended/13-patch-rfid/pre-scripts/01_klippy_fix_lf.sh
+++ b/overlays/firmware-extended/13-patch-rfid/pre-scripts/01_klippy_fix_lf.sh
@@ -8,4 +8,5 @@ fi
 ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
 
 dos2unix "$1/home/lava/klipper/klippy/extras/filament_detect.py" \
+  "$1/home/lava/klipper/klippy/extras/filament_protocol.py" \
   "$1/home/lava/klipper/klippy/extras/fm175xx_reader.py"

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -68,7 +68,7 @@ settings:
               - |
                 echo ""
                 echo ">> Detecting printer IP address..."
-                PRINTER_IP=$((ip -4 -o addr show eth0 || ip -4 -o addr show wlan0) | awk '{print $4}' | cut -d/ -f1)
+                PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) | awk '{print $4}' | cut -d/ -f1)
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."
@@ -117,7 +117,7 @@ settings:
               - |
                 echo ""
                 echo ">> Detecting printer IP address..."
-                PRINTER_IP=$((ip -4 -o addr show eth0 || ip -4 -o addr show wlan0) | awk '{print $4}' | cut -d/ -f1)
+                PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) | awk '{print $4}' | cut -d/ -f1)
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."

--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
@@ -13,7 +13,6 @@ location /screen/snapshot {
     proxy_pass http://127.0.0.1:8092/snapshot;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
-    access_log off;
 }
 
 location /screen/touch {

--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
@@ -13,6 +13,7 @@ location /screen/snapshot {
     proxy_pass http://127.0.0.1:8092/snapshot;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
+    access_log off;
 }
 
 location /screen/touch {

--- a/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
+++ b/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
@@ -7,9 +7,9 @@ fi
 
 set -eo pipefail
 
-VERSION=v1.36.3
+VERSION=v1.37.1
 URL=https://github.com/fluidd-core/fluidd/releases/download/$VERSION/fluidd.zip
-SHA256=c341e43065c3a08c22ff1b5122e9e8b934c278f39df782bb476b35eed1799c5c
+SHA256=f08e9d438fdce472553e1ce46a9be62f5ababb4b0f64f65efbd4561d9379653c
 FILENAME=fluidd-$VERSION.zip
 
 rm -rf "$ROOTFS_DIR/home/lava/fluidd"

--- a/overlays/firmware-extended/63-app-mainsail/root/etc/nginx/sites-available/mainsail
+++ b/overlays/firmware-extended/63-app-mainsail/root/etc/nginx/sites-available/mainsail
@@ -5,7 +5,7 @@ server {
     # uncomment the next line to activate IPv6
     # listen [::]:80 default_server;
 
-    # access_log /var/log/nginx/mainsail-access.log;
+    access_log off;
     error_log /var/log/nginx/mainsail-error.log;
 
     # disable this section on smaller hardware like a pi zero

--- a/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
+++ b/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GIT_URL=https://github.com/suchmememanyskill/OpenRFID.git
-GIT_SHA=195e47d59a70dc532dac8ff19923254f3df17f29
+GIT_SHA=ddd1609e9abe9cd37c4b8fa1a0e4307b976d5fd4
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
@@ -76,13 +76,21 @@ key = 536e61706d616b65725f71776572747975696f705b2c2e3b5d5f317132773365
 method = POST
 event = tag_parse_error
 url = http://localhost/printer/filament_detect/set
-body_json_template = {"channel":{{reader.slot}},"info":{}}
+body_json_template = {
+    "channel":{{reader.slot}},
+    "info": {
+      "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+      "CARD_TYPE": "{{ {'MifareUltralight': 'NTAG', 'MifareClassic1k': 'M1'}.get(scan.tag_type, scan.tag_type) }}"
+    }
+  }
 
 [webhook_exporter not_present_exporter]
 method = POST
 event = tag_not_present
 url = http://localhost/printer/filament_detect/set
-body_json_template = {"channel":{{reader.slot}},"info":{}}
+body_json_template = {
+    "channel":{{reader.slot}}
+  }
 
 [moonraker_on_property_change]
 moonraker_socket_path = /oem/printer_data/comms/moonraker.sock

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
@@ -13,6 +13,7 @@ body_json_template = {
             "BED_TEMP": {{ filament.bed_temp_c | int }},
             "ALPHA": {{ filament.alpha }},
             "RGB_1": {{ filament.rgb }},
-            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}]
+            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+            "CARD_TYPE": "{{ {'MifareUltralight': 'NTAG', 'MifareClassic1k': 'M1'}.get(scan.tag_type, scan.tag_type) }}"
         }
     }

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
@@ -13,6 +13,7 @@ body_json_template = {
             "BED_TEMP": {{ filament.bed_temp_c | int }},
             "ALPHA": {{ filament.alpha }},
             "RGB_1": {{ filament.rgb }},
-            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}]
+            "CARD_UID": [{% for i in range(0, scan.uid|length, 2) %}{{ scan.uid[i:i+2]|int(0, 16) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+            "CARD_TYPE": "{{ {'MifareUltralight': 'NTAG', 'MifareClassic1k': 'M1'}.get(scan.tag_type, scan.tag_type) }}"
         }
     }

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
@@ -13,3 +13,7 @@
 # Elegoo spools are disabled by default. They are not detected reliably on Snapmaker U1
 # due to tag placement. Uncomment to enable.
 #[elegoo_tag_processor]
+
+# SpoolEase tags (NTAG NDEF, https://spoolease.io) are disabled by default.
+# Uncomment to enable.
+#[spoolease_tag_processor]

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
@@ -22,18 +22,36 @@ check() {
     fi
 }
 
-download() {
+needs_upgrade() {
+    if [[ -L "$APP_DIR/latest" ]]; then
+        [[ "$(readlink "$APP_DIR/latest")" != "OctoPrint-OctoEverywhere-${VERSION}" ]]
+    else
+        return 1
+    fi
+}
+
+upgrade() {
+    download
+}
+
+clean() {
+    echo "Removing OctoEverywhere installation..."
     rm -rf "$APP_DIR"
-    mkdir -p "$APP_DIR"
+    echo "Removed."
+}
+
+download() {
+    rm -rf "$APP_DIR/tmp"
+    mkdir -p "$APP_DIR/tmp"
 
     echo "Downloading OctoEverywhere ${VERSION} From GitHub..."
-    if ! /usr/local/bin/curl -sfSL -o "$APP_DIR/octoeverywhere.zip" "$URL"; then
+    if ! /usr/local/bin/curl -sfSL -o "$APP_DIR/tmp/octoeverywhere.zip" "$URL"; then
         echo "Download failed"
         return 1
     fi
 
     echo "Verifying SHA256 checksum..."
-    ACTUAL_SHA256=$(sha256sum "$APP_DIR/octoeverywhere.zip" | awk '{print $1}')
+    ACTUAL_SHA256=$(sha256sum "$APP_DIR/tmp/octoeverywhere.zip" | awk '{print $1}')
     if [[ "$ACTUAL_SHA256" != "$SHA256" ]]; then
         echo "SHA256 mismatch!"
         echo "  Expected: $SHA256"
@@ -43,13 +61,13 @@ download() {
     echo "Checksum verified."
 
     echo "Extracting..."
-    if ! unzip -q "$APP_DIR/octoeverywhere.zip" -d "$APP_DIR"; then
+    if ! unzip -q "$APP_DIR/tmp/octoeverywhere.zip" -d "$APP_DIR/tmp"; then
         echo "Extraction failed"
         return 1
     fi
     echo "Extraction successful."
 
-    rm -rf "$APP_DIR/octoeverywhere.zip"
+    rm -rf "$APP_DIR/tmp/octoeverywhere.zip"
 
     echo "Setting up Python virtual environment (this can take up to 60 seconds)..."
     if ! python3 -m venv "$APP_DIR/venv"; then
@@ -58,7 +76,7 @@ download() {
     fi
 
     echo "Installing dependencies (this can also take a bit)..."
-    if ! "$APP_DIR/venv/bin/pip" install --disable-pip-version-check -r "$APP_DIR/OctoPrint-OctoEverywhere-${VERSION}/requirements.txt"; then
+    if ! "$APP_DIR/venv/bin/pip" install --disable-pip-version-check -r "$APP_DIR/tmp/OctoPrint-OctoEverywhere-${VERSION}/requirements.txt"; then
         echo "Failed to install dependencies"
         return 1
     fi
@@ -69,7 +87,9 @@ download() {
     fi
 
     # GitHub archives extract to OctoPrint-OctoEverywhere-<tag>
-    ln -s "OctoPrint-OctoEverywhere-${VERSION}" "$APP_DIR/latest"
+    rm -rf "$APP_DIR/OctoPrint-OctoEverywhere-"*
+    mv "$APP_DIR/tmp/OctoPrint-OctoEverywhere-${VERSION}" "$APP_DIR/"
+    ln -sf "OctoPrint-OctoEverywhere-${VERSION}" "$APP_DIR/latest"
     echo "OctoEverywhere installed successfully to $APP_DIR"
 }
 
@@ -77,30 +97,35 @@ case "$1" in
     check)
         check
         ;;
+    needs_upgrade)
+        needs_upgrade
+        ;;
     download)
         if check; then
             echo "OctoEverywhere is already installed."
             exit 0
         fi
+        if ! clean; then
+            echo "Failed to clean old installation"
+            exit 1
+        fi
         if ! download; then
             rm -rf "$APP_DIR"
             exit 1
         fi
         ;;
-    update)
-        echo "Updating OctoEverywhere..."
-        if ! download; then
-            rm -rf "$APP_DIR"
+    upgrade)
+        echo "Upgrading OctoEverywhere..."
+        if ! upgrade; then
+            rm -rf "$APP_DIR/tmp"
             exit 1
         fi
         ;;
     clean)
-        echo "Removing OctoEverywhere installation..."
-        rm -rf "$APP_DIR"
-        echo "Removed."
+        clean
         ;;
     *)
-        echo "Usage: $0 check|download|update|clean"
+        echo "Usage: $0 check|needs_upgrade|download|upgrade|clean"
         exit 1
         ;;
 esac

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/bin/octoeverywhere-pkg
@@ -5,9 +5,9 @@
 # Downloads and installs a pinned version of OctoEverywhere from GitHub
 #
 
-VERSION="4.6.8"
+VERSION="5.1.0"
 URL="https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/${VERSION}.zip"
-SHA256="fd16e88824f9b8026b1879a03a48f015f81a4f96b28448cd94fe3093ad52e750"
+SHA256="096b477882f00ad4e356716393a906b0c55c34284cf31c07693d5dea18eb4dc0"
 
 # These paths are referenced in the init.d script
 APP_DIR="/oem/apps/octoeverywhere"

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
@@ -4,6 +4,7 @@ settings:
       cloud:
         label: Cloud Access (Experimental)
         description: Enable alternative cloud access from outside your network.
+        help_url: https://snapmakeru1-extended-firmware.pages.dev/cloud
         get_cmd:
           - /usr/local/bin/extended-config.py
           - get
@@ -50,6 +51,8 @@ settings:
                 echo "If you need help, follow this guide:"
                 echo "https://octoeverywhere.com/s/snapmaker-u1"
                 echo "Contact Support: https://octoeverywhere.com/support"
+                echo ""
+                echo "If the plugin is already connected to your account, you can ignore this message."
                 echo
 
                 for i in {1..15}; do
@@ -62,4 +65,5 @@ settings:
                 done
 
                 echo "Authorization URL not found in logs. Please check the logs for more details."
+                echo "If the plugin is already connected to your account, you can ignore this message."
         default: none

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/25_actions_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/25_actions_cloud.yaml
@@ -1,0 +1,15 @@
+quick_actions:
+  upgrades:
+    items:
+      octoeverywhere-upgrade:
+        label: Upgrade OctoEverywhere
+        description: Download and install the latest pinned OctoEverywhere version.
+        if_cmd: /usr/local/bin/octoeverywhere-pkg needs_upgrade
+        confirm: "Upgrade OctoEverywhere and restart the cloud service?"
+        cmd:
+          - bash
+          - -ec
+          - |
+            /usr/local/bin/octoeverywhere-pkg upgrade
+            /etc/init.d/S99cloud restart
+        message: "Upgrading OctoEverywhere..."

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/bin/tailscale-pkg
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/bin/tailscale-pkg
@@ -4,9 +4,16 @@ VERSION=1.92.5
 URL="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
 SHA256=13a59c3181337dfc9fdf9dea433b04c1fbf73f72ec059f64d87466b79a3a313c
 
-TAILSCALE_DIR="/oem/apps/tailscale-${VERSION}"
+APP_DIR="/oem/apps/tailscale"
 TAILSCALE_STATE_DIR="/home/lava/printer_data/tailscale"
-TMP_DIR="$TAILSCALE_DIR.tmp"
+LEGACY_DIR="/oem/apps/tailscale-1.92.5"
+
+# Follow the `latest` symlink to the installed version, so an older binary
+# keeps working until an upgrade replaces it with the pinned version.
+TAILSCALE_DIR="$APP_DIR/latest"
+if [[ ! -L "$TAILSCALE_DIR" || ! -e "$TAILSCALE_DIR" ]]; then
+    TAILSCALE_DIR="$LEGACY_DIR"
+fi
 
 case "$(basename "$0")" in
     tailscaled)
@@ -28,7 +35,7 @@ esac
 
 check() {
     if [[ -x "$TAILSCALE_DIR/tailscale" && -x "$TAILSCALE_DIR/tailscaled" ]]; then
-        echo "Tailscale is installed (version $VERSION)."
+        echo "Tailscale is installed."
         return 0
     else
         echo "Tailscale is not installed."
@@ -36,64 +43,93 @@ check() {
     fi
 }
 
+needs_upgrade() {
+    if [[ -L "$APP_DIR/latest" && -e "$APP_DIR/latest" ]]; then
+        [[ "$(readlink "$APP_DIR/latest")" != "tailscale-${VERSION}" ]]
+    elif check; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+upgrade() {
+    download
+}
+
+clean() {
+    echo "Removing Tailscale installation..."
+    rm -rf "$APP_DIR" "$LEGACY_DIR" "$TAILSCALE_STATE_DIR"
+    echo "Removed."
+}
+
 download() {
-    rm -rf "$TMP_DIR"
-    mkdir -p "$TMP_DIR"
+    rm -rf "$APP_DIR/tmp"
+    mkdir -p "$APP_DIR/tmp/tailscale-${VERSION}"
 
     echo "Downloading Tailscale $VERSION..."
-    if ! /usr/local/bin/curl -fSL -o "$TMP_DIR/tailscale.tgz" "$URL"; then
+    if ! /usr/local/bin/curl -fSL -o "$APP_DIR/tmp/tailscale-${VERSION}.tgz" "$URL"; then
         echo "Download failed"
         return 1
     fi
 
     echo "Verifying checksum..."
-    if ! echo "$SHA256  $TMP_DIR/tailscale.tgz" | sha256sum -c; then
+    if ! echo "$SHA256  $APP_DIR/tmp/tailscale-${VERSION}.tgz" | sha256sum -c; then
         echo "Checksum verification failed"
         return 1
     fi
 
     echo "Installing..."
-    if ! tar --strip-components=1 -xzf "$TMP_DIR/tailscale.tgz" -C "$TMP_DIR"; then
+    mkdir -p "$APP_DIR/tailscale-${VERSION}"
+    if ! tar --strip-components=1 -xzf "$APP_DIR/tmp/tailscale-${VERSION}.tgz" -C "$APP_DIR/tmp/tailscale-${VERSION}"; then
         echo "Extraction failed"
         return 1
     fi
 
-    if [[ ! -x "$TMP_DIR/tailscale" || ! -x "$TMP_DIR/tailscaled" ]]; then
+    if [[ ! -x "$APP_DIR/tmp/tailscale-${VERSION}/tailscale" || ! -x "$APP_DIR/tmp/tailscale-${VERSION}/tailscaled" ]]; then
         echo "Installation failed: binaries not found"
         return 1
     fi
 
-    rm -rf "$TAILSCALE_DIR" "$TMP_DIR/tailscale.tgz"
-
-    if ! mv "$TMP_DIR" "$TAILSCALE_DIR"; then
-        echo "Failed to move Tailscale to $TAILSCALE_DIR"
-        return 1
-    fi
-
-    echo "Tailscale $VERSION installed to $TAILSCALE_DIR"
+    rm -rf "$LEGACY_DIR" "$APP_DIR/tmp/tailscale-${VERSION}.tgz"
+    rm -rf "$APP_DIR/tailscale-"*
+    mv "$APP_DIR/tmp/tailscale-${VERSION}" "$APP_DIR/"
+    ln -sf "tailscale-${VERSION}" "$APP_DIR/latest"
+    echo "Tailscale $VERSION installed to $APP_DIR"
 }
 
 case "$1" in
     check)
         check
         ;;
+    needs_upgrade)
+        needs_upgrade
+        ;;
+    upgrade)
+        if ! upgrade; then
+            rm -rf "$APP_DIR/tmp"
+            exit 1
+        fi
+        ;;
     download)
         if check; then
             echo "Tailscale is already installed."
             exit 0
         fi
+        if ! clean; then
+            echo "Failed to clean old installation"
+            exit 1
+        fi
         if ! download; then
-            rm -rf "$TMP_DIR"
+            rm -rf "$APP_DIR"
             exit 1
         fi
         ;;
     clean)
-        echo "Removing Tailscale installation..."
-        rm -rf "$TAILSCALE_DIR" "$TAILSCALE_STATE_DIR"
-        echo "Removed."
+        clean
         ;;
     *)
-        echo "Usage: $0 check|download|clean"
+        echo "Usage: $0 check|needs_upgrade|download|upgrade|clean"
         exit 1
         ;;
 esac

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
@@ -1,3 +1,19 @@
+quick_actions:
+  upgrades:
+    items:
+      tailscale-upgrade:
+        label: Upgrade Tailscale
+        description: Download and install the latest pinned Tailscale version.
+        if_cmd: /usr/local/bin/tailscale-pkg needs_upgrade
+        confirm: "Upgrade Tailscale and restart the VPN service?"
+        cmd:
+          - bash
+          - -ec
+          - |
+            /usr/local/bin/tailscale-pkg upgrade
+            /etc/init.d/S99vpn restart
+        message: "Upgrading Tailscale..."
+
 actions:
   troubleshooting:
     items:

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -88,16 +88,16 @@ for overlay; do
     popd > /dev/null
   fi
 
+  if [[ -d "$overlay/root/" ]]; then
+    echo ">> Copying custom files..."
+    cp -rv "$overlay/root/." "$ROOTFS_DIR/"
+  fi
+
   if [[ -d "$overlay/scripts/" ]]; then
     for scriptfile in "$overlay/scripts/"*.sh; do
       echo "[+] Running script: $(basename "$scriptfile")"
       ./"$scriptfile" "$ROOTFS_DIR"
     done
-  fi
-
-  if [[ -d "$overlay/root/" ]]; then
-    echo ">> Copying custom files..."
-    cp -rv "$overlay/root/." "$ROOTFS_DIR/"
   fi
 done
 

--- a/scripts/dev/checkout-pr.sh
+++ b/scripts/dev/checkout-pr.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+PUSH_USER="${PUSH_USER:-paxx12}"
+
+while getopts "u:" opt; do
+  case "$opt" in
+    u) PUSH_USER="$OPTARG" ;;
+    *)
+      echo "usage: $0 [-u <user>] <remote> <pr-number>" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 [-u <user>] <remote> <pr-number>"
+  echo "example: $0 -u paxx12 origin 42"
+  exit 1
+fi
+
+BASE_REMOTE="$1"
+PR_NUMBER="$2"
+
+# Resolve the base repo (`owner/repo`) from the given remote's URL.
+REMOTE_URL="$(git remote get-url "$BASE_REMOTE")"
+BASE_REPO="$(printf '%s' "$REMOTE_URL" | sed -E 's#^.*github\.com[:/]##; s#\.git$##')"
+
+if [[ -z "$BASE_REPO" ]]; then
+  echo "error: could not resolve a GitHub repo from remote '$BASE_REMOTE' ($REMOTE_URL)" >&2
+  exit 1
+fi
+
+# Use `curl` against the GitHub REST API to resolve the fork the PR comes from.
+API_URL="https://api.github.com/repos/$BASE_REPO/pulls/$PR_NUMBER"
+AUTH_HEADER=()
+if [[ -n "$GITHUB_TOKEN" ]]; then
+  AUTH_HEADER=(-H "Authorization: token $GITHUB_TOKEN")
+fi
+
+PR_JSON="$(curl -fsSL "${AUTH_HEADER[@]}" -H "Accept: application/vnd.github+json" "$API_URL")"
+
+read -r FORK_ORG BRANCH_NAME CLONE_URL < <(
+  printf '%s' "$PR_JSON" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+head = d["head"]
+repo = head["repo"]
+print(repo["owner"]["login"], head["ref"], repo["clone_url"])
+'
+)
+
+if [[ -z "$FORK_ORG" || -z "$BRANCH_NAME" || -z "$CLONE_URL" ]]; then
+  echo "error: could not resolve PR #$PR_NUMBER from $BASE_REPO" >&2
+  exit 1
+fi
+
+LOCAL_BRANCH="pr-$PR_NUMBER-$FORK_ORG-$BRANCH_NAME"
+
+# Inject `$PUSH_USER@` into the fork URL so pushes authenticate as the maintainer.
+PUSH_URL="${CLONE_URL/https:\/\//https://$PUSH_USER@}"
+
+REMOTE_NAME="$FORK_ORG"
+if git remote get-url "$REMOTE_NAME" >/dev/null 2>&1; then
+  git remote set-url "$REMOTE_NAME" "$PUSH_URL"
+else
+  git remote add "$REMOTE_NAME" "$PUSH_URL"
+fi
+
+echo ">> Fetching $REMOTE_NAME/$BRANCH_NAME..."
+git fetch "$REMOTE_NAME" "$BRANCH_NAME"
+
+if git show-ref --verify --quiet "refs/heads/$LOCAL_BRANCH"; then
+  git checkout "$LOCAL_BRANCH"
+else
+  git checkout -b "$LOCAL_BRANCH" "$REMOTE_NAME/$BRANCH_NAME"
+fi
+
+# Track the fork branch so `git push` (-u) targets the contributor's branch.
+git branch --set-upstream-to "$REMOTE_NAME/$BRANCH_NAME" "$LOCAL_BRANCH"
+
+echo ">> Checked out PR #$PR_NUMBER as '$LOCAL_BRANCH'"
+echo ">> Push target: $PUSH_URL ($BRANCH_NAME)"

--- a/scripts/dev/qemu.sh
+++ b/scripts/dev/qemu.sh
@@ -21,6 +21,7 @@ APPEND="console=ttyAMA0,115200 earlycon=pl011,mmio32,0x09000000"
 APPEND="$APPEND systemd.volatile=overlay ro rootwait rootfstype=squashfs root=/dev/vda"
 APPEND="$APPEND storagemedia=emmc androidboot.storagemedia=emmc androidboot.mode=normal androidboot.verifiedbootstate=orange android_slotsufix=_a vertype=rel"
 APPEND="$APPEND androidboot.fwver=ddr-v1.07-6e9ae14bbb,bl31-v1.21,bl32-v1.07,uboot-3ed3e17641-12/30/2025"
+APPEND="$APPEND video=Virtual-1:480x320 net.ifnames=0"
 
 set -e
 
@@ -61,6 +62,9 @@ qemu-system-aarch64 \
   -m 1024 \
   -serial mon:stdio \
   -display none \
+  -global virtio-mmio.force-legacy=false \
+  -device virtio-gpu-device,xres=480,yres=320 \
+  -device virtio-multitouch-device \
   -kernel "$KERNEL_FILE" \
   -append "$APPEND initcall_blacklist=rockchip_drm_init" \
   -netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2280-:80,hostfwd=tcp::2443-:443 \

--- a/scripts/dev/upgrade-firmware.sh
+++ b/scripts/dev/upgrade-firmware.sh
@@ -15,5 +15,5 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 set -xe
 
 make build OUTPUT_FILE=firmware/firmware_$PROFILE.bin PROFILE="$PROFILE" OVERWRITE=1
-sshpass -p "$PASSWORD" scp $SSH_OPTS "tmp/firmware/update.img" "$SSH_HOST:/tmp/"
-sshpass -p "$PASSWORD" ssh $SSH_OPTS "$SSH_HOST" /home/lava/bin/systemUpgrade.sh upgrade soc /tmp/update.img
+sshpass -p "$PASSWORD" scp $SSH_OPTS "tmp/firmware/update.img" "$SSH_HOST:/userdata/"
+sshpass -p "$PASSWORD" ssh $SSH_OPTS "$SSH_HOST" /home/lava/bin/systemUpgrade.sh upgrade soc /userdata/update.img


### PR DESCRIPTION
## New Features

- New: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/512
- New: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/496
- New: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/448
- New: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/547
- Bug Fix: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/536
- Bug Fix: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/522
- Upgrade: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/525
- Upgrade: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/526
- Upgrade: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/497
- Development: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/529
- Development: https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/524

<!-- CHANGELOG_START -->
## 📋 Changelog

This release includes the following pull requests:

- #547: Add `full-recover.txt` USB recovery variant (@paxx12)
- #536: Disable `access_log` globally in mainsail nginx config (@paxx12)
- #534: Disable access log for `/screen/snapshot` (@paxx12)
- #529: Add virtio GPU and multitouch support to QEMU dev environment (@paxx12)
- #526: Update OctoEverywhere to `5.1.0` and add cloud `help_url` (@paxx12)
- #512: Add `quick_actions` and component upgrade support (@paxx12)
- #525: Upgrade `fluidd` to v1.37.1 (@paxx12)
- #448: Add `CARD_UID` and `CARD_TYPE` tag metadata to RFID stack (@paxx12)
- #524: Add PR checkout helper and fix firmware upgrade path [ci skip] (@paxx12)
- #497: Update OpenRFID to support SpoolEase (@suchmememanyskill)
- #520: docs(ssh): document firmware-config web interface as SSH fallback (@St0rmingBr4in)
- #496: (patch) Add AHT2x/AHT3x sensor support and temperature_combined fix (@jimmyjon711)
- #522: Suppress `eth0` error on WiFi-only devices in Panda Breath setup (@paxx12)
<!-- CHANGELOG_END -->