### PR TITLE
Support `if_cmd` for settings items in `firmware-config`

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
@@ -289,6 +289,10 @@ class FirmwareConfigHandler(SimpleHTTPRequestHandler):
                 items = group_cfg.get('items', {})
                 settings_list = []
                 for setting_id, config in items.items():
+                    if_cmd = config.get('if_cmd')
+                    if if_cmd and not self._check_condition(if_cmd):
+                        continue
+
                     try:
                         cmd_result = subprocess.run(
                             config["get_cmd"],


### PR DESCRIPTION
Extends `handle_get_settings` in `firmware-config.py` to skip items whose `if_cmd` shell condition fails, matching the existing `if_cmd` behavior already used for `status` sections and `actions`/ `quick_actions` items. This lets a setting be hidden until another setting has a particular value.