### PR TITLE
Drop card resolution from the Klipper `spoollink` router

### DIFF
--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/klipper/klippy/extras/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/klipper/klippy/extras/spoollink.py
@@ -8,29 +8,6 @@ class SpoolLink:
         self.gcode = self.printer.lookup_object('gcode')
         self.printer.lookup_object('webhooks').register_endpoint(
             'spoollink/set', self._handle_set)
-        self.printer.register_event_handler('klippy:ready', self._handle_ready)
-
-    def _handle_ready(self):
-        fd = self.printer.lookup_object('filament_detect', None)
-        if fd is not None:
-            fd.register_cb_2_update_filament_info(self._on_filament_info)
-
-    def _on_filament_info(self, channel, info, is_clear):
-        if is_clear:
-            return
-        spool_id = info.get('SPOOL_ID', 0) or 0
-        uid_raw = info.get('CARD_UID') or []
-        card_uid = (''.join('%02X' % b for b in uid_raw)
-                    if uid_raw and any(b != 0 for b in uid_raw) else '')
-        wh = self.printer.lookup_object('webhooks')
-        if spool_id != 0 or not wh.has_remote_method('spoollink_resolve_spool'):
-            return
-        if card_uid:
-            wh.call_remote_method('spoollink_resolve_spool',
-                                  channel=channel, spool_id=spool_id,
-                                  card_uid=card_uid)
-        else:
-            self.gcode.respond_raw('// SpoolLink: E%d no card present' % (channel + 1))
 
     def _handle_set(self, web_request):
         wh = self.printer.lookup_object('webhooks')


### PR DESCRIPTION
The Klipper `[spoollink]` router registered a `filament_detect` callback that called `spoollink_resolve_spool` on every card read, duplicating the card-UID resolution Moonraker already performs from its own `filament_detect` subscription. A single card read reached SpoolLink twice — once via the callback, once via the subscription — so each load applied the same spool twice, with a redundant Spoolman fetch each time:

```
.806  apply spool 21          ← resolve via the Klipper callback
.904  spool_ids 0 → 21        ← echo of that apply landing in `print_task_config`
.904  ch1: card UID changed   ← Moonraker's subscription seeing the same read
.981  apply spool 21 (again)  ← redundant
```

The callback could not contribute anything the subscription did not. `SPOOL_ID` is absent from `filament_protocol.FILAMENT_INFO_STRUCT` and `filament_detect/set` rejects it, so `info.get('SPOOL_ID', 0)` was always `0`: the `spool_id != 0` guard never fired and the call always resolved by card UID alone. It was also driven by `_filament_info_update`, which notifies on every read rather than on change, so identical re-scans re-resolved.

Moonraker's subscription is edge-triggered, is needed regardless for `print_task_config` and `toolhead`, and is the only path that resolves a card already present when Moonraker reconnects.

`spoollink_resolve_spool` itself stays registered: `afc.cfg` calls it with a non-zero `SPOOL_ID` for resolve-by-ID, and `spoollink/set` still probes it to detect whether the Moonraker component is loaded.

## Note

The `// SpoolLink: E%d no card present` message was only emitted from the removed callback and is gone. Happy to reinstate it as a minimal callback that does nothing else if it is worth keeping.