### PR TITLE
Add camera resolution/framerate settings to `firmware-config`

### DIFF
--- a/docs/camera_support.md
+++ b/docs/camera_support.md
@@ -13,6 +13,7 @@ The extended firmware includes hardware-accelerated camera support with WebRTC s
 - MIPI CSI internal camera and USB camera support
 - Low-latency WebRTC streaming (best quality and performance)
 - Hot-plug detection for USB cameras
+- Configurable resolution/framerate presets (paxx12 service only)
 - Web-based camera controls with settings persistence
 - Optional RTSP streaming support
 - Compatible with AI detection and Snapmaker Cloud features
@@ -138,6 +139,31 @@ To disable USB camera, set `usb: none` in extended2.cfg.
 When enabled, USB cameras are accessible at `http://<printer-ip>/webcam2/`.
 
 Note: Only one streaming mode can be active per camera.
+
+### Resolution & Framerate
+
+Available for the paxx12 camera service only.
+
+The internal camera is fixed at 1080p (required for AI detection); only framerate can be lowered. The USB camera can be lowered in both resolution and framerate to reduce bandwidth/CPU usage.
+
+#### Using firmware-config Web UI (preferred)
+
+Navigate to the [firmware-config](firmware_config.md) web interface, go to the Camera section, and select **Internal Camera Resolution** and/or **USB Camera Resolution**. These options only appear once the corresponding camera is set to the paxx12 service.
+
+#### Manual Setup (advanced)
+
+**Step 1:** Edit `/home/lava/printer_data/config/extended/extended2.cfg`:
+```ini
+[camera]
+internal_resolution: 1080p25
+usb_resolution: 720p25
+```
+
+Internal camera options: `1080p30`, `1080p25` (default), `1080p15`, `1080p5`.
+
+USB camera options: `1080p30`, `1080p25` (default), `1080p5`, `720p30`, `720p25`, `720p5`, `360p30`, `360p25`, `360p5`.
+
+**Step 2:** Restart the relevant camera service (`S99v4l2-mpp-mipi` or `S99v4l2-mpp-usb`) or reboot the printer for changes to take effect.
 
 ### RTSP Streaming
 

--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -43,8 +43,10 @@ Toggle settings directly from the web interface:
 | Frontend | Fluidd, Mainsail | Switch between web interfaces |
 | Require Login (Fluidd only) | Enabled, Disabled | Require login for Moonraker API access |
 | Internal Camera | Paxx12, Snapmaker, Disabled | Select camera service |
+| Internal Camera Resolution | 1080p30, 1080p25, 1080p15, 1080p5 | Framerate for the internal camera (paxx12 service only; resolution is fixed at 1080p for AI detection) |
 | Camera RTSP Stream | Enabled, Disabled | Enable RTSP streaming |
 | USB Camera | Enabled, Disabled | Enable USB camera support |
+| USB Camera Resolution | 1080p30, 1080p25, 1080p5, 720p30, 720p25, 720p5, 360p30, 360p25, 360p5 | Resolution and framerate for the USB camera (paxx12 service only) |
 | Remote Screen | Enabled, Disabled | Enable remote screen access |
 | Klipper Metrics Exporter | Enabled, Disabled | Enable Prometheus metrics |
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
@@ -144,9 +146,15 @@ Note: Remote screen requires additional Moonraker configuration. See [Remote Scr
 - `snapmaker` - Native Snapmaker camera service
 - `none` - Disable internal camera
 
+**internal_resolution** - Internal camera framerate (paxx12 service only; resolution is fixed at 1080p for AI detection)
+- `1080p30`, `1080p25` (default), `1080p15`, `1080p5`
+
 **usb** - USB camera service selection
 - `paxx12` - Enable USB camera with paxx12 service at `http://<printer-ip>/webcam2/`
 - `none` (default) - USB camera disabled
+
+**usb_resolution** - USB camera resolution and framerate (paxx12 service only)
+- `1080p30`, `1080p25` (default), `1080p5`, `720p30`, `720p25`, `720p5`, `360p30`, `360p25`, `360p5`
 
 **rtsp** - Enable RTSP streaming support (paxx12 service only)
 - `true` - Enable RTSP streaming at `rtsp://<printer-ip>:8554/stream` (internal) and `rtsp://<printer-ip>:8555/stream` (USB)
@@ -206,8 +214,12 @@ remote_screen: false
 [camera]
 # Internal (Case) camera options: paxx12, snapmaker, none
 internal: paxx12
+# Internal (Case) camera resolution/framerate preset, resolution is always 1080p: 1080p30, 1080p25, 1080p15, 1080p5
+# internal_resolution: 1080p25
 # External (USB) camera options: paxx12, none
 usb: none
+# External (USB) camera resolution/framerate preset: 1080p30, 1080p25, 1080p5, 720p30, 720p25, 720p5, 360p30, 360p25, 360p5
+# usb_resolution: 1080p25
 # Enable RTSP streaming server: true, false
 rtsp: false
 

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -11,8 +11,12 @@ remote_screen: false
 [camera]
 # Internal (Case) camera options: paxx12, snapmaker, none
 internal: paxx12
+# Internal (Case) camera resolution/framerate preset, resolution is always 1080p: 1080p30, 1080p25, 1080p15, 1080p5
+# internal_resolution: 1080p25
 # External (USB) camera options: paxx12, none
 usb: none
+# External (USB) camera resolution/framerate preset: 1080p30, 1080p25, 1080p5, 720p30, 720p25, 720p5, 360p30, 360p25, 360p5
+# usb_resolution: 1080p25
 # Enable RTSP streaming server: true, false
 rtsp: false
 

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
@@ -11,7 +11,16 @@ if [ "$CAMERA_LOGS" = "syslog" ]; then
 fi
 RTSP_ENABLED=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera rtsp false)
 
