### PR TITLE
Add Cloudflare Pages Functions backing the firmware-upgrade imposter

### DIFF
--- a/.github/workflows/cloudflare_pages.yaml
+++ b/.github/workflows/cloudflare_pages.yaml
@@ -36,7 +36,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy _site --project-name=snapmakeru1-extended-firmware --branch=${{ github.ref_name }}
+          workingDirectory: docs
+          command: pages deploy ../_site --project-name=snapmakeru1-extended-firmware --branch=${{ github.ref_name }}
 
       - name: Add deployment comment
         if: github.event_name == 'push' && github.ref != 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-firmware/
+/firmware/
 tmp/
 tools/upfile/upfile
 tools/rk2918_tools/afptool

--- a/docs/functions/README.md
+++ b/docs/functions/README.md
@@ -1,0 +1,100 @@
+# Cloudflare Pages Functions
+
+Server-side endpoints for the `snapmakeru1-extended-firmware.pages.dev` Pages
+project, deployed by `.github/workflows/cloudflare_pages.yaml`. Wrangler picks
+up a `functions/` directory that sits next to *its own working directory*, not
+one nested inside the deployed static output — so the deploy step runs with
+`workingDirectory: docs` and deploys `../_site` (the Jekyll build output),
+letting this `docs/functions/` directory be uploaded alongside it.
+
+## `GET /api/device/firmware/latest`
+
+Consumed by the `firmware-imposter` `LD_PRELOAD` shim (see
+`overlays/firmware-extended/38-feature-upgrade-firmware/`), which rewrites
+`unisrv`'s `https://id.snapmaker.com/api/device/firmware/latest` check to this
+same path on our own host when `upgrade.firmware` in `extended2.cfg` is
+`stable` or `beta` (`none` and `snapmaker` both leave the launcher on stock,
+unmodified behaviour). Deliberately mirrors the real path rather than a
+custom one, since it's a drop-in replacement for the same request.
+
+**Query params**
+
+| Param     | Values           | Default  | Behaviour                                                        |
+|-----------|------------------|----------|-------------------------------------------------------------------|
+| `channel` | `stable`, `beta` | `stable` | `stable` = latest GitHub release only; `beta` = latest of either a release or a pre-release, whichever was published last |
+
+The response mirrors the shape of Snapmaker's own `ApiDeviceFirmwareLatest`
+response:
+
+```json
+{
+  "code": 200,
+  "msg": "success",
+  "data": {
+    "id": 342972029,
+    "name": "v1.4.1-paxx12-20",
+    "note": "https://snapmakeru1-extended-firmware.pages.dev/api/device/firmware/upgrade_desc?id=342972029",
+    "url": "https://github.com/.../U1_extended_1.4.1-paxx12-20_upgrade.bin",
+    "status": 200,
+    "version": "1.4.1-paxx12-20",
+    "createDate": "2026-06-21T20:57:51",
+    "modifiedDate": "2026-06-23T15:21:32"
+  }
+}
+```
+
+`authDevices` (a per-device auth allowlist in the real API) is intentionally
+omitted; it is unrelated to this flow.
+
+`url` points straight at the GitHub release asset. `unisrv` fetches it with
+its own `curl` handle (a call the shim does not intercept), so it still
+attaches its Snapmaker `Authorization: Bearer` header — modern libcurl (the
+device ships 8.6.0) strips `Authorization` by default on any redirect that
+changes host, so the token is not handed on to GitHub's storage backend.
+
+## `GET /api/device/firmware/upgrade_desc`
+
+The `note` URL above. Given `?id=<release id>`, generates the firmware
+descriptor `unisrv` downloads after the initial check — dynamically, from
+GitHub release metadata, rather than a file baked at release time:
+
+```json
+{
+  "name": "v1.4.1-paxx12-20",
+  "version": "1.4.1",
+  "fullversion": "1.4.1-paxx12-20",
+  "size": 290327624,
+  "md5": null,
+  "sha256": "8ddb1d6dc889f8c11d6ac708dd4858439b13e830d3bf93064e857433a70ff3c3",
+  "release_notes": {
+    "en-GB": ["Quick Actions panel in Firmware Config with in-place upgrade buttons...", "..."]
+  }
+}
+```
+
+- `size` and `sha256` come straight from the GitHub release-asset metadata
+  (`digest: sha256:...`, added to the Releases API).
+- `release_notes.en-GB` is scraped from the `## New Features and Key Changes`
+  section of the release body (`extractSection()` in `_lib/github-releases.js`).
+- **`md5` is a placeholder (`null`).** GitHub's API doesn't expose an MD5 for
+  release assets, and hashing the ~250-300MB `.bin` on every request isn't
+  implemented. The key is present because `unisrv`'s parser requires it to
+  exist, but a real device will fail the post-download `CheckFirmwareFile`
+  integrity check until this is filled in — auto-upgrade via this endpoint
+  is not yet end-to-end functional.
+
+## Caching
+
+Both endpoints cache their response at Cloudflare's edge (Cache API, keyed by
+the full request URL) for `CACHE_SECONDS` (5 minutes, `_lib/github-releases.js`),
+so GitHub is called at most once per distinct `channel`/`id` per cache window.
+
+## Configuration
+
+| Env var        | Required | Purpose                                                              |
+|----------------|----------|------------------------------------------------------------------------|
+| `GITHUB_REPO`  | No       | `owner/repo` to query; defaults to `paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware` |
+| `GITHUB_TOKEN` | No       | Sent as a `Bearer` token to the GitHub API to lift the 60 req/hour unauthenticated rate limit; set as a Pages secret if devices poll often enough to hit it |
+
+Set both via the Cloudflare Pages dashboard (Settings → Environment
+variables) for the `snapmakeru1-extended-firmware` project, not in this repo.

