### PR TITLE
Add `v1.5.2-paxx12-21` heroes

### DIFF
--- a/HEROES.md
+++ b/HEROES.md
@@ -19,6 +19,19 @@ You can thank them here:
 | [@justinh-rahb](https://github.com/justinh-rahb) | `@wildtang3nt` | V4L2 camera controls, Mainsail Remote Screen support, Panda Breath chamber heater | [![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://buymeacoffee.com/wildtang3nt) |
 | [@suchmememanyskill](https://github.com/suchmememanyskill) | `@Sims` | OpenRFID | [![Ko-Fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/suchmememanyskill) |
 | [@morgendagen](https://github.com/morgendagen) | | OpenSpool `subtype` field for material specification | |
+| [@Tareku99](https://github.com/Tareku99) | | `.zip` firmware upload support in `firmware-config` | |
+| [@plastikman](https://github.com/plastikman) | | Panda Breath firmware `V1.0.4` support | |
+| [@djgringoboy2003](https://github.com/djgringoboy2003) | | Root-caused the `cavity_led` PWM camera flicker | |
+
+---
+
+## v1.5.2-paxx12-21
+
+| Contributor | Contribution | PR |
+|---|---|---|
+| [@Tareku99](https://github.com/Tareku99) | Allow firmware upgrades from a `.zip` archive | [#585](https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/585) |
+| [@plastikman](https://github.com/plastikman) | Accept Panda Breath stock firmware `V1.0.4` when binding | [#594](https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/594) |
+| [@djgringoboy2003](https://github.com/djgringoboy2003) | Investigated and root-caused the `cavity_led` PWM camera flicker | [#575](https://github.com/paxx12/SnapmakerU1-Extended-Firmware/pull/575) |
 
 ---
 


### PR DESCRIPTION
Records the external contributions in this release:

| Contributor | Contribution | PR |
|---|---|---|
| [@Tareku99](https://github.com/Tareku99) | Allow firmware upgrades from a `.zip` archive | #585 |
| [@plastikman](https://github.com/plastikman) | Accept Panda Breath stock firmware `V1.0.4` when binding | #594 |
| [@djgringoboy2003](https://github.com/djgringoboy2003) | Investigated and root-caused the `cavity_led` PWM camera flicker | #575 |

#575 was authored by @paxx12, but the fix came out of @djgringoboy2003's investigation and reference PR, so the credit is recorded here.

All three are also added to the `Support the Heroes` table with empty `Support` cells, so they can attach a Ko-Fi or Buy Me a Coffee link.