-CMD_CAPTURE="/usr/local/bin/capture-v4l2-raw-mpp --device /dev/video11 --format nv12 --jpeg-quality 7 --jpeg-sock /tmp/capture-mipi-jpeg.sock --mjpeg-sock /tmp/capture-mipi-mjpeg.sock --h264-sock /tmp/capture-mipi-h264.sock --raw-frame-sock /tmp/capture-mipi-raw.sock --width 1920 --height 1080 --fps 30"
+INTERNAL_RESOLUTION=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera internal_resolution 1080p25)
+case "$INTERNAL_RESOLUTION" in
+    1080p30) INTERNAL_WIDTH=1920; INTERNAL_HEIGHT=1080; INTERNAL_FPS=30 ;;
+    1080p25) INTERNAL_WIDTH=1920; INTERNAL_HEIGHT=1080; INTERNAL_FPS=25 ;;
+    1080p15) INTERNAL_WIDTH=1920; INTERNAL_HEIGHT=1080; INTERNAL_FPS=15 ;;
+    1080p5)  INTERNAL_WIDTH=1920; INTERNAL_HEIGHT=1080; INTERNAL_FPS=5  ;;
+    *)       INTERNAL_WIDTH=1920; INTERNAL_HEIGHT=1080; INTERNAL_FPS=25 ;;
+esac
+
+CMD_CAPTURE="/usr/local/bin/capture-v4l2-raw-mpp --device /dev/video11 --format nv12 --jpeg-quality 7 --jpeg-sock /tmp/capture-mipi-jpeg.sock --mjpeg-sock /tmp/capture-mipi-mjpeg.sock --h264-sock /tmp/capture-mipi-h264.sock --raw-frame-sock /tmp/capture-mipi-raw.sock --width $INTERNAL_WIDTH --height $INTERNAL_HEIGHT --fps $INTERNAL_FPS --buffers 3"
 
 CMD_WEBRTC="/usr/local/bin/stream-webrtc --h264-sock /tmp/capture-mipi-h264.sock --webrtc-sock /tmp/capture-mipi-webrtc.sock"
 

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-usb
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-usb
@@ -11,7 +11,21 @@ if [ "$CAMERA_LOGS" = "syslog" ]; then
 fi
 RTSP_ENABLED=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera rtsp false)
 
-CMD_CAPTURE="/usr/local/bin/capture-v4l2-jpeg-mpp --device /dev/video18 --jpeg-sock /tmp/capture-usb-jpeg.sock --mjpeg-sock /tmp/capture-usb-mjpeg.sock --h264-sock /tmp/capture-usb-h264.sock"
+USB_RESOLUTION=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera usb_resolution 1080p25)
+case "$USB_RESOLUTION" in
+    1080p30) USB_WIDTH=1920; USB_HEIGHT=1080; USB_FPS=30 ;;
+    1080p25) USB_WIDTH=1920; USB_HEIGHT=1080; USB_FPS=25 ;;
+    1080p5)  USB_WIDTH=1920; USB_HEIGHT=1080; USB_FPS=5  ;;
+    720p30)  USB_WIDTH=1280; USB_HEIGHT=720;  USB_FPS=30 ;;
+    720p25)  USB_WIDTH=1280; USB_HEIGHT=720;  USB_FPS=25 ;;
+    720p5)   USB_WIDTH=1280; USB_HEIGHT=720;  USB_FPS=5  ;;
+    360p30)  USB_WIDTH=640;  USB_HEIGHT=360;  USB_FPS=30 ;;
+    360p25)  USB_WIDTH=640;  USB_HEIGHT=360;  USB_FPS=25 ;;
+    360p5)   USB_WIDTH=640;  USB_HEIGHT=360;  USB_FPS=5  ;;
+    *)       USB_WIDTH=1920; USB_HEIGHT=1080; USB_FPS=25 ;;
+esac
+
+CMD_CAPTURE="/usr/local/bin/capture-v4l2-jpeg-mpp --device /dev/video18 --width $USB_WIDTH --height $USB_HEIGHT --fps $USB_FPS --buffers 2 --jpeg-sock /tmp/capture-usb-jpeg.sock --mjpeg-sock /tmp/capture-usb-mjpeg.sock --h264-sock /tmp/capture-usb-h264.sock"
 
 CMD_WEBRTC="/usr/local/bin/stream-webrtc --h264-sock /tmp/capture-usb-h264.sock --webrtc-sock /tmp/capture-usb-webrtc.sock"
 