--- a/docs/functions/_lib/github-releases.js
+++ b/docs/functions/_lib/github-releases.js
@@ -1,0 +1,60 @@
+export const DEFAULT_REPO = "paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware";
+export const BIN_ASSET_SUFFIX = "_upgrade.bin";
+export const CACHE_SECONDS = 300;
+
+async function githubApi(path, env) {
+  const headers = {
+    accept: "application/vnd.github+json",
+    "user-agent": "snapmakeru1-extended-firmware-worker",
+  };
+  if (env.GITHUB_TOKEN) headers.authorization = `Bearer ${env.GITHUB_TOKEN}`;
+
+  const res = await fetch(`https://api.github.com${path}`, { headers });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${path} returned ${res.status}`);
+  }
+  return res.json();
+}
+
+// `stable` uses GitHub's dedicated "latest release" endpoint, which already
+// excludes drafts and pre-releases. `beta` takes whatever GitHub says is
+// newest overall — release or pre-release, whichever was published last.
+export async function findRelease(channel, env) {
+  const repo = env.GITHUB_REPO || DEFAULT_REPO;
+
+  if (channel === "stable") {
+    return githubApi(`/repos/${repo}/releases/latest`, env);
+  }
+
+  const releases = await githubApi(`/repos/${repo}/releases?per_page=1`, env);
+  if (!releases.length) throw new Error("no releases found");
+  return releases[0];
+}
+
+export async function getReleaseById(id, env) {
+  const repo = env.GITHUB_REPO || DEFAULT_REPO;
+  return githubApi(`/repos/${repo}/releases/${id}`, env);
+}
+
+export function findAsset(release, suffix) {
+  return release.assets.find((asset) => asset.name.endsWith(suffix));
+}
+
+// Pulls the bullet list out of a named `## <heading>` section of a release
+// body (GitHub-flavoured markdown), stopping at the next `##` heading.
+export function extractSection(body, heading) {
+  if (!body) return [];
+
+  const lines = body.split("\n");
+  const startIndex = lines.findIndex((line) => line.trim().toLowerCase() === `## ${heading}`.toLowerCase());
+  if (startIndex === -1) return [];
+
+  const items = [];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^##\s/.test(line.trim())) break;
+    const bullet = line.match(/^\s*-\s+(.*)$/);
+    if (bullet) items.push(bullet[1].trim());
+  }
+  return items;
+}

