### PR TITLE
Fix chroot `/root` cache persistence in `create_firmware.sh`

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -15,4 +15,4 @@ TTY_FLAG=""
 
 ENV_FLAGS="-e GIT_VERSION -e CI -e PASSWORD"
 
-exec docker run --rm $DOCKER_OPTS $TTY_FLAG $ENV_FLAGS --cap-add=SYS_ADMIN -w "$PWD" -v "$PWD:$PWD" "$IMAGE_NAME" "$@"
+exec docker run --rm $DOCKER_OPTS $TTY_FLAG $ENV_FLAGS -w "$PWD" -v "$PWD:$PWD" "$IMAGE_NAME" "$@"

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -28,7 +28,6 @@ export ROOTFS_IMG="$BUILD_DIR/rk-unpacked/rootfs.img"
 export GOPATH="$ROOT_DIR/tmp/cache-go"
 export CCACHE_DIR="$ROOT_DIR/tmp/ccache"
 export CHROOT_CACHE="$ROOT_DIR/tmp/cache-chroot"
-export PIP_CACHE_DIR="/cache/pip"
 
 rm -rf "$BUILD_DIR"
 

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -28,6 +28,7 @@ export ROOTFS_IMG="$BUILD_DIR/rk-unpacked/rootfs.img"
 export GOPATH="$ROOT_DIR/tmp/cache-go"
 export CCACHE_DIR="$ROOT_DIR/tmp/ccache"
 export CHROOT_CACHE="$ROOT_DIR/tmp/cache-chroot"
+export PIP_CACHE_DIR="/cache/pip"
 
 rm -rf "$BUILD_DIR"
 
@@ -63,6 +64,12 @@ echo ">> Verifying ownership preservation..."
 check_perms "$ROOTFS_DIR/etc/passwd" 0 0
 check_perms "$ROOTFS_DIR/home/lava/bin/hwver.sh" 1000 1000
 echo "   Ownership check passed"
+
+if [[ -z "$CI" ]]; then
+  echo ">> Restoring chroot cache..."
+  mkdir -p "$CHROOT_CACHE" "$ROOTFS_DIR/cache"
+  cp -a "$CHROOT_CACHE/." "$ROOTFS_DIR/cache/"
+fi
 
 for overlay; do
   if [[ ! -d "$overlay" ]]; then
@@ -100,6 +107,12 @@ for overlay; do
     done
   fi
 done
+
+if [[ -z "$CI" ]]; then
+  echo ">> Saving chroot cache..."
+  cp -a "$ROOTFS_DIR/cache/." "$CHROOT_CACHE/"
+  rm -rf "$ROOTFS_DIR/cache"
+fi
 
 echo ">> Checking for non-ARM binaries in rootfs..."
 if FILES=$(find "$ROOTFS_DIR" -type f -exec file {} + | grep "ELF" | grep -v "ARM"); then

--- a/scripts/helpers/cache_pip.sh
+++ b/scripts/helpers/cache_pip.sh
@@ -13,9 +13,9 @@ chroot_cmd() {
 }
 
 chroot_cmd bash -c '
-  pip3 install --no-index --find-links=/root/pip "$@" ||
+  pip3 install --no-index --find-links=/cache/pip "$@" ||
   (
-    pip3 download -d /root/pip "$@" &&
-    pip3 install --no-index --find-links=/root/pip "$@"
+    pip3 download -d /cache/pip "$@" &&
+    pip3 install --no-index --find-links=/cache/pip "$@"
   )
 ' -- "$@"

--- a/scripts/helpers/chroot_firmware.sh
+++ b/scripts/helpers/chroot_firmware.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [[ $# -lt 2 ]]; then
   echo "Usage: $0 <rootfs> <cmd> [args...]"
   exit 1
@@ -16,10 +18,6 @@ shift
 cd "$ROOTFS"
 
 cleanup() {
-  mountpoint "$ROOTFS/root" && umount "$ROOTFS/root"
-  rm -rf "$ROOTFS/root"
-  mkdir -p "$ROOTFS/root"
-
   rm -f ./etc/resolv.conf
   if [[ -e ./etc/resolv.conf.bak || -L ./etc/resolv.conf.bak ]]; then
     mv ./etc/resolv.conf.bak ./etc/resolv.conf
@@ -31,14 +29,6 @@ if [[ -e ./etc/resolv.conf || -L ./etc/resolv.conf ]]; then
 fi
 
 trap 'cleanup' EXIT
-
-if [[ -z "$CI" ]]; then
-  # Cache /root
-  mkdir -p "$CHROOT_CACHE/root"
-  mount --bind "$CHROOT_CACHE/root" "$ROOTFS/root"
-fi
-
-set -euo pipefail
 
 echo "nameserver 1.1.1.1" > ./etc/resolv.conf
 chroot "$ROOTFS" "$@"


### PR DESCRIPTION
## Summary
- Python packages installed during a firmware build (e.g. `pyyaml`, `apprise`) are now actually cached across builds — previously the cache silently never persisted, so every `./dev.sh` build re-downloaded them from scratch regardless of `tmp/cache-chroot`.
- `dev.sh` no longer requests `--cap-add=SYS_ADMIN` from Docker; it wasn't doing anything useful.

## Test plan
- [x] Built via `./dev.sh` twice with `overlays/firmware-extended/02-firmware-config`: first run downloaded `pyyaml`, second run installed it from cache with no network hit.