### PR TITLE
Fix `[components] rfid` disabling the RFID reader by default

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -21,7 +21,8 @@ usb: none
 rtsp: false
 
 [components]
-rfid: external, snapmaker, openrfid, openrfid-generic
+# Filament tag detection: external, snapmaker, openrfid, openrfid-generic
+# rfid: snapmaker
 
 [remote_access]
 # Enable SSH access: true, false


### PR DESCRIPTION
The `[components]` section listed the accepted values as the value itself, so a freshly seeded `extended2.cfg` reads back:

```ini
[components]
rfid: external, snapmaker, openrfid, openrfid-generic
```

`S59rfid-support` and `S99openrfid` both `case` on that string, and the option list matches none of the arms. `S59rfid-support` therefore falls through to `*)` and symlinks `disable-rfid-reader.cfg`, **turning the stock RFID reader off on a fresh install** even though `snapmaker` is the intended default that every caller passes.

## Fix

Comment the key out and move the value list into a description comment, matching the `[camera]` section above it. `extended-config.py get` then falls back to the `snapmaker` default, and picking a reader in firmware-config still writes a real `rfid:` line.

## Verified

Running the `S59rfid-support` selection logic against the template before and after:

| | `get components rfid snapmaker` | result |
|---|---|---|
| before | `external, snapmaker, openrfid, openrfid-generic` | RFID reader **disabled** |
| after | `snapmaker` | RFID reader **enabled** |

Selecting a non-default reader still works — `add ... components rfid openrfid` reads back `openrfid`.

## Scope

Only affects configs seeded from this template. `S49extended-config` copies with `cp -rn`, so existing installs keep whatever they already have.