--- a/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
+++ b/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
@@ -58,6 +58,52 @@ settings:
                 /etc/init.d/S90lmd stop
         default: paxx12
 
+      camera-internal-resolution:
+        label: Internal Camera Resolution
+        description: Resolution and framerate for the built-in MIPI camera. Resolution is always 1080p; only framerate can be lowered.
+        if_cmd: test "$(/usr/local/bin/extended-config.py get /home/lava/printer_data/config/extended/extended2.cfg camera internal paxx12)" = "paxx12"
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /home/lava/printer_data/config/extended/extended2.cfg
+          - camera
+          - internal_resolution
+          - 1080p25
+        options:
+          1080p30:
+            label: 1920x1080 @ 30fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera internal_resolution 1080p30 &&
+                /etc/init.d/S99v4l2-mpp-mipi restart
+          1080p25:
+            label: 1920x1080 @ 25fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera internal_resolution 1080p25 &&
+                /etc/init.d/S99v4l2-mpp-mipi restart
+          1080p15:
+            label: 1920x1080 @ 15fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera internal_resolution 1080p15 &&
+                /etc/init.d/S99v4l2-mpp-mipi restart
+          1080p5:
+            label: 1920x1080 @ 5fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera internal_resolution 1080p5 &&
+                /etc/init.d/S99v4l2-mpp-mipi restart
+        default: 1080p25
+
       camera-usb:
         label: USB Camera
         description: Enable streaming from an attached USB camera.
@@ -91,6 +137,92 @@ settings:
                 /etc/init.d/S99v4l2-mpp-usb stop &&
                 /etc/init.d/S61moonraker restart
         default: none
+
+      camera-usb-resolution:
+        label: USB Camera Resolution
+        description: Resolution and framerate for the USB camera stream. Only supported by the paxx12 USB camera driver.
+        if_cmd: test "$(/usr/local/bin/extended-config.py get /home/lava/printer_data/config/extended/extended2.cfg camera usb none)" = "paxx12"
+        get_cmd:
+          - /usr/local/bin/extended-config.py
+          - get
+          - /home/lava/printer_data/config/extended/extended2.cfg
+          - camera
+          - usb_resolution
+          - 1080p25
+        options:
+          1080p30:
+            label: 1920x1080 @ 30fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 1080p30 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          1080p25:
+            label: 1920x1080 @ 25fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 1080p25 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          1080p5:
+            label: 1920x1080 @ 5fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 1080p5 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          720p30:
+            label: 1280x720 @ 30fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 720p30 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          720p25:
+            label: 1280x720 @ 25fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 720p25 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          720p5:
+            label: 1280x720 @ 5fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 720p5 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          360p30:
+            label: 640x360 @ 30fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 360p30 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          360p25:
+            label: 640x360 @ 25fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 360p25 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+          360p5:
+            label: 640x360 @ 5fps
+            cmd:
+              - bash
+              - -xc
+              - |
+                /usr/local/bin/extended-config.py add /home/lava/printer_data/config/extended/extended2.cfg camera usb_resolution 360p5 &&
+                /etc/init.d/S99v4l2-mpp-usb restart
+        default: 1080p25
 
       camera-rtsp:
         label: RTSP Stream (paxx12 only)

--- a/overlays/firmware-extended/60-app-camera/scripts/01-v4l2-mpp.sh
+++ b/overlays/firmware-extended/60-app-camera/scripts/01-v4l2-mpp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GIT_URL=https://github.com/paxx12/v4l2-mpp.git
-GIT_SHA=1cb2b9c111ee1034eba72d29f447cbccb44f197c
+GIT_SHA=a8cd3ad5acc33bab3475aea151e5a50002b742bb
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."


### PR DESCRIPTION
Exposes `camera-internal-resolution` and `camera-usb-resolution` in `firmware-config`'s Camera settings, following the same preset-based pattern already used for `camera-internal`/`camera-usb`/`camera-rtsp`.

**Both default to `1080p25` and are left commented out in `extended2.cfg`, like other optional settings.**

Internal camera presets vary only fps, since resolution must stay at 1080p for AI detection and related features to work: `1080p30`, `1080p25`, `1080p15`, `1080p5`. USB presets vary both resolution and fps: `1080p30`, `1080p25`, `1080p5`, `720p30`, `720p25`, `720p5`, `360p30`, `360p25`, `360p5` - all 16:9 to match `aspect_ratio: 16:9` in the moonraker `webcam` sections.

`S99v4l2-mpp-mipi` and `S99v4l2-mpp-usb` now derive WIDTH/HEIGHT/FPS for `CMD_CAPTURE` from the selected preset, and pass `--buffers` (3 internal, 2 USB) to it.

## Reason

This was deeply investigated by @djgringoboy2003. He also create reference PR: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/490 for this change.

## References

- Closes https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/490
- Closes https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/issues/437

## Screenshots

<img width="868" height="314" alt="image" src="https://github.com/user-attachments/assets/d4afc043-c7cd-4cfc-9c7a-18cbb7b25c59" />

