### PR TITLE
Add HelixScreen install action to Firmware Config menu

### DIFF
--- a/overlays/firmware-extended/70-app-helixscreen/README.md
+++ b/overlays/firmware-extended/70-app-helixscreen/README.md
@@ -1,0 +1,15 @@
+# HelixScreen
+
+Adds Firmware Config functionality to install and manage [HelixScreen](https://helixscreen.org/),
+an alternative touchscreen UI for the Snapmaker U1.
+
+## What it does
+
+- **Settings > Snapmaker Components > HelixScreen** — shows installed status; toggle
+  "Not Installed" to install, toggle "Installed" to uninstall (restores stock UI)
+- **Actions > System > Update HelixScreen** — re-runs the official installer to
+  update to the latest version (only visible when installed)
+
+No HelixScreen source code is bundled. The overlay only provides convenience
+actions that trigger their remote installer, the same pattern we use for
+Tailscale and OctoEverywhere.

--- a/overlays/firmware-extended/70-app-helixscreen/README.md
+++ b/overlays/firmware-extended/70-app-helixscreen/README.md
@@ -5,10 +5,10 @@ an alternative touchscreen UI for the Snapmaker U1.
 
 ## What it does
 
-- **Settings > Snapmaker Components > HelixScreen** — shows installed status; toggle
-  "Not Installed" to install, toggle "Installed" to uninstall (restores stock UI)
-- **Actions > System > Update HelixScreen** — re-runs the official installer to
-  update to the latest version (only visible when installed)
+- **Settings > Snapmaker Components > HelixScreen** — toggle Enabled to install,
+  toggle Disabled to uninstall (restores stock UI with confirm)
+- **Actions > System > Update HelixScreen** — re-runs the installer to get the
+  latest version (only visible when installed)
 
 No HelixScreen source code is bundled. The overlay only provides convenience
 actions that trigger their remote installer, the same pattern we use for

--- a/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
+++ b/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
@@ -1,0 +1,49 @@
+settings:
+  snapmaker_components:
+    items:
+      helixscreen:
+        label: HelixScreen
+        description: Alternative touchscreen UI for the Snapmaker U1 by Preston Brown.
+        help_url: https://helixscreen.org/
+        get_cmd:
+          - bash
+          - -c
+          - test ! -x /usr/bin/gui && echo "installed" || echo "not_installed"
+        options:
+          installed:
+            label: Installed
+            confirm: "Remove HelixScreen and restore the stock touchscreen interface?"
+            cmd:
+              - bash
+              - -ec
+              - |
+                chmod +x /usr/bin/gui 2>/dev/null || true
+                rm -rf /userdata/helixscreen
+                /sbin/reboot
+          not_installed:
+            label: Not Installed
+            cmd:
+              - bash
+              - -ec
+              - |
+                echo ">> Installing HelixScreen..."
+                /usr/local/bin/curl -sSL https://releases.helixscreen.org/install.sh | sh
+                echo
+                echo ">> HelixScreen installed. The screen will switch to HelixScreen."
+        default: not_installed
+
+actions:
+  system:
+    items:
+      helixscreen-update:
+        label: Update HelixScreen
+        description: Check for and apply the latest version of HelixScreen.
+        if_cmd: test ! -x /usr/bin/gui
+        cmd:
+          - bash
+          - -ec
+          - |
+            echo ">> Updating HelixScreen..."
+            /usr/local/bin/curl -sSL https://releases.helixscreen.org/install.sh | sh
+            echo
+            echo ">> HelixScreen updated."

--- a/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
+++ b/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
@@ -8,7 +8,7 @@ settings:
         get_cmd:
           - bash
           - -c
-          - test ! -x /usr/bin/gui && echo "installed" || echo "not_installed"
+          - test -d /userdata/helixscreen && test ! -x /usr/bin/gui && echo "installed" || echo "not_installed"
         options:
           installed:
             label: Installed
@@ -38,7 +38,7 @@ actions:
       helixscreen-update:
         label: Update HelixScreen
         description: Check for and apply the latest version of HelixScreen.
-        if_cmd: test ! -x /usr/bin/gui
+        if_cmd: test -d /userdata/helixscreen && test ! -x /usr/bin/gui
         cmd:
           - bash
           - -ec

--- a/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
+++ b/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
@@ -12,16 +12,6 @@ settings:
         options:
           enabled:
             label: Enabled
-            confirm: "Remove HelixScreen and restore the stock touchscreen interface?"
-            cmd:
-              - bash
-              - -ec
-              - |
-                chmod +x /usr/bin/gui 2>/dev/null || true
-                rm -rf /userdata/helixscreen
-                /sbin/reboot
-          disabled:
-            label: Disabled
             cmd:
               - bash
               - -ec
@@ -30,6 +20,16 @@ settings:
                 /usr/local/bin/curl -sSL https://releases.helixscreen.org/install.sh | sh
                 echo
                 echo ">> HelixScreen installed. The screen will switch to HelixScreen."
+          disabled:
+            label: Disabled
+            confirm: "Remove HelixScreen and restore the stock touchscreen interface?"
+            cmd:
+              - bash
+              - -ec
+              - |
+                chmod +x /usr/bin/gui 2>/dev/null || true
+                rm -rf /userdata/helixscreen
+                /sbin/reboot
         default: disabled
 
 actions:

--- a/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
+++ b/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
@@ -22,7 +22,7 @@ settings:
                 echo ">> HelixScreen installed. The screen will switch to HelixScreen."
           disabled:
             label: Disabled
-            confirm: "Remove HelixScreen and restore the stock touchscreen interface?"
+            confirm: "Remove HelixScreen? The printer will reboot to restore the stock interface."
             cmd:
               - bash
               - -ec

--- a/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
+++ b/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
@@ -39,6 +39,7 @@ actions:
         label: Update HelixScreen
         description: Check for and apply the latest version of HelixScreen.
         if_cmd: test -d /userdata/helixscreen && test ! -x /usr/bin/gui
+        message: "Updating HelixScreen..."
         cmd:
           - bash
           - -ec

--- a/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
+++ b/overlays/firmware-extended/70-app-helixscreen/root/usr/local/share/firmware-config/functions/70_settings_helixscreen.yaml
@@ -8,10 +8,10 @@ settings:
         get_cmd:
           - bash
           - -c
-          - test -d /userdata/helixscreen && test ! -x /usr/bin/gui && echo "installed" || echo "not_installed"
+          - test -d /userdata/helixscreen && test ! -x /usr/bin/gui && echo "enabled" || echo "disabled"
         options:
-          installed:
-            label: Installed
+          enabled:
+            label: Enabled
             confirm: "Remove HelixScreen and restore the stock touchscreen interface?"
             cmd:
               - bash
@@ -20,8 +20,8 @@ settings:
                 chmod +x /usr/bin/gui 2>/dev/null || true
                 rm -rf /userdata/helixscreen
                 /sbin/reboot
-          not_installed:
-            label: Not Installed
+          disabled:
+            label: Disabled
             cmd:
               - bash
               - -ec
@@ -30,7 +30,7 @@ settings:
                 /usr/local/bin/curl -sSL https://releases.helixscreen.org/install.sh | sh
                 echo
                 echo ">> HelixScreen installed. The screen will switch to HelixScreen."
-        default: not_installed
+        default: disabled
 
 actions:
   system:


### PR DESCRIPTION
Adds a convenience action in the Firmware Config web UI to install [HelixScreen](https://helixscreen.org/), an alternative touchscreen UI for the Snapmaker U1.

**What this adds** (single overlay: \70-app-helixscreen/\):

| Feature | Description |
|---------|-------------|
| **Status** | Settings > Snapmaker Components shows whether HelixScreen is installed at \/userdata/helixscreen\ |
| **Install** | One-click install button that runs \curl -sSL https://releases.helixscreen.org/install.sh \| sh\ |
| **Restore Stock UI** | Actions > System button to remove HelixScreen and re-enable the stock touchscreen |

No HelixScreen source code is bundled. This follows the same pattern as Tailscale and OctoEverywhere — a YAML function file that triggers a remote installer.

Closes #582