### PR TITLE
Feature/panda stock mqtt

### DIFF
--- a/docs/panda_breath.md
+++ b/docs/panda_breath.md
@@ -30,7 +30,9 @@ See also: [Quick overview on fan mods applied for Snapmaker U1](https://www.redd
 ## Prerequisites
 
 1. **Install motherboard cooling** — see [Risks and Warranty](#risks-and-warranty) above.
-2. Panda Breath device running firmware **v1.0.3**.
+2. Panda Breath device running firmware **v1.0.3 or v1.0.4**. (v1.0.4 only adds an
+   optional Home Assistant MQTT interface; the WebSocket control path this integration
+   uses is unchanged, so both versions work identically here.)
 3. **Static DHCP leases** for both the printer and the Panda Breath device on your router. The printer IP is embedded into the Panda Breath device during setup and must not change on reboot. Klipper connects to the Panda Breath by IP address on every print.
 4. Power-cycle the Panda Breath and wait at least 5 seconds before enabling.
 
@@ -42,7 +44,7 @@ Two modes are available:
 
 | Mode | Description |
 |------|-------------|
-| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Requires firmware v1.0.3. |
+| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Requires firmware v1.0.3 or v1.0.4. |
 | **Manual** (advanced) | Pure `heater_generic` control throughout. Legacy fallback; less safe if the device or network is lost during a print. |
 
 During setup the web interface will ask for the Panda Breath IP address and will automatically bind the device to the printer.

--- a/docs/panda_breath.md
+++ b/docs/panda_breath.md
@@ -40,14 +40,17 @@ See also: [Quick overview on fan mods applied for Snapmaker U1](https://www.redd
 
 Enable via the Firmware Config web interface at `http://<printer-ip>/firmware-config/` under **Tweaks > Panda Breath Chamber Heater**.
 
-Two modes are available:
+Three modes are available:
 
 | Mode | Description |
 |------|-------------|
-| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Requires firmware v1.0.3 or v1.0.4. |
-| **Manual** (advanced) | Pure `heater_generic` control throughout. Legacy fallback; less safe if the device or network is lost during a print. |
+| **Auto** (recommended) | Klipper heats the chamber to target, then hands off hold and cool-down to Panda native auto mode. Uses the WebSocket control path. Requires firmware v1.0.3 or v1.0.4. |
+| **MQTT** (v1.0.4+) | The Panda talks to the printer's own MQTT broker on a dedicated, password-protected listener; Klipper controls the chamber heater directly via `heater_generic`. Requires firmware **v1.0.4 or newer**. |
+| **Manual** (advanced) | Pure `heater_generic` control over the WebSocket path throughout. Legacy fallback; less safe if the device or network is lost during a print. |
 
 During setup the web interface will ask for the Panda Breath IP address and will automatically bind the device to the printer.
+
+In **MQTT** mode the setup also provisions a locked-down mosquitto listener (port 1885, ACL-scoped to `panda_breath/#`) with a generated password, and binds the Panda to that broker automatically over its WebSocket API — there are no manual web-UI steps on the Panda.
 
 ## Configuration File
 

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
@@ -139,10 +139,20 @@ def ws_conn(fn, *args):
         ws_close(sock)
 
 
-def check_fw_version(sock, settings, expected):
+# Stock OEM firmware versions this integration is known to work with over the
+# WebSocket transport. 1.0.4 only adds a Home Assistant MQTT interface; the
+# WebSocket protocol used here is unchanged from 1.0.3, so both are accepted.
+SUPPORTED_FW_VERSIONS = ("V1.0.3", "V1.0.4")
+
+
+def check_fw_version(sock, settings, allowed):
     firmware = settings.get("settings", {}).get("fw_version", "")
-    if firmware != expected:
-        print(f"Error: expected firmware {expected}, got '{firmware}'", file=sys.stderr)
+    if firmware not in allowed:
+        print(
+            f"Error: unsupported firmware '{firmware}' "
+            f"(supported: {', '.join(allowed)})",
+            file=sys.stderr,
+        )
         sys.exit(1)
     print(f"Firmware OK: {firmware}")
     print()
@@ -231,7 +241,10 @@ def main():
     p = sub.add_parser("bind-klipper", help="Bind Panda Breath to a Klipper instance")
     p.add_argument("--printer-ip", required=True, help="Klipper printer IP")
     p.add_argument("--printer-port", type=int, default=80, help="Klipper printer port")
-    p.add_argument("--version", default="V1.0.3", help="Required firmware version")
+    p.add_argument(
+        "--version", action="append", metavar="VERSION",
+        help="Accepted firmware version (repeatable); default: "
+             + ", ".join(SUPPORTED_FW_VERSIONS))
 
     args = parser.parse_args()
     host = args.host
@@ -244,7 +257,7 @@ def main():
     elif args.command == "unbind":
         ws_conn(unbind_printer)
     elif args.command == "bind-klipper":
-        ws_conn(check_fw_version, args.version)
+        ws_conn(check_fw_version, args.version or list(SUPPORTED_FW_VERSIONS))
         ws_conn(unbind_printer)
         ws_conn(set_printer_type, PRINTER_TYPE_KLIPPER)
         # unbind again in case printer_type change caused a reconnect (previously saved Klipper)

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
@@ -210,6 +210,52 @@ def bind_printer(sock, settings, printer_ip, printer_port):
     sys.exit(1)
 
 
+def bind_broker(sock, settings, broker_ip, broker_port, user, password):
+    # Stock firmware v1.0.4+ native Home-Assistant MQTT bind. The device
+    # connects to the given broker as an MQTT client (topics panda_breath/<id>/*).
+    # Reuses the same connection-state enum as the printer bind.
+    print(f"Binding broker {broker_ip}:{broker_port} (user '{user}') ...")
+    ws_send_json(sock, {"ha": {
+        "ip": broker_ip, "port": broker_port, "user": user, "password": password}})
+    # After a new bind the firmware transitions DISCONNECTED(0) -> CONNECTING(2)
+    # -> CONNECTED(3) (or an error). Wait for a terminal state, ignoring the
+    # transient 0/2 — otherwise a mosquitto restart just before the bind makes
+    # us read the momentary disconnect and report a false failure.
+    terminal = {PRINTER_STATE_CONNECTED, PRINTER_STATE_IP_ERROR,
+                PRINTER_STATE_SN_ERROR, PRINTER_STATE_ACCESS_CODE_ERROR,
+                PRINTER_STATE_UNKNOWN_ERROR}
+    try:
+        resp = ws_recv_json(
+            sock,
+            match=lambda r: r.get("ha", {}).get("state") in terminal,
+            timeout=30)
+    except TimeoutError:
+        print("Error: broker did not connect within 30s "
+              "(check broker IP/port and user/password)", file=sys.stderr)
+        sys.exit(1)
+    state = resp.get("ha", {}).get("state")
+    if state == PRINTER_STATE_CONNECTED:
+        print("Broker bind successful.")
+        return
+    if state == PRINTER_STATE_IP_ERROR:
+        print("Error: broker IP/connection error", file=sys.stderr)
+        sys.exit(1)
+    print(f"Device reported ha state {state}: bind failed "
+          "(check user/password)", file=sys.stderr)
+    sys.exit(1)
+
+
+def unbind_broker(sock, settings):
+    state = settings.get("ha", {}).get("state", 0)
+    if state in (PRINTER_STATE_DISCONNECTED, PRINTER_STATE_INVALID_INFO):
+        return
+    print(f"Disconnecting broker (state={state})...")
+    ws_send_json(sock, {"ha": {"disconnect": 1}})
+    ws_recv_json(sock, match=lambda r: r.get("ha", {}).get("state") == PRINTER_STATE_DISCONNECTED)
+    print("Broker unbind successful.")
+    print()
+
+
 def print_fw_version(sock, settings):
     print(settings.get("settings", {}).get("fw_version", "unknown"))
 
@@ -238,6 +284,19 @@ def main():
 
     sub.add_parser("unbind", help="Disconnect the bound printer from Panda Breath")
 
+    sub.add_parser("unbind-broker", help="Disconnect the bound MQTT broker from Panda Breath")
+
+    pb = sub.add_parser("bind-broker",
+                        help="Bind Panda Breath (stock v1.0.4+) to an MQTT broker")
+    pb.add_argument("--broker-ip", required=True, help="MQTT broker IP")
+    pb.add_argument("--broker-port", type=int, default=1883, help="MQTT broker port")
+    pb.add_argument("--user", default="", help="MQTT username")
+    pb.add_argument("--password", default="", help="MQTT password")
+    pb.add_argument(
+        "--version", action="append", metavar="VERSION",
+        help="Accepted firmware version (repeatable); default: "
+             + ", ".join(SUPPORTED_FW_VERSIONS))
+
     p = sub.add_parser("bind-klipper", help="Bind Panda Breath to a Klipper instance")
     p.add_argument("--printer-ip", required=True, help="Klipper printer IP")
     p.add_argument("--printer-port", type=int, default=80, help="Klipper printer port")
@@ -256,6 +315,11 @@ def main():
         ws_conn(print_fw_version)
     elif args.command == "unbind":
         ws_conn(unbind_printer)
+    elif args.command == "unbind-broker":
+        ws_conn(unbind_broker)
+    elif args.command == "bind-broker":
+        ws_conn(check_fw_version, args.version or list(SUPPORTED_FW_VERSIONS))
+        ws_conn(bind_broker, args.broker_ip, args.broker_port, args.user, args.password)
     elif args.command == "bind-klipper":
         ws_conn(check_fw_version, args.version or list(SUPPORTED_FW_VERSIONS))
         ws_conn(unbind_printer)

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_mqtt_setup.sh
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_mqtt_setup.sh
@@ -22,7 +22,9 @@ MUSER=panda
 if [[ -s "$PWPLAIN" ]]; then
   PB_PASS="$(cat "$PWPLAIN")"
 else
-  PB_PASS="$(openssl rand -hex 20)"
+  # 20 hex chars (80-bit): strong for an ACL-scoped LAN listener and within the
+  # Panda "Bind a Broker" field length limit (longer values get truncated).
+  PB_PASS="$(openssl rand -hex 10)"
   printf '%s' "$PB_PASS" > "$PWPLAIN"
   chown lava:lava "$PWPLAIN"; chmod 600 "$PWPLAIN"
 fi
@@ -56,10 +58,7 @@ fi
 PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) \
   | awk '{print $4}' | cut -d/ -f1 | head -1)
 echo ""
-echo ">> Panda Breath MQTT broker is ready."
-echo "   In the Panda web UI -> Bind a Broker, enter:"
-echo "     IP:       ${PRINTER_IP}"
-echo "     Port:     ${PORT}"
-echo "     Username: ${MUSER}"
-echo "     Password: ${PB_PASS}"
+echo ">> Panda Breath MQTT broker is ready (listener ${PORT}, user ${MUSER})."
+echo "   IP ${PRINTER_IP}:${PORT} — the Panda is bound to this automatically over"
+echo "   its WebSocket API; no manual web-UI entry is required."
 echo ""

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_mqtt_setup.sh
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_mqtt_setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Panda Breath — set up a dedicated, authenticated mosquitto listener for the
+# stock firmware v1.0.4+ native-MQTT integration.
+#
+# The stock v1.0.4 firmware speaks Home-Assistant-style MQTT. We give it its
+# own LAN listener on the printer's broker, locked down with a per-device
+# password and a topic ACL (panda_breath/* only). The internal 127.0.0.1:1883
+# listener is untouched and stays private; the Klipper extra uses that one.
+#
+# Idempotent: re-runs reuse the generated password and don't duplicate config.
+
+set -eo pipefail
+
+CONF=/etc/mosquitto/mosquitto.conf
+PWFILE=/etc/mosquitto/panda_pw.conf
+PWPLAIN=/etc/mosquitto/panda_pw.plain     # root-only, lets us re-show the cred
+ACL=/etc/mosquitto/acl_panda.conf
+PORT=1885
+MUSER=panda
+
+# 1. password — reuse if already generated, otherwise create a strong one
+if [[ -s "$PWPLAIN" ]]; then
+  PB_PASS="$(cat "$PWPLAIN")"
+else
+  PB_PASS="$(openssl rand -hex 20)"
+  printf '%s' "$PB_PASS" > "$PWPLAIN"
+  chown lava:lava "$PWPLAIN"; chmod 600 "$PWPLAIN"
+fi
+
+# 2. hashed password file for mosquitto
+mosquitto_passwd -c -b "$PWFILE" "$MUSER" "$PB_PASS"
+chown lava:lava "$PWFILE"; chmod 600 "$PWFILE"
+
+# 3. ACL — this user may only touch its own topics (+ read HA discovery)
+printf 'user %s\ntopic readwrite panda_breath/#\ntopic read homeassistant/#\n' "$MUSER" > "$ACL"
+chown lava:lava "$ACL"; chmod 644 "$ACL"
+
+# 4. listener (idempotent, backed up)
+cp -n "$CONF" "$CONF.bak-panda" 2>/dev/null || true
+if ! grep -q "listener $PORT\b" "$CONF"; then
+  cat >> "$CONF" <<EOF
+
+# Panda Breath stock-mqtt listener (LAN): auth + ACL, restricted to panda_breath/*
+listener $PORT
+allow_anonymous false
+password_file $PWFILE
+acl_file $ACL
+max_connections 8
+EOF
+fi
+
+# 5. restart broker so the new listener takes effect
+/etc/init.d/S50mosquitto restart >/dev/null 2>&1 || true
+
+# 6. print the binding the user enters once in the Panda web UI
+PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) \
+  | awk '{print $4}' | cut -d/ -f1 | head -1)
+echo ""
+echo ">> Panda Breath MQTT broker is ready."
+echo "   In the Panda web UI -> Bind a Broker, enter:"
+echo "     IP:       ${PRINTER_IP}"
+echo "     Port:     ${PORT}"
+echo "     Username: ${MUSER}"
+echo "     Password: ${PB_PASS}"
+echo ""

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -72,7 +72,7 @@ settings:
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."
-                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}" --version "V1.0.3"
+                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}"
 
                 echo ""
                 echo ">> Writing configuration..."
