### PR TITLE
Point `wpa-conf` at persistent storage so joined networks survive

### DIFF
--- a/overlays/firmware-extended/14-patch-wifi-persist/patches/01-remove-stock-wpa-conf.patch
+++ b/overlays/firmware-extended/14-patch-wifi-persist/patches/01-remove-stock-wpa-conf.patch
@@ -1,0 +1,52 @@
+Remove the stock `wpa-conf.sh`.
+
+It exists to link `$IF_WPA_CONF` to a writable copy of the config, but
+`interfaces.d/wlan0` now points `wpa-conf` straight at a file on `/oem`, so
+`wpa_supplicant` reads and rewrites persistent storage directly and there is
+nothing left to link.
+
+It must not run in that arrangement: it `rm -rf`s `$IF_WPA_CONF` on every `ifup`
+before re-linking, which would delete the saved networks on every boot, and the
+symlink it creates is what defeated `SAVE_CONFIG` to begin with.
+
+Deleted rather than shadowed by a same-named overlay file so a future stock
+change to this script fails the build loudly instead of being silently
+discarded.
+
+Seeding `$IF_WPA_CONF` from the pristine `/etc` copy moves to `pre-up` on
+`interfaces.d/wlan0` instead - see `02-wpa-conf-persistent-path.patch`.
+
+--- a/etc/network/if-pre-up.d/wpa-conf.sh
++++ /dev/null
+@@ -1,31 +0,0 @@
+-#!/bin/sh
+-
+-# This file is executed by ifupdown in pre-up, post-up, pre-down and
+-# post-down phases of network interface configuration.
+-
+-# run this script only for interfaces which have wpa-conf option
+-[ -z "$IF_WPA_CONF" ] && exit 0
+-
+-# Check for original conf
+-WPA_CONF="${WPA_CONF:-/etc/wpa_supplicant.conf}"
+-[ -r "$WPA_CONF" ] || exit 0
+-
+-mkdir -p "$(dirname "$IF_WPA_CONF")" || exit 0
+-rm -rf "$IF_WPA_CONF"
+-
+-# The original conf is writable
+-if touch "$WPA_CONF" 2>/dev/null; then
+-	ln -sf "$WPA_CONF" "$IF_WPA_CONF"
+-	exit 0
+-fi
+-
+-# Prefer using /userdata to store new conf
+-if [ -d /userdata ] && touch /userdata 2>/dev/null; then
+-	mkdir -p /userdata/cfg
+-	cp -p "$WPA_CONF" /userdata/cfg/wpa_config.conf
+-	ln -sf /userdata/cfg/wpa_config.conf "$IF_WPA_CONF"
+-	exit 0
+-fi
+-
+-cp -p "$WPA_CONF" "$IF_WPA_CONF"
+-exit 0

