### PR TITLE
Set `cavity_led` PWM to 300Hz to fix camera flicker

### DIFF
--- a/overlays/firmware-extended/60-app-camera/patches/03-cavity-led-pwm-frequency.patch
+++ b/overlays/firmware-extended/60-app-camera/patches/03-cavity-led-pwm-frequency.patch
@@ -1,0 +1,12 @@
+--- a/home/lava/origin_printer_data/config/printer.cfg
++++ b/home/lava/origin_printer_data/config/printer.cfg
+@@ -260,6 +260,9 @@
+ 
+ [led cavity_led]
+ white_pin: PA10
++# 300Hz cycle_time divides evenly into both 25fps and 30fps camera framerates,
++# avoiding beat-frequency flicker against the default 100Hz (cycle_time: 0.010).
++cycle_time: 0.003333
+ 
+ [purifier]
+ # exhaust fan


### PR DESCRIPTION
Patches `printer.cfg` to set `cycle_time: 0.003333` (300Hz) on `[led cavity_led]`, up from Klipper's default of `cycle_time: 0.010` (100Hz).

100Hz doesn't divide evenly into the paxx12 camera's 30fps capture rates, so each frame samples the LED's software PWM duty cycle at a different phase, producing a slow flicker/beat pattern in recordings. 300Hz divides evenly into both (12 cycles per frame at 25fps, 10 at 30fps), so every frame sees the same duty cycle and the flicker goes away.

## Reason

This was deeply investigated by @djgringoboy2003. He also create reference PR: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/490 for this change.

## References

- https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/574
- https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/490
- https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/issues/437