@@ -121,7 +121,7 @@ settings:
 
                 echo ""
                 echo ">> Binding Panda Breath at ${PANDA_BREATH_IP} to printer at ${PRINTER_IP}..."
-                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}" --version "V1.0.3"
+                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-klipper --printer-ip "${PRINTER_IP}"
 
                 echo ""
                 echo ">> Writing configuration..."

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -27,7 +27,19 @@ settings:
               - bash
               - -ec
               - |
-                if PANDA_BREATH_IP=$(/usr/local/bin/extended-config.py get /oem/printer_data/config/extended/klipper/panda_breath.cfg panda_breath host 2>/dev/null); then
+                CFG=/oem/printer_data/config/extended/klipper/panda_breath.cfg
+
+                if grep -qE '^[[:space:]]*firmware:[[:space:]]*stock-mqtt' "$CFG" 2>/dev/null; then
+                  # MQTT mode: disconnect the Panda from the broker (like the
+                  # device's own "Unbind" button). The Panda IP is stored as a
+                  # comment in the config so we can reach it here.
+                  PANDA_BREATH_IP=$(sed -nE 's/^#[[:space:]]*panda_device_ip:[[:space:]]*([0-9.]+).*/\1/p' "$CFG" | head -1)
+                  if [ -n "${PANDA_BREATH_IP}" ]; then
+                    echo ""
+                    echo ">> Unbinding Panda Breath broker at ${PANDA_BREATH_IP}..."
+                    /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" unbind-broker || true
+                  fi
+                elif PANDA_BREATH_IP=$(/usr/local/bin/extended-config.py get "$CFG" panda_breath host 2>/dev/null); then
                   echo ""
                   echo ">> Unbinding Panda Breath at ${PANDA_BREATH_IP}..."
                   /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" unbind || true
