### PR TITLE
Add firmware-upgrade imposter and force-block snapmaker firmware auto-updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 firmware/
 tmp/
+*.o
+*.so
 tools/upfile/upfile
 tools/rk2918_tools/afptool
 tools/rk2918_tools/img_maker

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/Makefile
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/Makefile
@@ -1,0 +1,34 @@
+CROSS_COMPILE ?=
+CC = $(CROSS_COMPILE)gcc
+STRIP = $(CROSS_COMPILE)strip
+
+TARGET = libfirmware-imposter.so
+
+CFLAGS = -Wall -Wextra -O2 -fPIC
+LDFLAGS = -shared -lpthread -ldl
+
+SRCS = main.c
+OBJS = $(SRCS:.c=.o)
+
+PREFIX ?= /usr/local
+LIBDIR ?= $(PREFIX)/lib
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CC) $(OBJS) -o $@ $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+strip: $(TARGET)
+	$(STRIP) $(TARGET)
+
+clean:
+	rm -f $(OBJS) $(TARGET)
+
+install: $(TARGET)
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m 755 $(TARGET) $(DESTDIR)$(LIBDIR)/
+
+.PHONY: all clean strip install

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/README.md
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/README.md
@@ -1,0 +1,46 @@
+# firmware-imposter
+
+A `libcurl` wrapper library that blocks the firmware-update check made by
+`unisrv` instead of letting it reach `id.snapmaker.com`.
+
+## Description
+
+`unisrv` performs its firmware-update check over HTTPS using `libcurl`. It
+issues a `GET` to `https://id.snapmaker.com/api/device/firmware/latest` and
+parses the JSON response (`ApiDeviceFirmwareLatest`).
+
+This library provides a drop-in replacement for `curl_easy_perform`. When
+loaded via `LD_PRELOAD` with `FW_UPDATE_BLOCK=1` set, every perform reads the
+request's current URL with `curl_easy_getinfo(CURLINFO_EFFECTIVE_URL)`. If
+that URL contains the configured match string, the request fails immediately
+with `CURLE_COULDNT_CONNECT` without performing any transfer at all, so
+`unisrv` never reaches the network and reports no update available.
+
+Everything happens inside `curl_easy_perform` — there is no per-handle
+bookkeeping. The library only activates when `FW_UPDATE_BLOCK` is set, and
+only inside the `unisrv` process (it checks `/proc/self/exe`), so preloading
+it on the `lmd` launcher — which also starts `gui` and `flow_calc_server` —
+leaves those processes untouched.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FW_IMPOSTER_DEBUG` | `0` | Set to `1` to enable debug logging to stderr |
+| `FW_UPDATE_URL` | (none — must be set) | Substring matched against the request URL |
+| `FW_UPDATE_BLOCK` | `0` | Set to `1` to fail matching requests, disabling the update check entirely |
+
+## Usage
+
+```sh
+LD_PRELOAD=/usr/local/lib/libfirmware-imposter.so \
+  FW_UPDATE_URL="/api/device/firmware/latest" \
+  FW_UPDATE_BLOCK=1 \
+  unisrv
+```
+
+## Notes
+
+- Reading the pending URL before the transfer relies on
+  `CURLINFO_EFFECTIVE_URL`, which returns the set URL in libcurl 8.x (the
+  device ships libcurl/8.6.0).

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/main.c
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/main.c
@@ -1,0 +1,87 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <dlfcn.h>
+
+#define LOG_PREFIX "[firmware-imposter] "
+#define LOG_DEBUG(fmt, ...) do { if (cfg_debug) fprintf(stderr, LOG_PREFIX "DEBUG[%d]: " fmt "\n", getpid(), ##__VA_ARGS__); } while(0)
+#define LOG_INFO(fmt, ...) fprintf(stderr, LOG_PREFIX "INFO[%d]: " fmt "\n", getpid(), ##__VA_ARGS__)
+
+typedef void CURL;
+typedef int CURLcode;
+typedef int CURLINFO;
+
+#define CURLINFO_EFFECTIVE_URL 0x100001
+#define CURLE_COULDNT_CONNECT 7
+
+typedef CURLcode (*perform_fn)(CURL *);
+typedef CURLcode (*getinfo_fn)(CURL *, CURLINFO, ...);
+
+static perform_fn real_perform;
+static getinfo_fn real_getinfo;
+
+static pthread_once_t g_once = PTHREAD_ONCE_INIT;
+static bool g_active = false;
+
+static int cfg_debug = 0;
+static char cfg_url_match[256] = "";
+
+static void init_once(void)
+{
+    const char *env;
+
+    real_perform = (perform_fn)dlsym(RTLD_NEXT, "curl_easy_perform");
+    real_getinfo = (getinfo_fn)dlsym(RTLD_NEXT, "curl_easy_getinfo");
+
+    char self_path[256];
+    ssize_t len = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+    if (len >= 0) {
+        self_path[len] = '\0';
+        const char *base = strrchr(self_path, '/');
+        base = base ? base + 1 : self_path;
+        if (strcmp(base, "unisrv") != 0) {
+            LOG_DEBUG("Current process is not unisrv (%s), passthrough", base);
+            return;
+        }
+    }
+
+    env = getenv("FW_IMPOSTER_DEBUG");
+    if (env && atoi(env))
+        cfg_debug = 1;
+
+    env = getenv("FW_UPDATE_URL");
+    if (env && strlen(env) > 0) {
+        strncpy(cfg_url_match, env, sizeof(cfg_url_match) - 1);
+        cfg_url_match[sizeof(cfg_url_match) - 1] = '\0';
+    }
+
+    env = getenv("FW_UPDATE_BLOCK");
+    if (env && atoi(env)) {
+        g_active = true;
+        LOG_INFO("Active: blocking requests matching '%s'", cfg_url_match);
+    } else {
+        LOG_DEBUG("FW_UPDATE_BLOCK not set, passthrough");
+    }
+}
+
+CURLcode curl_easy_perform(CURL *handle)
+{
+    pthread_once(&g_once, init_once);
+
+    if (!g_active || handle == NULL)
+        return real_perform(handle);
+
+    char *url = NULL;
+    real_getinfo(handle, CURLINFO_EFFECTIVE_URL, &url);
+
+    if (url && strstr(url, cfg_url_match) != NULL) {
+        LOG_INFO("Blocking request to %s", url);
+        return CURLE_COULDNT_CONNECT;
+    }
+
+    return real_perform(handle);
+}

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/patches/01-preload-firmware-imposter.patch
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/patches/01-preload-firmware-imposter.patch
@@ -1,0 +1,14 @@
+--- a/etc/init.d/S90lmd
++++ b/etc/init.d/S90lmd
+@@ -5,6 +5,11 @@
+
+ PROG=/usr/bin/lmd
+
++echo "Starting lmd with firmware-upgrade check disabled!"
++export LD_PRELOAD="/usr/local/lib/libfirmware-imposter.so${LD_PRELOAD:+:$LD_PRELOAD}"
++export FW_UPDATE_URL="/api/device/firmware/latest"
++export FW_UPDATE_BLOCK=1
++
+ case "$1" in
+     start)
+         ulimit -c 102400

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/scripts/01-firmware-imposter.sh
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/scripts/01-firmware-imposter.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+CUR_DIR="$(realpath "$(dirname "$0")")"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rootfs-dir>"
+  exit 1
+fi
+
+set -eo pipefail
+
+echo ">> Setting up cross-compilation environment..."
+export CROSS_COMPILE=aarch64-linux-gnu-
+
+echo ">> Compiling firmware-imposter..."
+make -C "$CUR_DIR/../apps/firmware-imposter" install DESTDIR="$1"
+
+echo ">> Validate binaries..."
+stat "$1/usr/local/lib/libfirmware-imposter.so" >/dev/null
+
+echo ">> firmware-imposter installation completed successfully."

--- a/overlays/firmware-extended/60-app-camera/patches/02-disable-native-camera.patch
+++ b/overlays/firmware-extended/60-app-camera/patches/02-disable-native-camera.patch
@@ -8,7 +8,7 @@
 +        CAMERA_INTERNAL=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera internal snapmaker)
 +        if [ "$CAMERA_INTERNAL" = "paxx12" ]; then
 +            echo "Starting lmd in v4l2-imposter mode!"
-+            export LD_PRELOAD=/usr/local/lib/libv4l2-imposter.so
++            export LD_PRELOAD=/usr/local/lib/libv4l2-imposter.so${LD_PRELOAD:+:$LD_PRELOAD}
 +            export V4L2_IMPOSTER_SOCKET_PATH=/tmp/capture-mipi-raw.sock
 +            export V4L2_IMPOSTER_DEVICE=/dev/video11
 +            export V4L2_IMPOSTER_WIDTH=1920


### PR DESCRIPTION
`unisrv` performs its firmware-update check over HTTPS with `libcurl`, issuing a `GET` to `https://id.snapmaker.com/api/device/firmware/latest`. Adds the `40-feature-upgrade-firmware` overlay, which builds `libfirmware-imposter.so`, an `LD_PRELOAD` shim that interposes `curl_easy_perform`: it reads the request URL via
`curl_easy_getinfo(CURLINFO_EFFECTIVE_URL)` and, when it matches the firmware endpoint and `FW_UPDATE_BLOCK` is set, fails the request immediately with `CURLE_COULDNT_CONNECT` without touching the network. The shim only activates inside `unisrv`.
 
The overlay patches `etc/init.d/S90lmd` (the `lmd` launcher that `execv`s `unisrv`) to unconditionally preload the shim and set `FW_UPDATE_BLOCK=1`, so the update check is force-disabled for now with no config toggle. The injection appends to `LD_PRELOAD` rather than replacing it, and the camera imposter's branch in `60-app-camera/patches/02-disable-native-camera.patch` is made additive too, so the two compose when both are enabled.