### PR TITLE
Allow manual dispatch of `Deploy to Cloudflare Pages` workflow

### DIFF
--- a/.github/workflows/cloudflare_pages.yaml
+++ b/.github/workflows/cloudflare_pages.yaml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'scripts/build_docs.sh'
       - '.github/workflows/cloudflare_pages.yaml'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds `workflow_dispatch` alongside the existing `push` trigger so the docs deploy can be re-run manually from the Actions tab, without needing a new commit to `docs/**`.