@@ -35,7 +47,7 @@ settings:
 
                 echo ""
                 echo ">> Removing Panda Breath configuration..."
-                rm -f /oem/printer_data/config/extended/klipper/panda_breath.cfg
+                rm -f "$CFG"
 
                 echo ""
                 echo ">> Panda Breath disabled. Restarting Klipper..."
@@ -137,6 +149,7 @@ settings:
                   'firmware: stock-mqtt' \
                   'mqtt_broker: 127.0.0.1' \
                   'mqtt_port: 1883' \
+                  "# panda_device_ip: ${PANDA_BREATH_IP}" \
                   '' \
                   '[include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg]' \
                   > /oem/printer_data/config/extended/klipper/panda_breath.cfg

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -9,7 +9,9 @@ settings:
           - bash
           - -c
           - |
-            if /usr/local/bin/extended-config.py has /oem/printer_data/config/extended/klipper/panda_breath.cfg "include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_auto.cfg" &>/dev/null; then
+            if grep -qE '^[[:space:]]*firmware:[[:space:]]*stock-mqtt' /oem/printer_data/config/extended/klipper/panda_breath.cfg 2>/dev/null; then
+              echo "mqtt"
+            elif /usr/local/bin/extended-config.py has /oem/printer_data/config/extended/klipper/panda_breath.cfg "include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_auto.cfg" &>/dev/null; then
               echo "auto"
             elif /usr/local/bin/extended-config.py has /oem/printer_data/config/extended/klipper/panda_breath.cfg "include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg" &>/dev/null; then
               echo "manual"
