### PR TITLE
Update OpenRFID to align RFID reset timeouts with firmware `1.4.0`

### DIFF
--- a/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
+++ b/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GIT_URL=https://github.com/suchmememanyskill/OpenRFID.git
-GIT_SHA=ddd1609e9abe9cd37c4b8fa1a0e4307b976d5fd4
+GIT_SHA=1a6f605d0334157b532afdd14f89fc182d9000f6
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."


### PR DESCRIPTION
Bumps the pinned OpenRFID checkout in `64-app-openrfid/pre-scripts/01-install-openrfid.sh` from `ddd1609e` to `1a6f605d` ([OpenRFID#23](https://github.com/suchmememanyskill/OpenRFID/commit/1a6f605d0334157b532afdd14f89fc182d9000f6), "Align RFID reset timeouts with Snapmaker U1 v1.4.0 firmware").

The new commit shortens the `hard_reset` pulse timings (`0.3s` → `0.1s`/`0.2s`) and adds a `sleep(0.100)` settle after switching channel-select GPIOs — the same changes previously carried locally, so the downstream `02-improve-channel-select.patch` can be dropped.