### PR TITLE
Update Mainsail to `v2.18.2`

### DIFF
--- a/overlays/firmware-extended/63-app-mainsail/scripts/01-install-mainsail.sh
+++ b/overlays/firmware-extended/63-app-mainsail/scripts/01-install-mainsail.sh
@@ -17,9 +17,9 @@ if [[ ! -L "$ROOTFS_DIR/etc/nginx/sites-enabled/fluidd" ]]; then
   exit 1
 fi
 
-VERSION=v2.17.0
+VERSION=v2.18.2
 URL=https://github.com/mainsail-crew/mainsail/releases/download/$VERSION/mainsail.zip
-SHA256=d010f4df25557d520ccdbb8e42fc381df2288e6a5c72d3838a5a2433c7a31d4e
+SHA256=df2ba7c301f7bfc8ac9f122741a6ba08356d679ecfa1f62f898d0337802d5de5
 FILENAME=mainsail-$VERSION.zip
 
 rm -rf "$ROOTFS_DIR/home/lava/mainsail"


### PR DESCRIPTION
Bumps the pinned Mainsail release from `v2.17.0` to `v2.18.2` in `63-app-mainsail/scripts/01-install-mainsail.sh`, updating the `VERSION` and the `SHA256` checksum of `mainsail.zip` accordingly.