@@ -85,6 +87,49 @@ settings:
 
                 echo ""
                 echo ">> Panda Breath auto mode enabled. Restarting Klipper..."
+                /etc/init.d/S60klipper restart
+          mqtt:
+            label: MQTT (v1.0.4+)
+            confirm: |
+              WARNING: Panda Breath significantly raises sustained enclosure temperatures, accelerating wear on electronics, motors, and other components beyond their rated conditions. Any damage attributable to elevated thermal stress is unlikely to be covered under warranty. Additional motherboard cooling is required before use — see the documentation for details.
+
+              Before enabling Panda Breath MQTT mode, complete all of the following steps:
+
+              1. Install additional active cooling on the motherboard (see documentation).
+              2. Ensure the Panda Breath device is running firmware v1.0.4 or newer.
+              3. Configure a static DHCP lease for the Panda Breath device on your router.
+              4. Power-cycle the Panda Breath device and wait at least 5 seconds before proceeding.
+
+              MQTT mode connects the Panda to this printer's own MQTT broker over a dedicated, password-protected listener; Klipper controls the chamber heater directly. After enabling, you will enter the broker details shown in the output on the Panda's web UI (Bind a Broker) — that is the only manual step.
+            inputs:
+              - name: ACKNOWLEDGED
+                label: "Type \"I UNDERSTAND\" to confirm you have read the documentation and accept the warranty and longevity risks"
+                placeholder: "I UNDERSTAND"
+                regex: '^I UNDERSTAND$'
+            cmd:
+              - bash
+              - -ec
+              - |
+                echo ""
+                echo ">> Setting up the Panda Breath MQTT broker listener..."
+                /usr/local/bin/panda_breath_mqtt_setup.sh
+
+                echo ""
+                echo ">> Writing Klipper configuration (stock-mqtt)..."
+                mkdir -p /oem/printer_data/config/extended/klipper
+                printf '%s\n' \
+                  '[panda_breath]' \
+                  'firmware: stock-mqtt' \
+                  'mqtt_broker: 127.0.0.1' \
+                  'mqtt_port: 1883' \
+                  '' \
+                  '[include /usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg]' \
+                  > /oem/printer_data/config/extended/klipper/panda_breath.cfg
+                chown lava:lava /oem/printer_data/config/extended/klipper/panda_breath.cfg
+
+                echo ""
+                echo ">> Panda Breath MQTT mode enabled. Restarting Klipper..."
+                echo ">> NEXT: bind the Panda to the broker shown above (Panda web UI -> Bind a Broker)."
                 /etc/init.d/S60klipper restart
           manual:
             label: Manual (Advanced)

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -99,20 +99,35 @@ settings:
               2. Ensure the Panda Breath device is running firmware v1.0.4 or newer.
               3. Configure a static DHCP lease for the Panda Breath device on your router.
               4. Power-cycle the Panda Breath device and wait at least 5 seconds before proceeding.