--- a/docs/functions/api/device/firmware/latest.js
+++ b/docs/functions/api/device/firmware/latest.js
@@ -1,0 +1,79 @@
+import {
+  BIN_ASSET_SUFFIX,
+  CACHE_SECONDS,
+  findAsset,
+  findRelease,
+} from "../../../_lib/github-releases.js";
+
+const CHANNELS = ["stable", "beta"];
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": `public, max-age=${CACHE_SECONDS}`,
+    },
+  });
+}
+
+// Trims the fractional-seconds/`Z` suffix GitHub timestamps carry, to match
+// the plain `YYYY-MM-DDTHH:MM:SS` shape of Snapmaker's own API responses.
+function toApiTimestamp(iso) {
+  return iso.replace(/\.\d+Z$/, "").replace(/Z$/, "");
+}
+
+export async function onRequestGet(context) {
+  const { request, env, waitUntil } = context;
+  const url = new URL(request.url);
+  const channel = (url.searchParams.get("channel") || "stable").toLowerCase();
+
+  if (!CHANNELS.includes(channel)) {
+    return jsonResponse(
+      { code: 400, msg: `invalid channel '${channel}', expected one of: ${CHANNELS.join(", ")}`, data: null },
+      400,
+    );
+  }
+
+  const cache = caches.default;
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  let release;
+  try {
+    release = await findRelease(channel, env);
+  } catch (err) {
+    return jsonResponse({ code: 404, msg: String(err.message || err), data: null }, 404);
+  }
+
+  const binAsset = findAsset(release, BIN_ASSET_SUFFIX);
+
+  if (!binAsset) {
+    return jsonResponse(
+      { code: 404, msg: `release '${release.tag_name}' has no .bin asset`, data: null },
+      404,
+    );
+  }
+
+  const descUrl = new URL("/api/device/firmware/upgrade_desc", url.origin);
+  descUrl.searchParams.set("id", release.id);
+
+  const body = {
+    code: 200,
+    msg: "success",
+    data: {
+      id: release.id,
+      name: release.name || release.tag_name,
+      note: descUrl.toString(),
+      url: binAsset.browser_download_url,
+      status: 200,
+      version: release.tag_name.replace(/^v/, ""),
+      createDate: toApiTimestamp(release.created_at),
+      modifiedDate: toApiTimestamp(release.published_at || release.created_at),
+    },
+  };
+
+  const response = jsonResponse(body);
+  waitUntil(cache.put(request, response.clone()));
+  return response;
+}

--- a/docs/functions/api/device/firmware/upgrade_desc.js
+++ b/docs/functions/api/device/firmware/upgrade_desc.js
@@ -1,0 +1,67 @@
+import {
+  BIN_ASSET_SUFFIX,
+  CACHE_SECONDS,
+  extractSection,
+  findAsset,
+  getReleaseById,
+} from "../../../_lib/github-releases.js";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": `public, max-age=${CACHE_SECONDS}`,
+    },
+  });
+}
+
+export async function onRequestGet(context) {
+  const { request, env, waitUntil } = context;
+  const url = new URL(request.url);
+  const id = url.searchParams.get("id");
+
+  if (!id || !/^\d+$/.test(id)) {
+    return jsonResponse({ error: "missing or invalid 'id' query param" }, 400);
+  }
+
+  const cache = caches.default;
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  let release;
+  try {
+    release = await getReleaseById(id, env);
+  } catch (err) {
+    return jsonResponse({ error: String(err.message || err) }, 404);
+  }
+
+  const binAsset = findAsset(release, BIN_ASSET_SUFFIX);
+  if (!binAsset) {
+    return jsonResponse({ error: `release '${release.tag_name}' has no .bin asset` }, 404);
+  }
+
+  const fullversion = release.tag_name.replace(/^v/, "");
+  const version = fullversion.split("-")[0];
+  const sha256 = binAsset.digest?.startsWith("sha256:") ? binAsset.digest.slice(7) : null;
+
+  const body = {
+    name: release.name || release.tag_name,
+    version,
+    fullversion,
+    size: binAsset.size,
+    // Not computed yet — GitHub's release API doesn't expose an MD5 for
+    // assets (only the sha256 `digest` below), and hashing the ~300MB
+    // asset on every request is not implemented. The key is present
+    // because unisrv's parser requires it, but its value is a placeholder.
+    md5: null,
+    sha256,
+    release_notes: {
+      "en-GB": extractSection(release.body, "New Features and Key Changes"),
+    },
+  };
+
+  const response = jsonResponse(body);
+  waitUntil(cache.put(request, response.clone()));
+  return response;
+}


### PR DESCRIPTION
Adds `docs/functions/api/device/firmware/latest` and `.../upgrade_desc`, deployed to `snapmakeru1-extended-firmware.pages.dev` alongside the Jekyll site (`cloudflare_pages.yaml` now runs `wrangler` with `workingDirectory: docs` so its `functions/` auto-detection picks up `docs/functions/`, deploying `../_site` for the static assets).

`latest` mirrors `unisrv`'s real `/api/device/firmware/latest` path and shape (`ApiDeviceFirmwareLatest`, minus `authDevices`). It takes `?channel=stable` (latest GitHub release) or `?channel=beta` (latest of either a release or pre-release), resolving against `GITHUB_REPO` via the GitHub API and caching at Cloudflare's edge for 5 minutes (`_lib/github-releases.js`). `upgrade_desc` builds the descriptor its `note` field points to on the fly from the same release's metadata: real `size` and `sha256` from the asset's GitHub `digest`, `release_notes.en-GB` scraped from the release body's "New Features and Key Changes" section, and a `md5: null` placeholder (GitHub doesn't expose one, and hashing the ~300MB asset per request isn't implemented, so real device auto-upgrade isn't fully wired up yet).