--- a/overlays/firmware-extended/14-patch-wifi-persist/patches/02-wpa-conf-persistent-path.patch
+++ b/overlays/firmware-extended/14-patch-wifi-persist/patches/02-wpa-conf-persistent-path.patch
@@ -1,0 +1,46 @@
+Point `wpa-conf` at persistent storage so joined networks survive a reboot.
+
+`if-up.d/wpasupplicant` passes this path to `wpa_supplicant` as `-c`, and that
+is the file `SAVE_CONFIG` rewrites. `wpa_config_write()` does not write it in
+place: it writes `<path>.tmp` and `rename()`s that over `<path>`.
+
+The stock path is `/var/run/wpa_supplicant/wpa_supplicant.conf`, which
+`wpa-conf.sh` symlinks to `/etc/wpa_supplicant.conf`. The rename replaces the
+symlink itself rather than following it, so the save landed on `/run` — tmpfs,
+per `/etc/fstab` — and never reached `/etc`, let alone anywhere persistent.
+Every network joined through `SAVE_CONFIG` was lost on the next boot.
+
+Naming the persistent file directly sidesteps both problems: there is no
+symlink for the rename to clobber, and `<path>.tmp` lands on `/oem` beside its
+target, so the rename stays within one filesystem.
+
+`do_start()` in `if-up.d/wpasupplicant` refuses to start `wpa_supplicant` at
+all when this file is missing ("cannot read contents of ..."), which would
+leave the printer with no WiFi and no obvious cause - reachable on a fresh
+printer, after a `full-recover`, or if the stock GUI is midway through
+rewriting its copy. `pre-up` seeds it from the pristine `/etc` copy before
+`wpa_supplicant` ever looks for it, guarded with `cp -n` so a real saved
+network is never clobbered. `/oem` is mounted by `S00mountall.sh` from
+`/etc/fstab`, long before `S40network` runs this.
+
+Each seeding step is `|| true`: `ifup` treats a failing `pre-up` as fatal and
+refuses to bring up the interface at all, and none of these are conditions
+worth failing WiFi over - `/etc/wpa_supplicant.conf` missing or `/oem` not
+yet mounted just means there is nothing to seed from (or nowhere to put it)
+yet, and a `chown` failing changes nothing that stops `wpa_supplicant` from
+reading the file.
+
+This is the same file the stock GUI keeps its own copy in, so both touchscreen
+UIs continue to see the same networks.
+
+--- a/etc/network/interfaces.d/wlan0
++++ b/etc/network/interfaces.d/wlan0
+@@ -1,4 +1,7 @@
+ iface wlan0 inet manual
++	pre-up mkdir -p /oem/printer_data/gui || true
++	pre-up cp -vn /etc/wpa_supplicant.conf /oem/printer_data/gui/wpa_supplicant.conf || true
++	pre-up chown lava:lava /oem/printer_data/gui/wpa_supplicant.conf || true
+ 	dhcp-up /sbin/dhcpcd
+ 	dhcp-down /sbin/dhcpcd -k
+-	wpa-conf /var/run/wpa_supplicant/wpa_supplicant.conf
++	wpa-conf /oem/printer_data/gui/wpa_supplicant.conf


### PR DESCRIPTION
Adds `14-patch-wifi-persist`, pointing `wpa_supplicant` at `/oem/printer_data/gui/wpa_supplicant.conf` — the file the stock GUI already keeps its networks in — so a network joined through `SAVE_CONFIG` survives a reboot.

Split out of #590, where HelixScreen surfaced the bug. It is a stock firmware bug on its own, so it lands separately.

## The bug

`SAVE_CONFIG` rewrites whichever file `wpa_supplicant` was given as `-c`, and `wpa_config_write()` does not write it in place — it writes `<path>.tmp` and `rename()`s that over `<path>`.

Stock `interfaces.d/wlan0` passes `/var/run/wpa_supplicant/wpa_supplicant.conf`, which `wpa-conf.sh` symlinks to `/etc/wpa_supplicant.conf`. The rename replaces the symlink instead of following it, so the save lands on `/run` — tmpfs, per `/etc/fstab` — and never reaches `/etc`, let alone persistent storage.

## The fix

`interfaces.d/wlan0` names the persistent file directly: no symlink for the rename to clobber, and `<path>.tmp` lands on `/oem` beside its target, so the rename stays within one filesystem.

`wpa-conf.sh` is replaced rather than dropped. The stock one `rm -rf`s `$IF_WPA_CONF` on every `ifup` before re-linking, which would delete the saved networks each boot. The replacement only seeds the file from the pristine `/etc` copy when missing or empty — `if-up.d/wpasupplicant` refuses to start `wpa_supplicant` at all in that case, which would leave a fresh printer with no WiFi and no obvious cause. The seed carries `ctrl_interface`, `ap_scan` and `update_config=1`, the last of which `SAVE_CONFIG` is refused without.

`/oem` is mounted by `S00mountall.sh` from `/etc/fstab`, long before `S40network` runs this.

## Impact

Nothing in the stock firmware uses `SAVE_CONFIG` — the stock GUI restarts `wpa_supplicant` with its own `-c` via `wifi-connect.sh`, and is unaffected either way. Because the path is the one it already uses, both it and any GUI that does use `SAVE_CONFIG` see the same networks.