+              5. Enter the Panda Breath IP address in the field below.
 
-              MQTT mode connects the Panda to this printer's own MQTT broker over a dedicated, password-protected listener; Klipper controls the chamber heater directly. After enabling, you will enter the broker details shown in the output on the Panda's web UI (Bind a Broker) — that is the only manual step.
+              MQTT mode connects the Panda to this printer's own MQTT broker over a dedicated, password-protected listener and binds it automatically over the Panda's WebSocket API — no manual web-UI steps. Klipper then controls the chamber heater directly.
             inputs:
               - name: ACKNOWLEDGED
                 label: "Type \"I UNDERSTAND\" to confirm you have read the documentation and accept the warranty and longevity risks"
                 placeholder: "I UNDERSTAND"
                 regex: '^I UNDERSTAND$'
+              - name: PANDA_BREATH_IP
+                label: Panda Breath IP Address
+                placeholder: "192.168.1.100"
+                regex: '^((25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])$'
             cmd:
               - bash
               - -ec
               - |
                 echo ""
+                echo ">> Detecting printer IP address..."
+                PRINTER_IP=$((ip -4 -o addr show eth0 2>/dev/null || ip -4 -o addr show wlan0 2>/dev/null) | awk '{print $4}' | cut -d/ -f1 | head -1)
+
+                echo ""
                 echo ">> Setting up the Panda Breath MQTT broker listener..."
                 /usr/local/bin/panda_breath_mqtt_setup.sh
