### PR TITLE
Derive `EXTRACT_DIR` per firmware version and prune unused images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 .PHONY: build
 build: $(OUTPUT_FILE)
 
-EXTRACT_DIR := tmp/extracted
+EXTRACT_DIR := tmp/extracted-$(FIRMWARE_VERSION)
 
 .PHONY: extract
 extract: firmware/$(FIRMWARE_FILE) tools

--- a/docs/development.md
+++ b/docs/development.md
@@ -206,7 +206,7 @@ To extract and examine the base firmware:
 ./dev.sh make extract
 ```
 
-Output: `tmp/extracted/`
+Output: `tmp/extracted-<version>/` (the `FIRMWARE_VERSION` from `vars.mk`)
 
 ## Upgrade Firmware
 

--- a/scripts/dev/save-patch.sh
+++ b/scripts/dev/save-patch.sh
@@ -8,8 +8,15 @@ fi
 
 set -xeo pipefail
 
-if [[ ! -d tmp/extracted/rootfs.original ]]; then
-  unsquashfs -d tmp/extracted/rootfs.original tmp/extracted/rk-unpacked/rootfs.img
+EXTRACT_DIR="tmp/extracted-$(sed -n 's/^FIRMWARE_VERSION=//p' vars.mk)"
+
+if [[ ! -d "$EXTRACT_DIR" ]]; then
+  echo "$EXTRACT_DIR not found, run 'make extract' first" >&2
+  exit 1
+fi
+
+if [[ ! -d "$EXTRACT_DIR/rootfs.original" ]]; then
+  unsquashfs -d "$EXTRACT_DIR/rootfs.original" "$EXTRACT_DIR/rk-unpacked/rootfs.img"
 fi
 
 OVERLAY_NAME="$1"

--- a/scripts/extract_squashfs.sh
+++ b/scripts/extract_squashfs.sh
@@ -19,4 +19,10 @@ echo ">> Unpacking firmware..."
 echo ">> Extracting squashfs from rootfs.img..."
 unsquashfs -d "$OUT_DIR/rootfs" "$OUT_DIR/rk-unpacked/rootfs.img"
 
+# Drop the repacked images now that rootfs is unpacked. rootfs.img is kept as
+# the pristine reference that scripts/dev/save-patch.sh diffs against.
+echo ">> Pruning images not needed for inspection..."
+rm -f "$OUT_DIR/rk-rom.img" "$OUT_DIR/update.img"
+find "$OUT_DIR/rk-unpacked" -type f -name '*.img' ! -name rootfs.img -delete
+
 echo ">> Done. Extracted rootfs is in $OUT_DIR/rootfs/."


### PR DESCRIPTION
`make extract` always wrote to `tmp/extracted`, so extracting a new
`FIRMWARE_VERSION` silently clobbered the previous extraction and left
no way to keep two versions side by side for comparison. `EXTRACT_DIR`
is now `tmp/extracted-$(FIRMWARE_VERSION)`, matching the convention
the archived `tmp/extracted-*` directories already follow.

`scripts/dev/save-patch.sh` hardcoded `tmp/extracted`, which would have
made it diff against a stale extraction of a different firmware version
once `make extract` started writing elsewhere. It now derives the same
path from `vars.mk` and fails early if the directory is missing.

`extract_squashfs.sh` also drops `rk-rom.img`, `update.img` and the
`rk-unpacked` images other than `rootfs.img` once `rootfs` is unpacked.
Nothing reads them -- `extract` is an inspection target and the build
path uses `BUILD_DIR` instead -- and they cost ~500M per version.
`rootfs.img` is kept as the pristine reference `save-patch.sh` unpacks
`rootfs.original` from. This takes an extraction from 1.1G to ~600M.