### PR TITLE
panda-breath: accept stock firmware v1.0.4 (WebSocket path unchanged)

### DIFF
--- a/docs/panda_breath.md
+++ b/docs/panda_breath.md
@@ -30,7 +30,9 @@ See also: [Quick overview on fan mods applied for Snapmaker U1](https://www.redd
 ## Prerequisites
 
 1. **Install motherboard cooling** — see [Risks and Warranty](#risks-and-warranty) above.
-2. Panda Breath device running firmware **v1.0.3**.
+2. Panda Breath device running firmware **v1.0.3 or v1.0.4**. (v1.0.4 only adds an
+   optional Home Assistant MQTT interface; the WebSocket control path this integration
+   uses is unchanged, so both versions work identically here.)
 3. **Static DHCP leases** for both the printer and the Panda Breath device on your router. The printer IP is embedded into the Panda Breath device during setup and must not change on reboot. Klipper connects to the Panda Breath by IP address on every print.
 4. Power-cycle the Panda Breath and wait at least 5 seconds before enabling.
 
@@ -42,7 +44,7 @@ Two modes are available:
 
 | Mode | Description |
 |------|-------------|
-| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Requires firmware v1.0.3. |
+| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Requires firmware v1.0.3 or v1.0.4. |
 | **Manual** (advanced) | Pure `heater_generic` control throughout. Legacy fallback; less safe if the device or network is lost during a print. |
 
 During setup the web interface will ask for the Panda Breath IP address and will automatically bind the device to the printer.

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
@@ -139,10 +139,20 @@ def ws_conn(fn, *args):
         ws_close(sock)
 
 
-def check_fw_version(sock, settings, expected):
+# Stock OEM firmware versions this integration is known to work with over the
+# WebSocket transport. 1.0.4 only adds a Home Assistant MQTT interface; the
+# WebSocket protocol used here is unchanged from 1.0.3, so both are accepted.
+SUPPORTED_FW_VERSIONS = ("V1.0.3", "V1.0.4")
+
+
+def check_fw_version(sock, settings, allowed):
     firmware = settings.get("settings", {}).get("fw_version", "")
-    if firmware != expected:
-        print(f"Error: expected firmware {expected}, got '{firmware}'", file=sys.stderr)
+    if firmware not in allowed:
+        print(
+            f"Error: unsupported firmware '{firmware}' "
+            f"(supported: {', '.join(allowed)})",
+            file=sys.stderr,
+        )
         sys.exit(1)
     print(f"Firmware OK: {firmware}")
     print()
@@ -231,7 +241,10 @@ def main():
     p = sub.add_parser("bind-klipper", help="Bind Panda Breath to a Klipper instance")
     p.add_argument("--printer-ip", required=True, help="Klipper printer IP")
     p.add_argument("--printer-port", type=int, default=80, help="Klipper printer port")
-    p.add_argument("--version", default="V1.0.3", help="Required firmware version")
+    p.add_argument(
+        "--version", action="append", metavar="VERSION",
+        help="Accepted firmware version (repeatable); default: "
+             + ", ".join(SUPPORTED_FW_VERSIONS))
 
     args = parser.parse_args()
     host = args.host
@@ -244,7 +257,7 @@ def main():
     elif args.command == "unbind":
         ws_conn(unbind_printer)
     elif args.command == "bind-klipper":
-        ws_conn(check_fw_version, args.version)
+        ws_conn(check_fw_version, args.version or list(SUPPORTED_FW_VERSIONS))
         ws_conn(unbind_printer)
         ws_conn(set_printer_type, PRINTER_TYPE_KLIPPER)
         # unbind again in case printer_type change caused a reconnect (previously saved Klipper)

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -72,7 +72,7 @@ settings:
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."
-                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}" --version "V1.0.3"
+                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}"
 
                 echo ""
                 echo ">> Writing configuration..."
@@ -121,7 +121,7 @@ settings:
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."
-                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}" --version "V1.0.3"
+                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}"
 
                 echo ""
                 echo ">> Writing configuration..."


### PR DESCRIPTION
The paxx integration hard-checked fw_version == V1.0.3 in two places, so v1.0.4 devices were refused during bind. The 1.0.3 -> 1.0.4 diff only adds a Home Assistant MQTT interface; the web-UI WebSocket protocol used here (settings, printer_type, printer bind) is byte-identical, and a real v1.0.4 device was verified working over WebSocket.

- panda_breath_cli.py: accept a set of supported versions (V1.0.3, V1.0.4) via SUPPORTED_FW_VERSIONS; make --version repeatable to override.
- firmware-config action yaml: drop the hard-coded --version "V1.0.3" from both bind-klipper calls so the CLI default (both versions) is the single source of truth.
- docs: note v1.0.4 support.