+
+                echo ""
+                echo ">> Binding the Panda at ${PANDA_BREATH_IP} to the broker at ${PRINTER_IP}:1885 (WebSocket)..."
+                PB_PASS="$(cat /etc/mosquitto/panda_pw.plain)"
+                /usr/local/bin/panda_breath_cli.py --host "${PANDA_BREATH_IP}" bind-broker \
+                  --broker-ip "${PRINTER_IP}" --broker-port 1885 --user panda --password "${PB_PASS}"
 
                 echo ""
                 echo ">> Writing Klipper configuration (stock-mqtt)..."
@@ -128,8 +143,7 @@ settings:
                 chown lava:lava /oem/printer_data/config/extended/klipper/panda_breath.cfg
 
                 echo ""
-                echo ">> Panda Breath MQTT mode enabled. Restarting Klipper..."
-                echo ">> NEXT: bind the Panda to the broker shown above (Panda web UI -> Bind a Broker)."
+                echo ">> Panda Breath MQTT mode enabled and bound. Restarting Klipper..."
                 /etc/init.d/S60klipper restart
           manual:
             label: Manual (Advanced)

--- a/overlays/firmware-extended/37-feature-panda-breath/scripts/01-install-panda-breath.sh
+++ b/overlays/firmware-extended/37-feature-panda-breath/scripts/01-install-panda-breath.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-GIT_URL=https://github.com/justinh-rahb/pandabreath-klipper.git
-GIT_SHA=2fc8c03b918519060f0a2cc6b40a56fbc232e74f
+GIT_URL=https://github.com/plastikman/pandabreath-klipper.git
+GIT_SHA=a36f41174a0b4133e8dd875d127640aca1607b44
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."


### PR DESCRIPTION

  Adds a "MQTT (v1.0.4+)" firmware-config mode for Panda Breath, using the stock
  firmware's native HA MQTT interface instead of the WebSocket control path.

  - Provisions a dedicated, password-protected mosquitto listener (port 1885,  ACL-scoped to panda_breath/#) on the printer's own broker.
  - Auto-binds the Panda to that broker over its WebSocket API (panda_breath_cli.py bind-broker/unbind-broker) — no manual web-UI entry.
  - Disabling MQTT mode unbinds the Panda from the broker.
  - Klipper controls the chamber heater directly via heater_generic.

  Requires the companion extra change (stock-mqtt transport, pinned via GIT_SHA).
  Validated end-to-end on hardware from a clean flash: broker setup → WS auto-bind  → Klipper reading chamber temp; enable/disable/re-enable cycle confirmed.

  Note: includes the "accept stock firmware v1.0.4" commit (9a1abf7); stacks on that change.

