### PR TITLE
Add `full-recover.txt` USB recovery variant

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ Quick steps:
 
 ## Troubleshooting
 
-- **Klipper failed to start**: Open Firmware Config at `http://IP/firmware-config`, go to `Recovery` and select `Reset Extended to Defaults`. This will reset all extended settings and reboot the printer.
+- **Custom extensions installed via SSH**: Installing third-party extensions or modifications over SSH (for example [helixscreen](https://github.com/prestonbrown/helixscreen)) can break the system. Because such changes are made outside the supported extended configuration, the built-in recovery may not undo them, and in some cases the system becomes very hard to recover. Do this only if you understand the risks and know how to restore the printer. If something breaks, try recovery in order: first `extended-recover.txt` (resets extended configuration), then `full-recover.txt` (also clears persisted changes, printer data and the debug flag), and only if neither works, reflash stock firmware via the [Snapmaker U1 Wiki](https://wiki.snapmaker.com/en/snapmaker_u1/firmware/release_notes).
 
 ## Revert
 

--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -281,6 +281,47 @@ If an invalid configuration breaks Moonraker (printer won't connect to WiFi):
 4. The extended configuration will be backed up to `extended.backup.N` and reset to defaults
 5. Remove the USB drive (the recovery file will be automatically deleted)
 
+On Windows with "Hide extensions for known file types" enabled, the file may be
+saved as `extended-recover.txt.txt`. Both names are recognised.
+
+### Full Recovery
+
+If the extended reset above is not enough — for example a persisted change or
+`/oem/.debug` flag keeps a broken state across reboots — use full recovery. In
+addition to resetting the extended configuration, it removes `/oem/.printer_data`
+and `/oem/.debug`, then reboots so the overlay (`S01aoverlayfs`) and printer data
+(`S48setup-lava-env`) are rebuilt from defaults on the next boot.
+
+1. Create an empty file named `full-recover.txt` on a USB drive
+   (`full-recover.txt.txt` is also recognised)
+2. Insert the USB drive into the printer
+3. Restart the printer
+4. The printer removes the recovery file, clears the persistence and debug flags,
+   flags the extended configuration for reset, and reboots
+5. Remove the USB drive
+
+**Important:** Full recovery resets ALL extended configuration and clears
+persisted changes and printer data. Use it only when a normal
+`extended-recover.txt` reset does not resolve the issue.
+
+### Custom Extensions Installed via SSH
+
+The recovery methods above only reset changes made through the supported extended
+configuration. Installing third-party extensions or modifications over SSH (for
+example [helixscreen](https://github.com/prestonbrown/helixscreen)) writes files
+outside that mechanism, so neither `extended-recover.txt` nor `full-recover.txt`
+is guaranteed to undo them. Such changes can break the system, and in some cases
+make it very hard to recover.
+
+Only install custom extensions over SSH if you understand the risks and know how
+to restore the printer. If something breaks, try recovery in this order:
+
+1. `extended-recover.txt` — resets the extended configuration only
+2. `full-recover.txt` — also clears persisted changes, printer data and the debug
+   flag, then reboots
+3. Reflash stock or extended firmware (see [Installation Guide](install.md)) if
+   neither recovery method fixes the problem
+
 ## Related Documentation
 
 - [Camera Support](camera_support.md) - Camera features and WebRTC streaming

--- a/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S49extended-config
+++ b/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S49extended-config
@@ -4,7 +4,24 @@ DEFAULT_DIR="/usr/local/share/firmware-config/extended"
 EXTENDED_DIR="/home/lava/printer_data/config/extended"
 
 start() {
-    if [ -f /mnt/udisk/extended-recover.txt ] || [ -f /oem/.extended-recover ]; then
+    # `.txt.txt` covers Windows users with "Hide extensions for known file types" enabled,
+    # who type `extended-recover.txt`/`full-recover.txt` but get a double extension from Explorer.
+
+    # Full recovery clears the extended config, printer data and the debug/overlay
+    # persistence flag, then reboots so the cleared flags take effect: `/oem/.debug`
+    # is read by `S01aoverlayfs` and `/oem/.printer_data` by `S48setup-lava-env`,
+    # both of which run before this script, so the reset only applies on next boot.
+    if [ -f /mnt/udisk/full-recover.txt ] || [ -f /mnt/udisk/full-recover.txt.txt ] || [ -f /oem/.full-recover ]; then
+        echo "Performing full recovery: removing extended config, printer data and debug flag, then rebooting..."
+        rm -f /mnt/udisk/full-recover.txt /mnt/udisk/full-recover.txt.txt /oem/.full-recover
+        rm -f /oem/.printer_data /oem/.debug
+        touch /oem/.extended-recover
+        sync
+        /sbin/reboot
+        exit 0
+    fi
+
+    if [ -f /mnt/udisk/extended-recover.txt ] || [ -f /mnt/udisk/extended-recover.txt.txt ] || [ -f /oem/.extended-recover ]; then
         # Move existing extended config to a backup location
         # find the next available backup number
         if [ -d "$EXTENDED_DIR" ]; then
@@ -14,7 +31,7 @@ start() {
             done
             mv "$EXTENDED_DIR" "$EXTENDED_DIR.backup.$BACKUP_NUM"
         fi
-        rm -f /mnt/udisk/extended-recover.txt /oem/.extended-recover
+        rm -f /mnt/udisk/extended-recover.txt /mnt/udisk/extended-recover.txt.txt /oem/.extended-recover
     fi
 
     mkdir -p "$EXTENDED_DIR"


### PR DESCRIPTION
Extends `S49extended-config` to recognise a new `full-recover.txt` trigger (and the `full-recover.txt.txt` double-extension that Windows Explorer produces). Unlike `extended-recover.txt`, which only resets the extended configuration, full recovery also removes `/oem/.printer_data` and `/oem/.debug`, flags the extended config for reset, and reboots so `S01aoverlayfs` and `S48setup-lava-env` rebuild the overlay and printer data from defaults on the next boot. The `.txt.txt` handling for `extended-recover.txt` is imported from the `feature-recovery` work.

Documents both recovery files in `docs/firmware_config.md`, including an escalation order (extended recovery, then full recovery, then reflash) and a warning that extensions installed over SSH (for example `helixscreen`) live outside the supported configuration, so recovery may not undo them and can make the system very hard to recover. Adds the same SSH warning to `RELEASE.md` and drops the redundant "Klipper failed to start" bullet, which is covered by extended recovery.